### PR TITLE
Implement pagination on the API

### DIFF
--- a/packages/api/src/controllers/BlocksController.js
+++ b/packages/api/src/controllers/BlocksController.js
@@ -19,9 +19,13 @@ class BlocksController {
     }
 
     getBlocks = async (request, response) => {
-        const {from, to, order = 'desc'} = request.query
+        const {page = 1, limit = 10, order = 'asc'} = request.query
 
-        const blocks = await this.blocksDAO.getBlocksPaginated(from, to, order)
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const blocks = await this.blocksDAO.getBlocks(Number(page), Number(limit), order)
 
         response.send(blocks);
     }

--- a/packages/api/src/controllers/DataContractsController.js
+++ b/packages/api/src/controllers/DataContractsController.js
@@ -7,7 +7,13 @@ class DataContractsController {
     }
 
     getDataContracts = async (request, response) => {
-        const dataContracts = await this.dataContractsDAO.getDataContracts();
+        const {page = 1, limit = 10, order = 'asc'} = request.query
+
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const dataContracts = await this.dataContractsDAO.getDataContracts(Number(page), Number(limit), order);
 
         response.send(dataContracts)
     }

--- a/packages/api/src/controllers/DocumentsController.js
+++ b/packages/api/src/controllers/DocumentsController.js
@@ -20,8 +20,13 @@ class DocumentsController {
 
     getDocumentsByDataContract = async (request, response) => {
         const {identifier} = request.params
+        const {page = 1, limit = 10, order = 'asc'} = request.query
 
-        const documents = await this.documentsDAO.getDocumentsByDataContract(identifier)
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const documents = await this.documentsDAO.getDocumentsByDataContract(identifier, Number(page), Number(limit), order)
 
         response.send(documents);
     }

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -9,9 +9,13 @@ class TransactionsController {
     }
 
     getTransactions = async (request, response) => {
-        const {from, to} = request.query
+        const {page = 1, limit = 10, order = 'asc'} = request.query
 
-        const transactions = await this.transactionsDAO.getTransactions(from, to)
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const transactions = await this.transactionsDAO.getTransactions(Number(page), Number(limit), order)
 
         response.send(transactions);
     }

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -74,7 +74,6 @@ module.exports = class BlockDAO {
         const rows = await this.knex(subquery)
             .select('rank', 'total_count', 'blocks.hash as hash', 'height', 'timestamp', 'block_version', 'app_version', 'l1_locked_height', 'state_transitions.hash as st_hash')
             .leftJoin('state_transitions', 'state_transitions.block_hash', 'blocks.hash')
-            .groupBy('blocks.rank', 'blocks.total_count', 'blocks.hash', 'height', 'blocks.timestamp', 'block_version', 'app_version', 'l1_locked_height', 'state_transitions.hash')
             .whereBetween('rank', [fromRank, toRank])
             .orderBy('blocks.height', order);
 

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -1,4 +1,5 @@
 const Block = require("../models/Block");
+const PaginatedResultSet = require("../models/PaginatedResultSet");
 
 module.exports = class BlockDAO {
     constructor(knex) {
@@ -62,23 +63,22 @@ module.exports = class BlockDAO {
         return Block.fromRow({header: block, txs});
     }
 
-    getBlocksPaginated = async (from, to, order = 'desc') => {
+    getBlocks = async (page, limit, order) => {
+        const fromRank = (page - 1) * limit
+        const toRank = fromRank + limit - 1
+
         const subquery = this.knex('blocks')
-            .select('blocks.hash as hash', 'blocks.height as height', 'blocks.timestamp as timestamp', 'blocks.block_version as block_version', 'blocks.app_version as app_version', 'blocks.l1_locked_height as l1_locked_height').as('blocks')
-            .where(function () {
-                if (from && to) {
-                    this.where('height', '>=', from)
-                    this.where('height', '<=', to)
-                }
-            })
-            .limit(30)
-            .orderBy('blocks.height', order);
+            .select(this.knex('blocks').count('height').as('total_count'), 'blocks.hash as hash', 'blocks.height as height', 'blocks.timestamp as timestamp', 'blocks.block_version as block_version', 'blocks.app_version as app_version', 'blocks.l1_locked_height as l1_locked_height').as('blocks')
+            .select(this.knex.raw(`rank() over (order by blocks.height ${order}) rank`))
 
         const rows = await this.knex(subquery)
-            .select('blocks.hash as hash', 'height', 'timestamp', 'block_version', 'app_version', 'l1_locked_height', 'state_transitions.hash as st_hash')
+            .select('rank', 'total_count', 'blocks.hash as hash', 'height', 'timestamp', 'block_version', 'app_version', 'l1_locked_height', 'state_transitions.hash as st_hash')
             .leftJoin('state_transitions', 'state_transitions.block_hash', 'blocks.hash')
-            .groupBy('blocks.hash', 'height', 'blocks.timestamp', 'block_version', 'app_version', 'l1_locked_height', 'state_transitions.hash')
-            .orderBy('height', 'desc')
+            .groupBy('blocks.rank', 'blocks.total_count', 'blocks.hash', 'height', 'blocks.timestamp', 'block_version', 'app_version', 'l1_locked_height', 'state_transitions.hash')
+            .whereBetween('rank', [fromRank, toRank])
+            .orderBy('blocks.height', order);
+
+        const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
 
         // map-reduce Blocks with Transactions
         const blocksMap = rows.reduce((blocks, row) => {
@@ -93,8 +93,10 @@ module.exports = class BlockDAO {
             return {...blocks, [row.hash]: {...row, txs}}
         }, {})
 
-        return Object.keys(blocksMap).map(blockHash => Block.fromRow({
-                header: blocksMap[blockHash], txs: blocksMap[blockHash].txs
-            }))
+        const resultSet = Object.keys(blocksMap).map(blockHash => Block.fromRow({
+            header: blocksMap[blockHash], txs: blocksMap[blockHash].txs
+        }))
+
+        return new PaginatedResultSet(resultSet, page, limit, totalCount)
     }
 }

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -1,20 +1,37 @@
 const DataContract = require("../models/DataContract");
+const PaginatedResultSet = require("../models/PaginatedResultSet");
 
 module.exports = class DataContractsDAO {
     constructor(knex) {
         this.knex = knex;
     }
 
-    getDataContracts = async () => {
+    getDataContracts = async (page, limit, order) => {
+        const fromRank = (page - 1) * limit
+        const toRank = fromRank + limit - 1
+
         const subquery = this.knex('data_contracts')
-            .select(this.knex.raw('data_contracts.id as id, data_contracts.identifier as identifier, data_contracts.version as version, rank() over (partition by identifier order by version desc) rank'))
+            .select(this.knex('data_contracts').countDistinct('identifier').as('total_count'), 'data_contracts.id as id', 'data_contracts.identifier as identifier', 'data_contracts.version as version')
+            .select(this.knex.raw(`rank() over (partition by identifier order by version desc) rank`))
             .as('data_contracts')
 
-        const rows = await this.knex(subquery)
-            .select('id', 'identifier', 'version', 'rank')
+        const filteredContracts = this.knex(subquery)
+            .select('total_count', 'id', 'identifier', 'version', 'rank')
+            .select(this.knex.raw(`rank() over (order by id ${order}) row_number`))
             .where('rank', '=', 1)
+            .orderBy('id', order)
+            .as('temp')
 
-        return rows.map(dataContract => DataContract.fromRow(dataContract));
+        const rows = await this.knex(filteredContracts)
+            .select('total_count', 'id', 'identifier', 'version', 'row_number')
+            .whereBetween('row_number', [fromRank, toRank])
+            .orderBy('id', order);
+
+        const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
+
+        const resultSet = rows.map(dataContract => DataContract.fromRow(dataContract));
+
+        return new PaginatedResultSet(resultSet, page, limit, totalCount);
     }
 
     getDataContractByIdentifier = async (identifier) => {

--- a/packages/api/src/dao/DocumentsDAO.js
+++ b/packages/api/src/dao/DocumentsDAO.js
@@ -1,4 +1,5 @@
 const Document = require("../models/Document");
+const PaginatedResultSet = require("../models/PaginatedResultSet");
 
 module.exports = class DocumentsDAO {
     constructor(knex) {
@@ -7,7 +8,8 @@ module.exports = class DocumentsDAO {
 
     getDocumentByIdentifier = async (identifier) => {
         const subquery = this.knex('documents')
-            .select(this.knex.raw('documents.id as id, documents.identifier as identifier, data_contracts.identifier as data_contract_identifier, documents.data as data, documents.revision as revision, documents.state_transition_hash as state_transition_hash, documents.deleted as deleted, rank() over (partition by documents.identifier order by documents.id desc) rank'))
+            .select('documents.id as id', 'documents.identifier as identifier', 'data_contracts.identifier as data_contract_identifier', 'documents.data as data', 'documents.revision as revision', 'documents.state_transition_hash as state_transition_hash', 'documents.deleted as deleted')
+            .select(this.knex.raw('rank() over (partition by documents.identifier order by documents.id desc) rank'))
             .leftJoin('data_contracts', 'data_contracts.id', 'documents.data_contract_id')
             .where('documents.identifier', '=', identifier)
             .as('documents')
@@ -25,17 +27,38 @@ module.exports = class DocumentsDAO {
         return Document.fromRow(row);
     }
 
-    getDocumentsByDataContract = async (identifier) => {
+    getDocumentsByDataContract = async (identifier, page, limit, order) => {
+        const fromRank = (page - 1) * limit
+        const toRank = fromRank + limit - 1
+
         const subquery = this.knex('documents')
-            .select(this.knex.raw('documents.id as id, documents.identifier as identifier, data_contracts.identifier as data_contract_identifier, documents.data as data, documents.revision as revision, documents.state_transition_hash as state_transition_hash, documents.deleted as deleted, rank() over (partition by documents.identifier order by documents.id desc) rank'))
+            .select('documents.id as id', 'documents.identifier as identifier',
+                'data_contracts.identifier as data_contract_identifier', 'documents.data as data',
+                'documents.revision as revision', 'documents.state_transition_hash as state_transition_hash',
+                'documents.deleted as deleted')
+            .select(this.knex.raw('rank() over (partition by documents.identifier order by documents.id desc) rank'))
             .leftJoin('data_contracts', 'data_contracts.id', 'documents.data_contract_id')
             .where('data_contracts.identifier', identifier)
-            .as('documents')
 
-        const rows = await this.knex(subquery)
-            .select('id', 'identifier', 'data_contract_identifier', 'data', 'revision', 'deleted', 'rank', 'state_transition_hash')
-            .orderBy('documents.id', 'asc')
+        const filteredDocuments = this.knex.with('with_alias', subquery)
+            .select('id', 'identifier', 'rank', 'revision', 'data_contract_identifier',
+                'state_transition_hash', 'deleted', 'data',
+                this.knex('with_alias').count('*').as('total_count').where('rank', '1'))
+            .select(this.knex.raw(`rank() over (order by id ${order}) row_number`))
+            .from('with_alias')
+            .where('rank', '1')
+            .orderBy('id', order)
+            .as('test')
 
-        return rows.map((row) => Document.fromRow(row));
+        const rows = await this.knex(filteredDocuments)
+            .select('id', 'identifier', 'row_number', 'revision', 'data_contract_identifier', 'state_transition_hash', 'deleted', 'data', 'total_count')
+            .whereBetween('row_number', [fromRank, toRank])
+            .orderBy('id', order);
+
+        const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
+
+        const resultSet = rows.map((row) => Document.fromRow(row));
+
+        return new PaginatedResultSet(resultSet, page, limit, totalCount)
     }
 }

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -1,4 +1,5 @@
 const Transaction = require("../models/Transaction");
+const PaginatedResultSet = require("../models/PaginatedResultSet");
 
 module.exports = class TransactionsDAO {
     constructor(knex) {
@@ -19,21 +20,26 @@ module.exports = class TransactionsDAO {
         return Transaction.fromRow(row)
     }
 
-    getTransactions = async (from, to) => {
-        const rows = await this.knex
-            .select('state_transitions.hash as hash', 'state_transitions.data as data', 'state_transitions.type as type',
-                'state_transitions.index as index', 'blocks.height as block_height', 'blocks.timestamp as timestamp')
-            .from('state_transitions')
-            .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
-            .where((builder) => {
-                if (from && to) {
-                    builder.where('block_height', '<', to);
-                    builder.where('block_height', '>', from);
-                }
-            })
-            .limit(30)
-            .orderBy('blocks.height', 'desc')
+    getTransactions = async (page, limit, order) => {
+        const fromRank = (page - 1) * limit
+        const toRank = fromRank + limit - 1
 
-        return rows.map((row) => Transaction.fromRow(row))
+        const subquery = this.knex('state_transitions')
+            .select(this.knex('state_transitions').count('hash').as('total_count'), 'state_transitions.hash as hash', 'state_transitions.data as data', 'state_transitions.type as type',
+                'state_transitions.index as index', 'blocks.height as block_height', 'blocks.timestamp as timestamp')
+            .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
+            .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
+            .as('transactions')
+
+        const rows = await this.knex(subquery)
+            .select('total_count', 'hash', 'data', 'type', 'index', 'block_height', 'timestamp', 'rank')
+            .whereBetween('rank', [fromRank, toRank])
+            .orderBy('block_height', order);
+
+        const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
+
+        const resultSet =  rows.map((row) => Transaction.fromRow(row))
+
+        return new PaginatedResultSet(resultSet, page, limit, totalCount)
     }
 }

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -26,13 +26,13 @@ module.exports = class TransactionsDAO {
 
         const subquery = this.knex('state_transitions')
             .select(this.knex('state_transitions').count('hash').as('total_count'), 'state_transitions.hash as hash', 'state_transitions.data as data', 'state_transitions.type as type',
-                'state_transitions.index as index', 'blocks.height as block_height', 'blocks.timestamp as timestamp')
+                'state_transitions.index as index')
             .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
-            .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
-            .as('transactions')
+            .as('state_transitions')
 
         const rows = await this.knex(subquery)
-            .select('total_count', 'hash', 'data', 'type', 'index', 'block_height', 'timestamp', 'rank')
+            .select('total_count', 'data', 'type', 'index', 'rank', 'state_transitions.hash as hash', 'blocks.height as block_height', 'blocks.timestamp as timestamp')
+            .leftJoin('blocks', 'blocks.hash', 'state_transitions.hash')
             .whereBetween('rank', [fromRank, toRank])
             .orderBy('block_height', order);
 

--- a/packages/api/src/models/PaginatedResultSet.js
+++ b/packages/api/src/models/PaginatedResultSet.js
@@ -1,0 +1,9 @@
+module.exports = class PaginatedResultSet {
+    resultSet
+    pagination
+
+    constructor(resultSet, page, limit, total) {
+        this.resultSet = resultSet;
+        this.pagination = {page, limit, total: resultSet.length ? total : -1};
+    }
+}

--- a/packages/indexer/Cargo.lock
+++ b/packages/indexer/Cargo.lock
@@ -544,7 +544,7 @@ dependencies = [
 
 [[package]]
 name = "dashpay-contract"
-version = "0.24.0-dev.1"
+version = "0.25.0"
 dependencies = [
  "lazy_static",
  "platform-value",
@@ -553,7 +553,7 @@ dependencies = [
 
 [[package]]
 name = "data-contracts"
-version = "0.24.0-dev.1"
+version = "0.25.0"
 dependencies = [
  "dashpay-contract",
  "dpns-contract",
@@ -649,7 +649,7 @@ checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
 
 [[package]]
 name = "dpns-contract"
-version = "0.24.0-dev.1"
+version = "0.25.0"
 dependencies = [
  "platform-value",
  "serde_json",
@@ -657,7 +657,7 @@ dependencies = [
 
 [[package]]
 name = "dpp"
-version = "0.25.0-dev.30"
+version = "0.25.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -827,7 +827,7 @@ checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "feature-flags-contract"
-version = "0.24.0-dev.1"
+version = "0.25.0"
 dependencies = [
  "platform-value",
  "serde_json",
@@ -1398,7 +1398,7 @@ checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
 name = "masternode-reward-shares-contract"
-version = "0.24.0-dev.1"
+version = "0.25.0"
 dependencies = [
  "platform-value",
  "serde_json",
@@ -1741,7 +1741,7 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "platform-serialization"
-version = "0.1.0"
+version = "0.25.0"
 dependencies = [
  "bincode",
  "platform-version",
@@ -1749,7 +1749,7 @@ dependencies = [
 
 [[package]]
 name = "platform-serialization-derive"
-version = "0.1.0"
+version = "0.25.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1759,7 +1759,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value"
-version = "0.1.0"
+version = "0.25.0"
 dependencies = [
  "base64 0.13.1",
  "bincode",
@@ -1780,7 +1780,7 @@ dependencies = [
 
 [[package]]
 name = "platform-value-convertible"
-version = "0.1.0"
+version = "0.25.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1789,7 +1789,7 @@ dependencies = [
 
 [[package]]
 name = "platform-version"
-version = "0.1.0"
+version = "0.25.0"
 dependencies = [
  "bincode",
  "thiserror",
@@ -3126,7 +3126,7 @@ dependencies = [
 
 [[package]]
 name = "withdrawals-contract"
-version = "0.24.0-dev.1"
+version = "0.25.0"
 dependencies = [
  "num_enum",
  "platform-value",


### PR DESCRIPTION
# Things done

* Implemented pagination on all listable methods on the API
* Added `PaginatedResultSet` interface

All lists are now paginated via query params `?page=1&limit=1&order=asc`

Paginated result returns to the client with the info of total items

<img width="744" alt="image" src="https://github.com/pshenmic/platform-explorer/assets/17009187/04372485-7e49-43af-b342-007d6bec6b21">
