### PR TITLE
Migrate owner to the state transitions

### DIFF
--- a/packages/indexer/migrations/V18__move_owners_to_state_transition.sql
+++ b/packages/indexer/migrations/V18__move_owners_to_state_transition.sql
@@ -1,0 +1,8 @@
+ALTER TABLE documents
+DROP COLUMN owner;
+
+ALTER TABLE data_contracts
+DROP COLUMN owner;
+
+ALTER TABLE state_transitions
+ADD COLUMN "owner" char(44) not null;

--- a/packages/indexer/src/entities/data_contract.rs
+++ b/packages/indexer/src/entities/data_contract.rs
@@ -2,7 +2,6 @@ use dpp::data_contract::serialized_version::DataContractInSerializationFormat;
 use dpp::data_contracts::SystemDataContract;
 use dpp::identifier::Identifier;
 use dpp::platform_value::string_encoding::Encoding;
-use dpp::platform_value::string_encoding::Encoding::Base58;
 use dpp::state_transition::data_contract_create_transition::DataContractCreateTransition;
 use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use serde_json::Value;
@@ -48,7 +47,6 @@ impl From<DataContractUpdateTransition> for DataContract {
                 match data_contract {
                     DataContractInSerializationFormat::V0(data_contract) => {
                         let identifier = data_contract.id;
-                        let owner = data_contract.owner_id;
                         let version = data_contract.version;
                         let schema = data_contract.document_schemas;
                         let schema_decoded = serde_json::to_value(schema).unwrap();
@@ -81,12 +79,11 @@ impl From<SystemDataContract> for DataContract {
 impl From<Row> for DataContract {
     fn from(row: Row) -> Self {
         let id: i32 = row.get(0);
-        let owner: String = row.get(1);
 
-        let identifier_str: String = row.get(2);
+        let identifier_str: String = row.get(1);
         let identifier = Identifier::from_string(&identifier_str, Encoding::Base58).unwrap();
 
-        let version:i32 = row.get(3);
+        let version:i32 = row.get(2);
 
         return DataContract{
             id: Some(id as u32),

--- a/packages/indexer/src/entities/document.rs
+++ b/packages/indexer/src/entities/document.rs
@@ -1,6 +1,5 @@
 use dpp::identifier::Identifier;
 use dpp::platform_value::string_encoding::Encoding;
-use dpp::platform_value::string_encoding::Encoding::Base58;
 use dpp::prelude::Revision;
 use dpp::state_transition::documents_batch_transition::document_base_transition::v0::v0_methods::DocumentBaseTransitionV0Methods;
 use dpp::state_transition::documents_batch_transition::document_create_transition::v0::v0_methods::DocumentCreateTransitionV0Methods;
@@ -14,7 +13,6 @@ use tokio_postgres::Row;
 pub struct Document {
     pub id: Option<u32>,
     pub identifier: Identifier,
-    pub owner: Option<Identifier>,
     pub data_contract_identifier: Identifier,
     pub data: Option<Value>,
     pub deleted: bool,
@@ -28,20 +26,17 @@ impl From<Row> for Document {
         let identifier_str: String = row.get(1);
         let identifier = Identifier::from_string(&identifier_str, Encoding::Base58).unwrap();
 
-        let owner: String = row.get(2);
-
-        let data_contract_identifier_str: String = row.get(3);
+        let data_contract_identifier_str: String = row.get(2);
         let data_contract_identifier = Identifier::from_string(&data_contract_identifier_str, Encoding::Base58).unwrap();
 
-        let revision: i32 = row.get(4);
+        let revision: i32 = row.get(3);
 
-        let deleted: bool = row.get(5);
+        let deleted: bool = row.get(4);
 
         return Document {
             id: Some(id as u32),
             deleted,
             identifier,
-            owner: Some(Identifier::from_string(&owner, Base58).unwrap()),
             data: None,
             data_contract_identifier,
             revision: Revision::from(revision as u64),
@@ -62,7 +57,6 @@ impl From<DocumentTransition> for Document {
 
                 return Document {
                     id: None,
-                    owner: None,
                     identifier,
                     data: Some(data_decoded),
                     data_contract_identifier,
@@ -80,7 +74,6 @@ impl From<DocumentTransition> for Document {
 
                 return Document {
                     id: None,
-                    owner: None,
                     identifier,
                     data: Some(data_decoded),
                     data_contract_identifier,
@@ -96,7 +89,6 @@ impl From<DocumentTransition> for Document {
 
                 return Document {
                     id: None,
-                    owner: None,
                     identifier,
                     data: None,
                     data_contract_identifier,

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -7,11 +7,10 @@ use dpp::state_transition::data_contract_create_transition::DataContractCreateTr
 use crate::processor::psql::dao::PostgresDAO;
 use base64::{Engine as _, engine::{general_purpose}};
 use dpp::data_contracts::SystemDataContract;
-use dpp::identifier::Identifier;
 use dpp::platform_value::string_encoding::Encoding::Base58;
 use dpp::serialization::PlatformSerializable;
 use dpp::state_transition::documents_batch_transition::accessors::DocumentsBatchTransitionAccessorsV0;
-use dpp::state_transition::documents_batch_transition::{ DocumentsBatchTransition};
+use dpp::state_transition::documents_batch_transition::{DocumentsBatchTransition};
 use sha256::digest;
 use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
@@ -66,27 +65,24 @@ impl PSQLProcessor {
     }
 
     pub async fn handle_data_contract_create(&self, state_transition: DataContractCreateTransition, st_hash: String) -> () {
-        let owner = state_transition.owner_id();
         let data_contract = DataContract::from(state_transition);
 
-        self.dao.create_data_contract(data_contract, owner, st_hash).await;
+        self.dao.create_data_contract(data_contract, st_hash).await;
     }
 
     pub async fn handle_data_contract_update(&self, state_transition: DataContractUpdateTransition, st_hash: String) -> () {
-        let owner = state_transition.owner_id();
         let data_contract = DataContract::from(state_transition);
 
-        self.dao.create_data_contract(data_contract, owner, st_hash).await;
+        self.dao.create_data_contract(data_contract, st_hash).await;
     }
 
     pub async fn handle_documents_batch(&self, state_transition: DocumentsBatchTransition, st_hash: String) -> () {
         let transitions = state_transition.transitions().clone();
-        let owner = state_transition.owner_id();
 
         for (_, document_transition) in transitions.iter().enumerate() {
             let document = Document::from(document_transition.clone());
 
-            self.dao.create_document(document, owner, st_hash.clone()).await;
+            self.dao.create_document(document, st_hash.clone()).await;
         }
     }
 
@@ -121,6 +117,8 @@ impl PSQLProcessor {
     }
 
     pub async fn handle_st(&self, block_hash: String, index: u32, state_transition: StateTransition) -> () {
+        let owner = state_transition.owner_id();
+
         let st_type = match state_transition.clone() {
             StateTransition::DataContractCreate(st) => st.state_transition_type() as u32,
             StateTransition::DataContractUpdate(st) => st.state_transition_type() as u32,
@@ -167,67 +165,50 @@ impl PSQLProcessor {
                 )).unwrap(),
         };
 
+        let st_hash = digest(bytes.clone()).to_uppercase();
+
+        self.dao.create_state_transition(block_hash.clone(), owner, st_type, index, bytes).await;
+
         match state_transition {
             StateTransition::DataContractCreate(st) => {
-                let st_hash = digest(bytes.clone()).to_uppercase();
-
-                self.dao.create_state_transition(block_hash.clone(), st_type, index, bytes).await;
-
                 self.handle_data_contract_create(st, st_hash).await;
 
                 println!("Processed DataContractCreate at block hash {}", block_hash);
             }
             StateTransition::DataContractUpdate(st) => {
-                let st_hash = digest(bytes.clone()).to_uppercase();
-
-                self.dao.create_state_transition(block_hash.clone(), st_type, index, bytes).await;
-
                 self.handle_data_contract_update(st, st_hash).await;
 
                 println!("Processed DataContractUpdate at block hash {}", block_hash);
             }
             StateTransition::DocumentsBatch(st) => {
-                let st_hash = digest(bytes.clone()).to_uppercase();
-
-                self.dao.create_state_transition(block_hash.clone(), st_type, index, bytes.clone()).await;
-
                 self.handle_documents_batch(st, st_hash).await;
 
                 println!("Processed DocumentsBatch at block hash {}", block_hash);
             }
             StateTransition::IdentityCreate(st) => {
-                let st_hash = digest(bytes.clone()).to_uppercase();
-
-                self.dao.create_state_transition(block_hash.clone(), st_type, index, bytes).await;
-
                 self.handle_identity_create(st, st_hash).await;
+
+                println!("Processed IdentityCreate at block hash {}", block_hash);
             }
             StateTransition::IdentityTopUp(st) => {
-                let st_hash = digest(bytes.clone()).to_uppercase();
-
-                self.dao.create_state_transition(block_hash.clone(), st_type, index, bytes).await;
-
                 self.handle_identity_top_up(st, st_hash).await;
+
+                println!("Processed IdentityTopUp at block hash {}", block_hash);
             }
             StateTransition::IdentityCreditWithdrawal(st) => {
-                let st_hash = digest(bytes.clone()).to_uppercase();
-
                 self.handle_identity_credit_withdrawal(st, st_hash).await;
+
+                println!("Processed IdentityCreditWithdrawal at block hash {}", block_hash);
             }
             StateTransition::IdentityUpdate(st) => {
-                let st_hash = digest(bytes.clone()).to_uppercase();
-
-                self.dao.create_state_transition(block_hash.clone(), st_type, index, bytes).await;
-
                 self.handle_identity_update(st, st_hash).await;
 
+                println!("Processed IdentityUpdate at block hash {}", block_hash);
             }
             StateTransition::IdentityCreditTransfer(st) => {
-                let st_hash = digest(bytes.clone()).to_uppercase();
-
-                self.dao.create_state_transition(block_hash.clone(), st_type, index, bytes).await;
-
                 self.handle_identity_credit_transfer(st, st_hash).await;
+
+                println!("Processed IdentityCreditTransfer at block hash {}", block_hash);
             }
         }
     }
@@ -273,33 +254,31 @@ impl PSQLProcessor {
         println!("Processing initChain");
 
         let mut system_contract;
-        let mut owner;
         let mut data_contract;
 
         system_contract = SystemDataContract::Withdrawals;
-        owner = Identifier::from(system_contract.source().unwrap().owner_id_bytes);
         data_contract = DataContract::from(system_contract);
         println!("Processing SystemDataContract::Withdrawals {}", data_contract.identifier.to_string(Base58));
-        self.dao.create_data_contract(data_contract, owner, String::from("initChain")).await;
+        self.dao.create_data_contract(data_contract, String::from("initChain")).await;
 
         system_contract = SystemDataContract::MasternodeRewards;
         data_contract = DataContract::from(system_contract);
         println!("Processing SystemDataContract::MasternodeRewards {}", data_contract.identifier.to_string(Base58));
-        self.dao.create_data_contract(data_contract, owner, String::from("initChain")).await;
+        self.dao.create_data_contract(data_contract, String::from("initChain")).await;
 
         system_contract = SystemDataContract::FeatureFlags;
         data_contract = DataContract::from(system_contract);
         println!("Processing SystemDataContract::FeatureFlags {}", data_contract.identifier.to_string(Base58));
-        self.dao.create_data_contract(data_contract, owner, String::from("initChain")).await;
+        self.dao.create_data_contract(data_contract, String::from("initChain")).await;
 
         system_contract = SystemDataContract::DPNS;
         data_contract = DataContract::from(system_contract);
         println!("Processing SystemDataContract::DPNS {}", data_contract.identifier.to_string(Base58));
-        self.dao.create_data_contract(data_contract, owner, String::from("initChain")).await;
+        self.dao.create_data_contract(data_contract, String::from("initChain")).await;
 
         system_contract = SystemDataContract::Dashpay;
         data_contract = DataContract::from(system_contract);
         println!("Processing SystemDataContract::Dashpay {}", data_contract.identifier.to_string(Base58));
-        self.dao.create_data_contract(data_contract, owner, String::from("initChain")).await;
+        self.dao.create_data_contract(data_contract, String::from("initChain")).await;
     }
 }


### PR DESCRIPTION
# Issue

In the previous PR https://github.com/pshenmic/platform-explorer/pull/71 I introduced owners of the documents and data contracts, but it is not correct. Owner should be persisted in the state_transitions table instead

# Things done
* Remove owner from data contracts & documents
* Added owner to state_transitions