### PR TITLE
Add get identity by identifier API

### DIFF
--- a/packages/api/index.js
+++ b/packages/api/index.js
@@ -10,6 +10,7 @@ const MainController = require("./src/controllers/MainController");
 const TransactionsController = require("./src/controllers/TransactionsController");
 const BlocksController = require("./src/controllers/BlocksController");
 const DocumentsController = require("./src/controllers/DocumentsController");
+const IdentitiesController = require("./src/controllers/IdentitiesController");
 const packageVersion = require('./package.json').version
 const Worker = require('./src/worker/index')
 const {BLOCK_TIME} = require("./src/constants");
@@ -74,8 +75,9 @@ const init = async () => {
     const transactionsController = new TransactionsController(client, knex)
     const dataContractsController = new DataContractsController(knex)
     const documentsController = new DocumentsController(knex)
+    const identitiesController = new IdentitiesController(knex)
 
-    Routes({fastify, mainController, blocksController, transactionsController, dataContractsController, documentsController})
+    Routes({fastify, mainController, blocksController, transactionsController, dataContractsController, documentsController, identitiesController})
 
     fastify.setErrorHandler(errorHandler)
     fastify.listen({ host: "0.0.0.0", port: 3005, listenTextResolver: (address) => console.log(`Platform indexer API has started on the ${address}`)});

--- a/packages/api/src/controllers/DocumentsController.js
+++ b/packages/api/src/controllers/DocumentsController.js
@@ -15,7 +15,7 @@ class DocumentsController {
             response.status(404).send({message: 'not found'})
         }
 
-        response.send(Document.fromRow(document));
+        response.send(document);
     }
 
     getDocumentsByDataContract = async (request, response) => {

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -1,0 +1,21 @@
+const IdentitiesDAO = require("../dao/IdentitiesDAO");
+
+class IdentitiesController {
+    constructor(knex) {
+        this.identitiesDAO = new IdentitiesDAO(knex)
+    }
+
+    getIdentityByIdentifier = async (request, response) => {
+        const {identifier} = request.params;
+
+        const identity = await this.identitiesDAO.getIdentityByIdentifier(identifier)
+
+        if (!identity) {
+            return response.status(404).send({message: 'not found'})
+        }
+
+        response.send(identity)
+    }
+}
+
+module.exports = IdentitiesController

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -1,5 +1,4 @@
 const cache = require("../cache");
-const Transaction = require("../models/Transaction");
 const TransactionsDAO = require("../dao/TransactionsDAO");
 
 class TransactionsController {

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -1,0 +1,57 @@
+const Identity = require("../models/Identity");
+
+module.exports = class IdentitiesDAO {
+    constructor(knex) {
+        this.knex = knex;
+    }
+
+    getIdentityByIdentifier = async (identifier) => {
+        const subquery = this.knex('identities')
+            .select('identities.id','identities.identifier as identifier', 'identities.state_transition_hash as st_hash',
+                'identities.revision as revision', 'identities.state_transition_hash as state_transition_hash')
+            .select(this.knex.raw('rank() over (partition by identities.identifier order by identities.id desc) rank'))
+            .where('identities.identifier', '=', identifier)
+            .as('all_identities')
+
+        const lastRevisionIdentities = this.knex(subquery)
+            .select('identifier', 'revision', 'st_hash',
+                'transfers.id as transfer_id', 'transfers.sender as sender',
+                'transfers.recipient as recipient', 'transfers.amount as amount')
+            .where('rank', 1)
+            .leftJoin('transfers', 'transfers.recipient', 'identifier')
+
+
+        const documentSubQuery = this.knex('documents')
+            .select('documents.id as id', 'documents.state_transition_hash as st_hash')
+            .join('state_transitions', 'st_hash', 'state_transitions.hash')
+            .where('state_transitions.owner', identifier)
+
+        const dataContractsSubQuery = this.knex('data_contracts')
+            .select('data_contracts.id as id', 'data_contracts.state_transition_hash as st_hash')
+            .join('state_transitions', 'st_hash', 'state_transitions.hash')
+            .where('state_transitions.owner', identifier)
+
+        const rows = await this.knex.with('with_alias', lastRevisionIdentities)
+            .select('identifier', 'revision',
+                'transfer_id', 'sender', 'st_hash', 'blocks.timestamp as timestamp',
+                'recipient', 'amount')
+            .join('state_transitions', 'state_transitions.hash', 'st_hash')
+            .join('blocks', 'state_transitions.block_hash', 'blocks.hash')
+            .select(this.knex('with_alias').sum('amount').where('recipient', identifier).as('total_received'))
+            .select(this.knex('with_alias').sum('amount').where('sender', identifier).as('total_sent'))
+            .select(this.knex('state_transitions').count('*').where('owner', identifier).as('total_txs'))
+            .select(this.knex.with('with_documents', documentSubQuery).count('*').where('owner', identifier).as('total_documents'))
+            .select(this.knex.with('with_data_contracts', dataContractsSubQuery).count('*').where('owner', identifier).as('total_data_contracts'))
+            .from('with_alias')
+
+        if (!rows.length) {
+            return null
+        }
+
+        const [row] = rows
+
+        const balance = Number(row.total_received ?? 0) - Number(row.total_sent ?? 0)
+
+        return Identity.fromRow({...row, balance})
+    }
+}

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -7,42 +7,52 @@ module.exports = class IdentitiesDAO {
 
     getIdentityByIdentifier = async (identifier) => {
         const subquery = this.knex('identities')
-            .select('identities.id','identities.identifier as identifier', 'identities.state_transition_hash as st_hash',
+            .select('identities.id','identities.identifier as identifier', 'identities.state_transition_hash as tx_hash',
                 'identities.revision as revision', 'identities.state_transition_hash as state_transition_hash')
             .select(this.knex.raw('rank() over (partition by identities.identifier order by identities.id desc) rank'))
             .where('identities.identifier', '=', identifier)
             .as('all_identities')
 
         const lastRevisionIdentities = this.knex(subquery)
-            .select('identifier', 'revision', 'st_hash',
+            .select('identifier', 'revision', 'tx_hash',
                 'transfers.id as transfer_id', 'transfers.sender as sender',
                 'transfers.recipient as recipient', 'transfers.amount as amount')
             .where('rank', 1)
             .leftJoin('transfers', 'transfers.recipient', 'identifier')
 
-
-        const documentSubQuery = this.knex('documents')
-            .select('documents.id as id', 'documents.state_transition_hash as st_hash')
-            .join('state_transitions', 'st_hash', 'state_transitions.hash')
+        const documentsSubQuery = this.knex('documents')
+            .select('documents.id', 'documents.state_transition_hash', 'state_transitions.owner as owner')
+            .select(this.knex.raw('rank() over (partition by documents.identifier order by documents.id desc) rank'))
+            .leftJoin('state_transitions', 'documents.state_transition_hash', 'state_transitions.hash')
             .where('state_transitions.owner', identifier)
+            .as('as_documents')
 
         const dataContractsSubQuery = this.knex('data_contracts')
-            .select('data_contracts.id as id', 'data_contracts.state_transition_hash as st_hash')
-            .join('state_transitions', 'st_hash', 'state_transitions.hash')
+            .select('data_contracts.id', 'data_contracts.state_transition_hash', 'state_transitions.owner as owner')
+            .select(this.knex.raw('rank() over (partition by data_contracts.identifier order by data_contracts.id desc) rank'))
+            .leftJoin('state_transitions', 'data_contracts.state_transition_hash', 'state_transitions.hash')
+            .where('state_transitions.owner', identifier)
+            .as('as_data_contracts')
+
+        const transfersSubquery = this.knex('transfers')
+            .select('transfers.id as id', 'transfers.state_transition_hash as tx_hash')
+            .leftJoin('state_transitions', 'tx_hash', 'state_transitions.hash')
             .where('state_transitions.owner', identifier)
 
         const rows = await this.knex.with('with_alias', lastRevisionIdentities)
             .select('identifier', 'revision',
-                'transfer_id', 'sender', 'st_hash', 'blocks.timestamp as timestamp',
+                'transfer_id', 'sender', 'tx_hash', 'blocks.timestamp as timestamp',
                 'recipient', 'amount')
-            .join('state_transitions', 'state_transitions.hash', 'st_hash')
+            .join('state_transitions', 'state_transitions.hash', 'tx_hash')
             .join('blocks', 'state_transitions.block_hash', 'blocks.hash')
             .select(this.knex('with_alias').sum('amount').where('recipient', identifier).as('total_received'))
             .select(this.knex('with_alias').sum('amount').where('sender', identifier).as('total_sent'))
             .select(this.knex('state_transitions').count('*').where('owner', identifier).as('total_txs'))
-            .select(this.knex.with('with_documents', documentSubQuery).count('*').where('owner', identifier).as('total_documents'))
-            .select(this.knex.with('with_data_contracts', dataContractsSubQuery).count('*').where('owner', identifier).as('total_data_contracts'))
+            .select(this.knex(documentsSubQuery).count('*').where('rank', 1).as('total_documents'))
+            .select(this.knex(dataContractsSubQuery).count('*').where('rank', 1).as('total_data_contracts'))
+            .select(this.knex.with('with_transfers', transfersSubquery).count('*').as('total_transfers'))
             .from('with_alias')
+            .limit(1)
 
         if (!rows.length) {
             return null

--- a/packages/api/src/models/DataContract.js
+++ b/packages/api/src/models/DataContract.js
@@ -3,6 +3,7 @@ module.exports = class DataContract {
     schema
     version
     txHash
+    timestamp
 
     constructor(identifier, schema, version, txHash, timestamp) {
         this.identifier = identifier;

--- a/packages/api/src/models/DataContract.js
+++ b/packages/api/src/models/DataContract.js
@@ -2,14 +2,17 @@ module.exports = class DataContract {
     identifier
     schema
     version
+    txHash
 
-    constructor(identifier, schema, version) {
+    constructor(identifier, schema, version, txHash, timestamp) {
         this.identifier = identifier;
         this.schema = schema;
         this.version = version;
+        this.txHash = txHash;
+        this.timestamp = timestamp;
     }
 
-    static fromRow({identifier, schema, version}) {
-        return new DataContract(identifier, schema, version)
+    static fromRow({identifier, schema, version, tx_hash, timestamp}) {
+        return new DataContract(identifier, schema, version, tx_hash, timestamp)
     }
 }

--- a/packages/api/src/models/Document.js
+++ b/packages/api/src/models/Document.js
@@ -2,20 +2,23 @@ module.exports = class Document {
     identifier
     dataContractIdentifier
     revision
-    stateTransitionHash
+    txHash
     deleted
     data
+    timestamp
 
-    constructor(identifier, dataContractIdentifier, revision, stateTransitionHash, deleted, data) {
+    constructor(identifier, dataContractIdentifier, revision, txHash, deleted, data, timestamp) {
         this.identifier = identifier;
         this.dataContractIdentifier = dataContractIdentifier;
         this.revision = revision;
-        this.stateTransitionHash = stateTransitionHash;
         this.deleted = deleted;
         this.data = data;
+        this.txHash = txHash;
+        this.data = data;
+        this.timestamp = timestamp;
     }
 
-    static fromRow({identifier, data_contract_identifier, revision, state_transition_hash, deleted, data}) {
-        return new Document(identifier, data_contract_identifier, revision, state_transition_hash, deleted, data)
+    static fromRow({identifier, data_contract_identifier, revision, tx_hash, deleted, data, timestamp}) {
+        return new Document(identifier, data_contract_identifier, revision, tx_hash, deleted, data, timestamp)
     }
 }

--- a/packages/api/src/models/Identity.js
+++ b/packages/api/src/models/Identity.js
@@ -1,0 +1,19 @@
+module.exports = class Identity {
+    identifier
+    revision
+    balance
+    timestamp
+    totalTxs
+
+    constructor(identifier, revision, balance, timestamp, totalTxs) {
+        this.identifier = identifier;
+        this.revision = revision;
+        this.balance = balance;
+        this.timestamp = timestamp;
+        this.totalTxs = totalTxs;
+    }
+
+    static fromRow({identifier, revision, balance, timestamp, total_txs}) {
+        return new Identity(identifier, revision, balance, timestamp, total_txs)
+    }
+}

--- a/packages/api/src/models/Identity.js
+++ b/packages/api/src/models/Identity.js
@@ -3,8 +3,11 @@ module.exports = class Identity {
     revision
     balance
     timestamp
-    totalTxs
     txHash
+    totalTxs
+    totalTransfers
+    totalDocuments
+    totalDataContracts
 
     constructor(identifier, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash) {
         this.identifier = identifier;

--- a/packages/api/src/models/Identity.js
+++ b/packages/api/src/models/Identity.js
@@ -4,16 +4,21 @@ module.exports = class Identity {
     balance
     timestamp
     totalTxs
+    txHash
 
-    constructor(identifier, revision, balance, timestamp, totalTxs) {
+    constructor(identifier, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash) {
         this.identifier = identifier;
         this.revision = revision;
         this.balance = balance;
         this.timestamp = timestamp;
         this.totalTxs = totalTxs;
+        this.totalDocuments = totalDocuments;
+        this.totalDataContracts = totalDataContracts;
+        this.totalTransfers = totalTransfers;
+        this.txHash = txHash
     }
 
-    static fromRow({identifier, revision, balance, timestamp, total_txs}) {
-        return new Identity(identifier, revision, balance, timestamp, total_txs)
+    static fromRow({identifier, revision, balance, timestamp, total_txs, total_data_contracts, total_documents, total_transfers, tx_hash}) {
+        return new Identity(identifier, revision, balance, timestamp, total_txs, total_data_contracts, total_documents, total_transfers, tx_hash)
     }
 }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -5,7 +5,7 @@
  * @param blockController {BlocksController}
  * @param transactionsController {TransactionsController}
  */
-module.exports = ({fastify, mainController, blocksController, transactionsController, dataContractsController, documentsController}) => {
+module.exports = ({fastify, mainController, blocksController, transactionsController, dataContractsController, documentsController, identitiesController}) => {
     const routes = [
         {
             path: '/status',
@@ -51,6 +51,11 @@ module.exports = ({fastify, mainController, blocksController, transactionsContro
             path: '/document/:identifier',
             method: 'GET',
             handler: documentsController.getDocumentByIdentifier
+        },
+        {
+            path: '/identities/:identifier',
+            method: 'GET',
+            handler: identitiesController.getIdentityByIdentifier
         },
         {
             path: '/search',


### PR DESCRIPTION
# Issue

Add /identities/$identity_id backend API route path, that will return info about the given identity. The info contains:
* identifier
* balance
* state transition hash
* transactions count
* transfers count
* data contracts count
* documents count

# Things done
* Added getIdentityByIdentifier API method
* Added state transition hash to the data contracts
* Added tx_hash and timestamp fields in the Documents & DataContracts APIs