### PR TITLE
Extend Identities API routes

### DIFF
--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -16,6 +16,58 @@ class IdentitiesController {
 
         response.send(identity)
     }
+
+    getTransactionsByIdentity = async (request, response) => {
+        const {identifier} = request.params
+        const {page = 1, limit = 10, order = 'asc'} = request.query
+
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const transactions = await this.identitiesDAO.getTransactionsByIdentity(identifier, Number(page), Number(limit), order)
+
+        response.send(transactions)
+    }
+
+    getDataContractsByIdentity = async (request, response) => {
+        const {identifier} = request.params
+        const {page = 1, limit = 10, order = 'asc'} = request.query
+
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const dataContracts = await this.identitiesDAO.getDataContractsByIdentity(identifier, Number(page), Number(limit), order)
+
+        response.send(dataContracts)
+    }
+
+    getDocumentsByIdentity = async (request, response) => {
+        const {identifier} = request.params
+        const {page = 1, limit = 10, order = 'asc'} = request.query
+
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const documents = await this.identitiesDAO.getDocumentsByIdentity(identifier, Number(page), Number(limit), order)
+
+        response.send(documents)
+    }
+
+    getTransfersByIdentity = async (request, response) => {
+        const {identifier} = request.params
+        const {page = 1, limit = 10, order = 'asc'} = request.query
+
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const transfers = await this.identitiesDAO.getTransfersByIdentity(identifier, Number(page), Number(limit), order)
+
+        response.send(transfers)
+    }
 }
 
 module.exports = IdentitiesController

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -1,4 +1,9 @@
 const Identity = require("../models/Identity");
+const Transfer = require("../models/Transfer");
+const Transaction = require("../models/Transaction");
+const Document = require("../models/Document");
+const DataContract = require("../models/DataContract");
+const PaginatedResultSet = require("../models/PaginatedResultSet");
 
 module.exports = class IdentitiesDAO {
     constructor(knex) {
@@ -7,16 +12,13 @@ module.exports = class IdentitiesDAO {
 
     getIdentityByIdentifier = async (identifier) => {
         const subquery = this.knex('identities')
-            .select('identities.id','identities.identifier as identifier', 'identities.state_transition_hash as tx_hash',
-                'identities.revision as revision', 'identities.state_transition_hash as state_transition_hash')
+            .select('identities.id', 'identities.identifier as identifier', 'identities.state_transition_hash as tx_hash', 'identities.revision as revision')
             .select(this.knex.raw('rank() over (partition by identities.identifier order by identities.id desc) rank'))
             .where('identities.identifier', '=', identifier)
             .as('all_identities')
 
         const lastRevisionIdentities = this.knex(subquery)
-            .select('identifier', 'revision', 'tx_hash',
-                'transfers.id as transfer_id', 'transfers.sender as sender',
-                'transfers.recipient as recipient', 'transfers.amount as amount')
+            .select('identifier', 'revision', 'tx_hash', 'transfers.id as transfer_id', 'transfers.sender as sender', 'transfers.recipient as recipient', 'transfers.amount as amount')
             .where('rank', 1)
             .leftJoin('transfers', 'transfers.recipient', 'identifier')
 
@@ -40,9 +42,7 @@ module.exports = class IdentitiesDAO {
             .where('state_transitions.owner', identifier)
 
         const rows = await this.knex.with('with_alias', lastRevisionIdentities)
-            .select('identifier', 'revision',
-                'transfer_id', 'sender', 'tx_hash', 'blocks.timestamp as timestamp',
-                'recipient', 'amount')
+            .select('identifier', 'revision', 'transfer_id', 'sender', 'tx_hash', 'blocks.timestamp as timestamp', 'recipient', 'amount')
             .join('state_transitions', 'state_transitions.hash', 'tx_hash')
             .join('blocks', 'state_transitions.block_hash', 'blocks.hash')
             .select(this.knex('with_alias').sum('amount').where('recipient', identifier).as('total_received'))
@@ -63,5 +63,112 @@ module.exports = class IdentitiesDAO {
         const balance = Number(row.total_received ?? 0) - Number(row.total_sent ?? 0)
 
         return Identity.fromRow({...row, balance})
+    }
+
+    getDataContractsByIdentity = async (identifier, page, limit, order) => {
+        const fromRank = (page - 1) * limit + 1
+        const toRank = fromRank + limit - 1
+
+        const subquery = this.knex('data_contracts')
+            .select('data_contracts.id', 'data_contracts.identifier as identifier', 'data_contracts.schema as schema', 'data_contracts.version as version', 'data_contracts.state_transition_hash as tx_hash')
+            .select(this.knex.raw(`rank() over (partition by data_contracts.identifier order by data_contracts.id desc) rank`))
+            .join('state_transitions', 'state_transitions.hash', 'data_contracts.state_transition_hash',)
+            .where('state_transitions.owner', '=', identifier)
+
+        const filteredDataContracts = this.knex.with('with_alias', subquery)
+            .select('id', 'identifier', 'schema', 'version', 'tx_hash', 'rank')
+            .select(this.knex('with_alias').count('*').where('rank', 1).as('total_count'))
+            .select(this.knex.raw(`rank() over (order by id ${order}) row_number`))
+            .from('with_alias')
+            .where('rank', 1)
+            .as('data_contracts')
+
+        const rows = await this.knex(filteredDataContracts)
+            .select('identifier', 'schema', 'version', 'tx_hash', 'rank', 'total_count', 'row_number', 'blocks.timestamp as timestamp')
+            .join('state_transitions', 'state_transitions.hash', 'tx_hash')
+            .join('blocks', 'blocks.hash', 'state_transitions.block_hash')
+            .whereBetween('row_number', [fromRank, toRank])
+            .orderBy('blocks.height ', order)
+
+        const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
+
+        return new PaginatedResultSet(rows.map(row => DataContract.fromRow(row)), page, limit, totalCount)
+    }
+
+    getDocumentsByIdentity = async (identifier, page, limit, order) => {
+        const fromRank = (page - 1) * limit + 1
+        const toRank = fromRank + limit - 1
+
+        const subquery = this.knex('documents')
+            .select('documents.id', 'documents.identifier as identifier', 'documents.data as document_data', 'documents.data_contract_id as data_contract_id', 'documents.revision as revision', 'documents.state_transition_hash as tx_hash', 'documents.deleted as deleted')
+            .select(this.knex.raw(`rank() over (partition by documents.identifier order by documents.id desc) rank`))
+            .join('state_transitions', 'state_transitions.hash', 'documents.state_transition_hash')
+            .where('state_transitions.owner', '=', identifier)
+
+        const filteredDocuments = this.knex.with('with_alias', subquery)
+            .select('id', 'identifier', 'revision', 'document_data', 'data_contract_id', 'deleted', 'tx_hash', 'rank')
+            .select(this.knex('with_alias').count('*').where('rank', 1).as('total_count'))
+            .select(this.knex.raw(`rank() over (order by id ${order}) row_number`))
+            .from('with_alias')
+            .where('rank', 1)
+            .as('documents')
+
+        const rows = await this.knex(filteredDocuments)
+            .select('documents.identifier as identifier', 'data_contracts.identifier as data_contract_identifier', 'revision', 'document_data', 'deleted', 'tx_hash', 'total_count', 'row_number', 'data_contract_id', 'blocks.timestamp as timestamp')
+            .join('state_transitions', 'state_transitions.hash', 'tx_hash')
+            .join('blocks', 'blocks.hash', 'state_transitions.block_hash')
+            .join('data_contracts', 'data_contracts.id', 'data_contract_id')
+            .whereBetween('row_number', [fromRank, toRank])
+            .orderBy('blocks.height ', order)
+
+        const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
+
+        return new PaginatedResultSet(rows.map(row => Document.fromRow({
+            ...row, data: row.document_data
+        })), page, limit, totalCount)
+    }
+
+    getTransactionsByIdentity = async (identifier, page, limit, order) => {
+        const fromRank = (page - 1) * limit + 1
+        const toRank = fromRank + limit - 1
+
+        const subquery = this.knex('state_transitions')
+            .select('state_transitions.hash as tx_hash', 'state_transitions.index as index', 'state_transitions.type as type', 'state_transitions.data as data', 'state_transitions.block_hash as block_hash')
+            .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
+            .where('state_transitions.owner', '=', identifier)
+
+        const rows = await this.knex.with('with_alias', subquery)
+            .select('tx_hash', 'index', 'data', 'block_hash', 'type', 'rank', 'blocks.timestamp as timestamp', 'blocks.height as block_height')
+            .select(this.knex('with_alias').count('*').as('total_count'))
+            .join('blocks', 'blocks.hash', 'block_hash')
+            .from('with_alias')
+            .whereBetween('rank', [fromRank, toRank])
+            .orderBy('blocks.height', order)
+
+        const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
+
+        return new PaginatedResultSet(rows.map(row => Transaction.fromRow(row)), page, limit, totalCount)
+    }
+
+    getTransfersByIdentity = async (identifier, page, limit, order) => {
+        const fromRank = (page - 1) * limit + 1
+        const toRank = fromRank + limit - 1
+
+        const subquery = this.knex('transfers')
+            .select('transfers.id', 'transfers.amount as amount', 'transfers.sender as sender', 'transfers.recipient as recipient', 'transfers.state_transition_hash as tx_hash')
+            .select(this.knex.raw(`rank() over (order by transfers.id ${order}) rank`))
+            .where('transfers.sender', '=', identifier)
+            .orWhere('transfers.recipient', '=', identifier)
+
+        const rows = await this.knex.with('with_alias', subquery)
+            .select('id', 'amount', 'sender', 'recipient', 'rank')
+            .select(this.knex('with_alias').count('*').as('total_count'))
+            .from('with_alias')
+            .whereBetween('rank', [fromRank, toRank])
+            .orderBy('id', order)
+
+        const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
+
+        return new PaginatedResultSet(rows.map(row => Transfer.fromRow(row)), page, limit, totalCount)
     }
 }

--- a/packages/api/src/models/Block.js
+++ b/packages/api/src/models/Block.js
@@ -5,8 +5,8 @@ module.exports = class Block {
     txs
 
     constructor(header, txs) {
-        this.header = header;
-        this.txs = txs;
+        this.header = header ?? null;
+        this.txs = txs ?? null;
     }
 
     static fromRow({header, txs}) {

--- a/packages/api/src/models/BlockHeader.js
+++ b/packages/api/src/models/BlockHeader.js
@@ -7,12 +7,12 @@ module.exports = class BlockHeader {
     l1_locked_height
 
     constructor(hash, height, timestamp, blockVersion, appVersion, l1LockedHeight) {
-        this.hash = hash;
-        this.height = height;
-        this.timestamp = timestamp;
-        this.blockVersion = blockVersion;
-        this.appVersion = appVersion;
-        this.l1LockedHeight = l1LockedHeight;
+        this.hash = hash ?? null;
+        this.height = height ?? null;
+        this.timestamp = timestamp ?? null;
+        this.blockVersion = blockVersion ?? null;
+        this.appVersion = appVersion ?? null;
+        this.l1LockedHeight = l1LockedHeight ?? null;
     }
 
     static fromRow({hash, height, timestamp, block_version, app_version, l1_locked_height}) {

--- a/packages/api/src/models/DataContract.js
+++ b/packages/api/src/models/DataContract.js
@@ -6,11 +6,11 @@ module.exports = class DataContract {
     timestamp
 
     constructor(identifier, schema, version, txHash, timestamp) {
-        this.identifier = identifier;
-        this.schema = schema;
-        this.version = version;
-        this.txHash = txHash;
-        this.timestamp = timestamp;
+        this.identifier = identifier ?? null;
+        this.schema = schema ?? null;
+        this.version = version ?? null;
+        this.txHash = txHash ?? null;
+        this.timestamp = timestamp ?? null;
     }
 
     static fromRow({identifier, schema, version, tx_hash, timestamp}) {

--- a/packages/api/src/models/Document.js
+++ b/packages/api/src/models/Document.js
@@ -8,14 +8,14 @@ module.exports = class Document {
     timestamp
 
     constructor(identifier, dataContractIdentifier, revision, txHash, deleted, data, timestamp) {
-        this.identifier = identifier;
-        this.dataContractIdentifier = dataContractIdentifier;
-        this.revision = revision;
-        this.deleted = deleted;
-        this.data = data;
-        this.txHash = txHash;
-        this.data = data;
-        this.timestamp = timestamp;
+        this.identifier = identifier ?? null;
+        this.dataContractIdentifier = dataContractIdentifier ?? null;
+        this.revision = revision ?? null;
+        this.deleted = deleted ?? null;
+        this.data = data ?? null;
+        this.txHash = txHash ?? null;
+        this.data = data ?? null;
+        this.timestamp = timestamp ?? null;
     }
 
     static fromRow({identifier, data_contract_identifier, revision, tx_hash, deleted, data, timestamp}) {

--- a/packages/api/src/models/Identity.js
+++ b/packages/api/src/models/Identity.js
@@ -10,15 +10,15 @@ module.exports = class Identity {
     totalDataContracts
 
     constructor(identifier, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash) {
-        this.identifier = identifier;
-        this.revision = revision;
-        this.balance = balance;
-        this.timestamp = timestamp;
-        this.totalTxs = totalTxs;
-        this.totalDocuments = totalDocuments;
-        this.totalDataContracts = totalDataContracts;
-        this.totalTransfers = totalTransfers;
-        this.txHash = txHash
+        this.identifier = identifier ?? null;
+        this.revision = revision ?? null;
+        this.balance = balance ?? null;
+        this.timestamp = timestamp ?? null;
+        this.totalTxs = totalTxs ?? null;
+        this.totalDocuments = totalDocuments ?? null;
+        this.totalDataContracts = totalDataContracts ?? null;
+        this.totalTransfers = totalTransfers ?? null;
+        this.txHash = txHash ?? null;
     }
 
     static fromRow({identifier, revision, balance, timestamp, total_txs, total_data_contracts, total_documents, total_transfers, tx_hash}) {

--- a/packages/api/src/models/Transaction.js
+++ b/packages/api/src/models/Transaction.js
@@ -1,21 +1,22 @@
 module.exports = class Transaction {
     hash
     index
-    block
+    blockHeight
     type
     data
     timestamp
 
-    constructor(hash, index, blockHeight, type, data, timestamp) {
-        this.hash = hash;
-        this.index = index;
-        this.blockHeight = blockHeight;
-        this.type = type;
-        this.data = data;
-        this.timestamp = timestamp;
+    constructor(hash, index, blockHeight, blockHash, type, data, timestamp) {
+        this.hash = hash ?? null;
+        this.index = index ?? null;
+        this.blockHash = blockHash ?? null;
+        this.blockHeight = blockHeight ?? null;
+        this.type = type ?? null;
+        this.data = data ?? null;
+        this.timestamp = timestamp ?? null;
     }
 
-    static fromRow({hash, index, block_height, type, data, timestamp}) {
-        return new Transaction(hash, index, block_height, type, data, timestamp)
+    static fromRow({tx_hash, index, block_height, block_hash, type, data, timestamp}) {
+        return new Transaction(tx_hash, index, block_height, block_hash, type, data, timestamp)
     }
 }

--- a/packages/api/src/models/Transfer.js
+++ b/packages/api/src/models/Transfer.js
@@ -1,0 +1,17 @@
+module.exports = class Transfer {
+    id
+    amount
+    sender
+    recipient
+
+    constructor(id, amount, sender, recipient) {
+        this.id = id ?? null;
+        this.amount = amount ?? null;
+        this.sender = sender ?? null;
+        this.recipient = recipient ?? null;
+    }
+
+    static fromRow({id, amount, sender, recipient}) {
+        return new Transfer(id, amount, sender, recipient)
+    }
+}

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -58,6 +58,26 @@ module.exports = ({fastify, mainController, blocksController, transactionsContro
             handler: identitiesController.getIdentityByIdentifier
         },
         {
+            path: '/identities/:identifier/transactions',
+            method: 'GET',
+            handler: identitiesController.getTransactionsByIdentity
+        },
+        {
+            path: '/identities/:identifier/dataContracts',
+            method: 'GET',
+            handler: identitiesController.getDataContractsByIdentity
+        },
+        {
+            path: '/identities/:identifier/documents',
+            method: 'GET',
+            handler: identitiesController.getDocumentsByIdentity
+        },
+        {
+            path: '/identities/:identifier/transfers',
+            method: 'GET',
+            handler: identitiesController.getTransfersByIdentity
+        },
+        {
             path: '/search',
             method: 'GET',
             handler: mainController.search


### PR DESCRIPTION
# Issue
Add ability to retrieve paginated transfers, transactions, data contracts and documents by the given Identity

# Things done
* Added getTransactionsByIdentity API route (`/identity/$identity_id/transactions`)
* Added getTransfersByIdentity API route (`/identity/$identity_id/transfers`)
* Added getDataContractsByIdentity API route (`/identity/$identity_id/dataContracts`)
* Added getDocumentsByIdentity API route (`/identity/$identity_id/documents`)
