### PR TITLE
Extend home page statistics

### DIFF
--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -2,6 +2,7 @@ const BlocksDAO = require('../dao/BlocksDAO')
 const DataContractsDAO = require('../dao/DataContractsDAO')
 const TransactionsDAO = require('../dao/TransactionsDAO')
 const DocumentsDAO = require('../dao/DocumentsDAO')
+const TenderdashRPC = require("../tenderdashRpc");
 
 class MainController {
     constructor(knex) {
@@ -12,15 +13,27 @@ class MainController {
     }
 
     getStatus = async (request, response) => {
-        const max = await this.blocksDAO.getMaxHeight()
+        let stats
+        let tdStatus
+
+        try {
+            stats = await this.blocksDAO.getStats()
+            tdStatus = await TenderdashRPC.getStatus();
+        } catch (e) {
+
+        }
 
         response.send({
-            network: "dash-testnet-33",
-            appVersion: "1",
-            p2pVersion: "8",
-            blockVersion: "13",
-            blocksCount: max,
-            tenderdashVersion: "0.13.3"
+            appVersion: stats?.appVersion,
+            blockVersion: stats?.blockVersion,
+            blocksCount: stats?.topHeight,
+            blockTimeAverage: stats?.blockTimeAverage,
+            txCount: stats?.txCount,
+            transfersCount: stats?.transfersCount,
+            dataContractsCount: stats?.dataContractsCount,
+            documentsCount: stats?.documentsCount,
+            network: tdStatus?.network,
+            tenderdashVersion: tdStatus?.tenderdashVersion
         });
     }
 

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -14,6 +14,67 @@ module.exports = class BlockDAO {
         return max
     }
 
+    getStats = async () => {
+        // total tx count
+        // total documents count
+        // total data contracts
+        // total transfers
+
+
+        const blocksQuery = this.knex('blocks')
+            .select('height', 'timestamp', 'block_version', 'app_version', 'l1_locked_height')
+            .select(this.knex.raw('LAG(timestamp, 1) over (order by blocks.height asc) prev_timestamp'))
+            .orderBy('height', 'desc')
+            .limit(10)
+
+        const diffQuery = this.knex.with('with_alias', blocksQuery)
+            .select('height', 'timestamp', 'prev_timestamp', 'block_version', 'app_version', 'l1_locked_height')
+            .select(this.knex.raw('timestamp - prev_timestamp as diff'))
+            .from('with_alias')
+            .as('blocks')
+
+        const averageQuery = this.knex(diffQuery)
+            .select('height', 'timestamp', 'prev_timestamp', 'diff', 'block_version', 'app_version', 'l1_locked_height')
+            .select(this.knex.raw('avg(diff) over () average'))
+            .limit(1)
+            .as('asdasd')
+
+        const final = await this.knex(averageQuery)
+            .select('height', 'timestamp', 'prev_timestamp', 'diff', 'block_version', 'app_version', 'l1_locked_height', 'average')
+            .select(this.knex.raw('extract (epoch from average) as average_seconds'))
+            .select(this.knex('state_transitions').count('*').as('tx_count'))
+            .select(this.knex('transfers').count('*').as('transfers_count'))
+            .select(this.knex('data_contracts').count('*').as('data_contracts_count'))
+            .select(this.knex('documents').count('*').as('documents_count'))
+            .limit(1)
+
+        const [result] = final
+
+        const {
+            height,
+            block_version,
+            app_version,
+            l1_locked_height,
+            average_seconds,
+            tx_count,
+            transfers_count,
+            data_contracts_count,
+            documents_count
+        } = result
+
+        return {
+            topHeight: height,
+            blockTimeAverage: average_seconds,
+            blockVersion: block_version,
+            appVersion: app_version,
+            l1LockedHeight: l1_locked_height,
+            txCount: tx_count,
+            transfersCount: transfers_count,
+            dataContractsCount: data_contracts_count,
+            documentsCount: documents_count
+        }
+    }
+
     getBlockByHash = async (blockHash) => {
         const results = await this.knex
             .select('blocks.hash as hash', 'state_transitions.hash as st_hash', 'blocks.height as height', 'blocks.timestamp as timestamp', 'blocks.block_version as block_version', 'blocks.app_version as app_version', 'blocks.l1_locked_height as l1_locked_height')

--- a/packages/frontend/src/routes/home/home.route.js
+++ b/packages/frontend/src/routes/home/home.route.js
@@ -42,10 +42,6 @@ function HomeRoute() {
                     <span>{appVersion}</span>
                 </div>
                 <div className="status_item">
-                    <span>P2P version</span>
-                    <span>{p2pVersion}</span>
-                </div>
-                <div className="status_item">
                     <span>Block version</span>
                     <span>{blockVersion}</span>
                 </div>


### PR DESCRIPTION
# Issue

Extend /status backend API with such information:

* Average Block time
* Transactions count
* Transfers count
* Data Contracts count
* Documents count

# Things done

* Added more stat information from database
* Replaced hardcoded chain with request to TD