### PR TITLE
Add list of identities retrieval API method

### DIFF
--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -17,6 +17,18 @@ class IdentitiesController {
         response.send(identity)
     }
 
+    getIdentities = async (request, response) => {
+        const {page = 1, limit = 10, order = 'asc'} = request.query
+
+        if (order !== 'asc' && order !== 'desc') {
+            return response.status(400).send({message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values`})
+        }
+
+        const identities = await this.identitiesDAO.getIdentities(Number(page), Number(limit), order)
+
+        response.send(identities)
+    }
+
     getTransactionsByIdentity = async (request, response) => {
         const {identifier} = request.params
         const {page = 1, limit = 10, order = 'asc'} = request.query

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -15,12 +15,6 @@ module.exports = class BlockDAO {
     }
 
     getStats = async () => {
-        // total tx count
-        // total documents count
-        // total data contracts
-        // total transfers
-
-
         const blocksQuery = this.knex('blocks')
             .select('height', 'timestamp', 'block_version', 'app_version', 'l1_locked_height')
             .select(this.knex.raw('LAG(timestamp, 1) over (order by blocks.height asc) prev_timestamp'))

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -58,6 +58,11 @@ module.exports = ({fastify, mainController, blocksController, transactionsContro
             handler: identitiesController.getIdentityByIdentifier
         },
         {
+            path: '/identities',
+            method: 'GET',
+            handler: identitiesController.getIdentities
+        },
+        {
             path: '/identities/:identifier/transactions',
             method: 'GET',
             handler: identitiesController.getTransactionsByIdentity


### PR DESCRIPTION
# Issue

Backend must have an route a path to retrieve all identities with pagination

# Things done

* Added an API route method (`/identities`)