### PR TITLE
Add timestamp to transfers

### DIFF
--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -190,11 +190,13 @@ module.exports = class IdentitiesDAO {
             .orWhere('transfers.recipient', '=', identifier)
 
         const rows = await this.knex.with('with_alias', subquery)
-            .select('id', 'amount', 'sender', 'recipient', 'rank')
+            .select('amount', 'sender', 'recipient', 'rank', 'tx_hash', 'blocks.timestamp as timestamp')
             .select(this.knex('with_alias').count('*').as('total_count'))
+            .join('state_transitions', 'state_transitions.hash', 'tx_hash')
+            .join('blocks', 'blocks.hash', 'state_transitions.block_hash')
             .from('with_alias')
             .whereBetween('rank', [fromRank, toRank])
-            .orderBy('id', order)
+            .orderBy('blocks.height', order)
 
         const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0;
 

--- a/packages/api/src/models/Transfer.js
+++ b/packages/api/src/models/Transfer.js
@@ -3,15 +3,17 @@ module.exports = class Transfer {
     amount
     sender
     recipient
+    timestamp
 
-    constructor(id, amount, sender, recipient) {
+    constructor(id, amount, sender, recipient, timestamp) {
         this.id = id ?? null;
         this.amount = amount ?? null;
         this.sender = sender ?? null;
         this.recipient = recipient ?? null;
+        this.timestamp = timestamp ?? null;
     }
 
-    static fromRow({id, amount, sender, recipient}) {
-        return new Transfer(id, amount, sender, recipient)
+    static fromRow({id, amount, sender, recipient, timestamp}) {
+        return new Transfer(id, amount, sender, recipient, timestamp)
     }
 }


### PR DESCRIPTION
# Issue
`identity/$identity_id/transfers` route path missing timestamp field

# Things done

* Added `timestamp` field to the getTransfersByIdentity API method