### PR TITLE
Fix indexer for dash-testnet-35

### DIFF
--- a/packages/indexer/Cargo.lock
+++ b/packages/indexer/Cargo.lock
@@ -513,7 +513,7 @@ dependencies = [
 [[package]]
 name = "dashcore"
 version = "0.30.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=master#d7beaf29203b961d2534e5199e466fcc6e006278"
+source = "git+https://github.com/pshenmic/rust-dashcore?branch=master#43ffb72915ae55574ac44fcdbd47589e0c815b59"
 dependencies = [
  "anyhow",
  "bech32",
@@ -529,12 +529,12 @@ dependencies = [
 [[package]]
 name = "dashcore-private"
 version = "0.1.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=master#d7beaf29203b961d2534e5199e466fcc6e006278"
+source = "git+https://github.com/pshenmic/rust-dashcore?branch=master#43ffb72915ae55574ac44fcdbd47589e0c815b59"
 
 [[package]]
 name = "dashcore_hashes"
 version = "0.12.0"
-source = "git+https://github.com/dashpay/rust-dashcore?branch=master#d7beaf29203b961d2534e5199e466fcc6e006278"
+source = "git+https://github.com/pshenmic/rust-dashcore?branch=master#43ffb72915ae55574ac44fcdbd47589e0c815b59"
 dependencies = [
  "dashcore-private",
  "rs-x11-hash",
@@ -1254,9 +1254,9 @@ dependencies = [
 
 [[package]]
 name = "integer-encoding"
-version = "3.0.4"
+version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
+checksum = "924df4f0e24e2e7f9cdd90babb0b96f93b20f3ecfa949ea9e6613756b8c8e1bf"
 
 [[package]]
 name = "ipnet"

--- a/packages/indexer/Dockerfile
+++ b/packages/indexer/Dockerfile
@@ -3,7 +3,7 @@ FROM rust:1.73-bookworm
 RUN apt-get update && apt-get install -y cmake clang
 
 WORKDIR /
-RUN git clone https://github.com/dashevo/platform
+RUN git clone --depth 1 --branch fix/rs-dpp-dashcore https://github.com/dashevo/platform
 
 WORKDIR /app
 COPY Cargo.lock /app

--- a/packages/indexer/src/entities/transfer.rs
+++ b/packages/indexer/src/entities/transfer.rs
@@ -1,4 +1,5 @@
 use dpp::identifier::Identifier;
+use dpp::identity::state_transition::AssetLockProved;
 use dpp::state_transition::identity_credit_transfer_transition::accessors::IdentityCreditTransferTransitionAccessorsV0;
 use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTransferTransition;
 use dpp::state_transition::identity_credit_withdrawal_transition::accessors::IdentityCreditWithdrawalTransitionAccessorsV0;
@@ -18,12 +19,12 @@ impl From<IdentityTopUpTransition> for Transfer {
     fn from(state_transition: IdentityTopUpTransition) -> Self {
         let identifier = state_transition.identity_id().clone();
         let asset_lock = state_transition.asset_lock_proof().clone();
-        let vout_index = asset_lock.instant_lock_output_index().unwrap();
+        let vout_index = asset_lock.output_index();
+
         let tx_out = asset_lock
             .transaction()
             .unwrap().clone()
-            .output.get(vout_index)
-            .cloned().unwrap();
+            .output.get(vout_index as usize).cloned().unwrap();
         let amount = tx_out.value * 1000;
 
         return Transfer {


### PR DESCRIPTION
# Issue

Indexer module does not compile against Dash Platform 0.25.12, failing with error:

![image](https://github.com/pshenmic/platform-explorer/assets/17009187/31f12c44-d165-46e0-8e15-933fb406006c)

# Things done
* Changed platform base branch to use my rust-dashcore fork so that project compiles succesfully
* Updated Transfer entity to correspond to changes in the rs-dpp