### PR TITLE
Fix text wrap styles

### DIFF
--- a/packages/frontend/src/components/blocks/BlocksListItem.scss
+++ b/packages/frontend/src/components/blocks/BlocksListItem.scss
@@ -23,12 +23,12 @@
     
     &__Timestamp {
         margin-right: 16px;
-        text-wrap: nowrap;
+        white-space: nowrap;
     }
 
     &__Txs {
         margin-left: 12px;
-        text-wrap: nowrap;
+        white-space: nowrap;
     } 
 
 
@@ -59,7 +59,7 @@
 
     @media screen and (max-width: 400px) {
         &__Timestamp {
-            text-wrap: wrap;
+            white-space: wrap;
         }
     }
 

--- a/packages/frontend/src/components/dataContracts/DataContractsListItem.scss
+++ b/packages/frontend/src/components/dataContracts/DataContractsListItem.scss
@@ -16,7 +16,7 @@
     }
 
     &__Timestamp {
-        text-wrap: nowrap;
+        white-space: nowrap;
     }
 
     .DataContractsList--SizeS &,
@@ -34,7 +34,7 @@
         }
 
         &__Timestamp {
-            text-wrap: wrap;
+            white-space: wrap;
         }
     }
 }

--- a/packages/frontend/src/components/documents/DocumentsListItem.scss
+++ b/packages/frontend/src/components/documents/DocumentsListItem.scss
@@ -6,7 +6,7 @@
 
     &__Identifier {
         word-wrap: break-word;
-        text-wrap: wrap;
+        white-space: wrap;
         word-break: break-all;
         font-family: monospace;
         font-size: 12pt;
@@ -18,7 +18,7 @@
     }
 
     &__Timestamp {
-        text-wrap: nowrap;
+        white-space: nowrap;
     }
 
     .DocumentsList--SizeM & {
@@ -35,7 +35,7 @@
         }
 
         &__Timestamp {
-            text-wrap: wrap;
+            white-space: wrap;
         }
     }
 }

--- a/packages/frontend/src/components/identities/IdentitiesListItem.scss
+++ b/packages/frontend/src/components/identities/IdentitiesListItem.scss
@@ -14,7 +14,7 @@
     }    
 
     &__Timestamp {
-        text-wrap: nowrap;
+        white-space: nowrap;
     }
 
     @media screen and (max-width: $breakpoint-sm) {
@@ -26,7 +26,7 @@
         }
 
         &__Timestamp {
-            text-wrap: wrap;
+            white-space: wrap;
         }
     }
 }

--- a/packages/frontend/src/components/transactions/TransactionsListItem.scss
+++ b/packages/frontend/src/components/transactions/TransactionsListItem.scss
@@ -11,7 +11,7 @@
 
     &__Timestamp {
         margin-right: 16px;
-        text-wrap: nowrap;
+        white-space: nowrap;
     }
 
     &__Identifier {
@@ -55,6 +55,12 @@
         &__Identifier {
             order: 3;
             width: 100%;
+        }
+    }
+
+    @media screen and (max-width: $breakpoint-sm) {
+        &__Timestamp {
+            white-space: wrap;
         }
     }
 }


### PR DESCRIPTION
# Issue
The `text-wrap` CSS property is not supported by some browsers.

# Things done
- Replaced `text-wrap` property with `white-space`