### PR TITLE
Fix empty blocks list error

### DIFF
--- a/packages/frontend/src/app/blocks/Blocks.js
+++ b/packages/frontend/src/app/blocks/Blocks.js
@@ -30,7 +30,7 @@ function Blocks() {
     const [pageSize, setPageSize] = useState(paginateConfig.pageSize.default)
     const [currentPage, setCurrentPage] = useState(0)
     const [blockHeightToSearch, setBlockHeightToSearch] = useState(0)
-    const pageCount = Math.ceil(total / pageSize)
+    const pageCount = Math.ceil(total / pageSize) ? Math.ceil(total / pageSize) : 1
     
     const fetchData = () => {
         setLoading(true)


### PR DESCRIPTION
# Issue
An error appears on the blocks page if the list of blocks received from the API is empty.

# Things done
Bug fix.