### PR TITLE
Create transactions page

### DIFF
--- a/packages/frontend/src/app/blocks/Blocks.scss
+++ b/packages/frontend/src/app/blocks/Blocks.scss
@@ -1,12 +1,4 @@
 .Blocks {
-    .ListNavigation {
-        display: flex;
-        justify-content: space-between;
-        align-items: flex-end;
-        margin-top: 10px;
-        flex-wrap: wrap;
-    }
-    
     .pagination {
         margin-top: 0;
         margin-bottom: 0;

--- a/packages/frontend/src/app/dataContract/[identifier]/DataContract.js
+++ b/packages/frontend/src/app/dataContract/[identifier]/DataContract.js
@@ -146,14 +146,16 @@ function DataContract({identifier}) {
                                         columnsCount={2}
                                     />
                                 </Box>
-
-                                {pageCount > 1 && 
-                                    <Pagination
-                                        onPageChange={handlePageClick}
-                                        pageCount={pageCount}
-                                        forcePage={currentPage}
-                                    />
-                                }
+                                
+                                <div className={'ListNavigation'}>
+                                    {pageCount > 1 && 
+                                        <Pagination
+                                            onPageChange={handlePageClick}
+                                            pageCount={pageCount}
+                                            forcePage={currentPage}
+                                        />
+                                    }
+                                </div>
                             </Box>
                         </TabPanel>
 

--- a/packages/frontend/src/app/transactions/Transactions.js
+++ b/packages/frontend/src/app/transactions/Transactions.js
@@ -1,0 +1,76 @@
+'use client'
+
+import {useEffect, useState} from 'react'
+import * as Api from '../../util/Api'
+import TransactionsList from '../../components/transactions/TransactionsList'
+import Pagination from '../../components/pagination'
+
+import { 
+    Container,
+    Heading, 
+} from '@chakra-ui/react'
+
+
+function Transactions() {
+    const [loading, setLoading] = useState(true)
+    const [transactions, setTransactions] = useState([])
+    const [total, setTotal] = useState(1)
+    const pageSize = 25
+    const [currentPage, setCurrentPage] = useState(0)
+    const pageCount = Math.ceil(total / pageSize)
+
+    const fetchData = () => {
+        setLoading(true)
+
+        Api.getTransactions(1, pageSize, 'desc')
+            .then((res) => {
+                setTransactions(res.resultSet)
+                setTotal(res.pagination.total)
+            })
+            .catch(console.log)
+            .finally(() => setLoading(false))
+    }
+
+    useEffect(fetchData, [])
+
+    const handlePageClick = ({selected}) => {
+        Api.getTransactions(selected+1, pageSize, 'desc')
+            .then((res) => {
+                setCurrentPage(selected)
+                setTransactions(res.resultSet)
+            })
+    }
+
+    return (
+        <Container 
+            maxW='container.lg' 
+            mt={8}
+            className={'IdentitiesPage'}
+        >
+            <Container 
+                maxW='container.lg' 
+                borderWidth='1px' borderRadius='lg'
+                className={'InfoBlock'}
+            >
+                <Heading className={'InfoBlock__Title'} as='h1' size='sm' >Transactions</Heading>
+
+                {!loading && <>
+                    <TransactionsList transactions={transactions}/>
+
+                    {pageCount > 1 && 
+                        <div className={'ListNavigation'}>
+                            <Pagination 
+                                onPageChange={handlePageClick}
+                                pageCount={pageCount}
+                                forcePage={currentPage} 
+                            />
+                        </div>
+                    }
+                </>}
+
+            </Container>
+        </Container>
+    )
+}
+
+export default Transactions

--- a/packages/frontend/src/app/transactions/Transactions.js
+++ b/packages/frontend/src/app/transactions/Transactions.js
@@ -4,18 +4,28 @@ import {useEffect, useState} from 'react'
 import * as Api from '../../util/Api'
 import TransactionsList from '../../components/transactions/TransactionsList'
 import Pagination from '../../components/pagination'
+import PageSizeSelector from '../../components/pageSizeSelector/PageSizeSelector'
+import './Transactions.scss'
 
 import { 
     Container,
     Heading, 
+    Box
 } from '@chakra-ui/react'
 
+const paginateConfig = {
+    pageSize: {
+        default: 25,
+        values: [10, 25, 50, 75, 100],
+    },
+    defaultPage: 1
+}
 
 function Transactions() {
     const [loading, setLoading] = useState(true)
     const [transactions, setTransactions] = useState([])
     const [total, setTotal] = useState(1)
-    const pageSize = 25
+    const [pageSize, setPageSize] = useState(paginateConfig.pageSize.default)
     const [currentPage, setCurrentPage] = useState(0)
     const pageCount = Math.ceil(total / pageSize)
 
@@ -33,6 +43,11 @@ function Transactions() {
 
     useEffect(fetchData, [])
 
+    useEffect(() => {
+        setCurrentPage(0)
+        handlePageClick({selected: 0})
+    }, [pageSize])
+
     const handlePageClick = ({selected}) => {
         Api.getTransactions(selected+1, pageSize, 'desc')
             .then((res) => {
@@ -45,7 +60,7 @@ function Transactions() {
         <Container 
             maxW='container.lg' 
             mt={8}
-            className={'IdentitiesPage'}
+            className={'Transactions'}
         >
             <Container 
                 maxW='container.lg' 
@@ -56,18 +71,26 @@ function Transactions() {
 
                 {!loading && <>
                     <TransactionsList transactions={transactions}/>
+                    
+                    <div className={'ListNavigation'}>
+                        <Box display={['none',,'block']} width={'100px'}/>
 
-                    {pageCount > 1 && 
-                        <div className={'ListNavigation'}>
+                        {pageCount > 1 && 
                             <Pagination 
                                 onPageChange={handlePageClick}
                                 pageCount={pageCount}
                                 forcePage={currentPage} 
                             />
-                        </div>
-                    }
-                </>}
+                        }
 
+                        <PageSizeSelector
+                            PageSizeSelectHandler={(e) => setPageSize(Number(e.target.value))}
+                            defaultValue={paginateConfig.pageSize.default}
+                            items={paginateConfig.pageSize.values}
+                        />
+
+                    </div>
+                </>}
             </Container>
         </Container>
     )

--- a/packages/frontend/src/app/transactions/Transactions.scss
+++ b/packages/frontend/src/app/transactions/Transactions.scss
@@ -1,0 +1,21 @@
+@import '../../styles/variables.scss';
+
+.Transactions {
+    @media screen and (max-width: $breakpoint-md) {
+        .ListNavigation {
+            flex-direction: column;
+            align-items: center;
+        }
+
+        .PageSizeSelector {
+            margin-top: 10px;
+            margin-left: auto;
+        }
+    }
+
+    @media screen and (max-width: $breakpoint-sm) {
+        .PageSizeSelector {
+            margin: 10px auto 0;
+        }        
+    }
+}

--- a/packages/frontend/src/app/transactions/page.js
+++ b/packages/frontend/src/app/transactions/page.js
@@ -1,0 +1,14 @@
+import Transactions from "./Transactions";
+
+export const metadata = {
+    title: 'Transactions — Dash Platform Explorer',
+    description: 'Identities on Dash Platform. The Identifier, Date of Creation',
+    keywords: ['Dash', 'platform', 'explorer', 'blockchain', 'Identities'],
+    applicationName: 'Dash Platform Explorer'
+}
+
+function TransactionsRoute() {
+    return <Transactions/>   
+}
+
+export default TransactionsRoute;

--- a/packages/frontend/src/components/navbar/Navbar.js
+++ b/packages/frontend/src/components/navbar/Navbar.js
@@ -18,6 +18,7 @@ import './NavbarMobileMenu.scss'
 const links = [
     {title:'Home', href:'/'},
     {title:'Blocks', href:'/blocks'},
+    {title:'Transactions', href:'/transactions'},
     {title:'Data Contracts', href:'/dataContracts'},
     {title:'Identities', href:'/identities'},
     {title:'API', href:'/api'},

--- a/packages/frontend/src/components/pageSizeSelector/PageSizeSelector.scss
+++ b/packages/frontend/src/components/pageSizeSelector/PageSizeSelector.scss
@@ -1,10 +1,13 @@
 .PageSizeSelector {
+    text-align: right;
+    
     &__Title {
         margin-bottom: 8px;
     }
 
     select {
-        width: 80px;
+        width: 100px;
+        max-width: 100%;
         height: 29px;
         box-sizing: border-box;
         border: 1px solid var(--chakra-colors-whiteAlpha-200);

--- a/packages/frontend/src/components/pagination/pagination.scss
+++ b/packages/frontend/src/components/pagination/pagination.scss
@@ -3,6 +3,7 @@
     justify-content: center;
     list-style: none;
     padding: 0;
+    margin: 0;
 }
   
 .page-item {

--- a/packages/frontend/src/styles/theme.scss
+++ b/packages/frontend/src/styles/theme.scss
@@ -45,7 +45,11 @@
 }
 
 .ListNavigation {
-    margin-top: 10px;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+    flex-wrap: wrap;
+    margin-top: 16px;
 }
 
 .disabled {


### PR DESCRIPTION
# Issue
Currently, the list of transactions is displayed in limited quantities on the main page. It is necessary to provide the ability to view complete information on transactions with a filter by type. https://github.com/pshenmic/platform-explorer/issues/112
 
# Things done
Created own page for transactions.