### PR TITLE
[Perf] Remove postgres from prod instance

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,14 +128,12 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           script: |
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:api
+            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:indexer
             docker stop $(docker ps -f name=platform-explorer-api -q)
             docker stop $(docker ps -f name=platform-explorer-indexer -q)
             docker rm platform-explorer-api platform-explorer-indexer
-            docker stop postgres && docker rm postgres
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:api
-            docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:indexer
-            docker run -d --name postgres -e POSTGRES_PASSWORD=indexer -e POSTGRES_USER=indexer -e POSTGRES_DB=indexer -p 5432:5432 postgres
-            sleep 20
+            docker run --rm --env-file api.env ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:api --command npm run db:drop
             docker run --rm --env-file api.env ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:indexer refinery migrate -e DATABASE_URL -p /app/migrations
             docker run -d -p 3005:3005 --restart always --env-file api.env --name platform-explorer-api ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:api
             sleep 3

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -7,7 +7,8 @@
     "start": "node index.js",
     "test:unit": "node --test test/unit/*.spec.js",
     "test:integration": "node --test --test-concurrency=1 test/integration/*.spec.js",
-    "db:migrate": "node ./test/utils/migrate.js ../indexer/migrations"
+    "db:migrate": "node ./test/utils/migrate.js ../indexer/migrations",
+    "db:drop": "node ./test/utils/drop.js"
   },
   "dependencies": {
     "@fastify/cors": "^8.3.0",

--- a/packages/api/test/utils/drop.js
+++ b/packages/api/test/utils/drop.js
@@ -1,0 +1,24 @@
+const pg = require('pg')
+const fs = require('fs')
+const path = require('path')
+const { getKnex } = require('../../src/utils')
+
+console.log(process.argv)
+console.log(process.execArgv)
+
+postgres://pshenmic:<user password>@:6432/pshenmic_main
+
+const client = getKnex()
+
+client
+  .connect()
+  .then(async () => {
+    const tables = ['transfers', 'documents', 'identities', 'data_contracts', 'state_transitions', 'blocks', 'refinery_schema_history']
+
+    const sql = tables.reduce((acc, table) => acc + `DROP TABLE IF EXISTS ${table};`, '')
+
+    console.log(sql)
+    await client.query(sql)
+  })
+  .then(() => console.log('Done'))
+  .finally(() => client.end())

--- a/packages/api/test/utils/drop.js
+++ b/packages/api/test/utils/drop.js
@@ -1,12 +1,4 @@
-const pg = require('pg')
-const fs = require('fs')
-const path = require('path')
 const { getKnex } = require('../../src/utils')
-
-console.log(process.argv)
-console.log(process.execArgv)
-
-postgres://pshenmic:<user password>@:6432/pshenmic_main
 
 const client = getKnex()
 


### PR DESCRIPTION
# Issue

Database load recently increased in the testnet which leads to lags and timeout errors in the production environment. It seems that instance is cheap and CPU resources is not getting properly balanced between different applications running or some SQL queries getting laggy after some real data. I will be investigating, applying this as a short fix.


# Things done

* Added npm script to drop database
* Removed self hosted postgres container from the production environment (move to external service)
* Updated github actions