### PR TITLE
Add transaction history API

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -470,7 +470,7 @@ GET /transactions/history?timespan=1h
         data: {
           txs: 5
         }
-    }
+    }, ...
 ]
 ```
 Response codes:

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -469,12 +469,16 @@ GET /transactions/history?timespan=1h
         timestamp: "2024-04-22T08:45:20.911Z",
         data: {
           txs: 5
+          blockHeight: 2,
+          blockHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
         }
     },
     {
         timestamp: "2024-04-22T08:50:20.911Z",
         data: {
-          txs: 13
+          txs: 13,
+          blockHeight: 7,
+          blockHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
         }
     }, ...
 ]

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -460,3 +460,22 @@ Response codes:
 200: OK
 500: Internal Server Error
 ```
+### Transactions history
+Return a series data for the amount of transactions chart with variable timespan (1h, 24h, 3d, 1w)
+```
+GET /transactions/history?timespan=1h
+[
+    {
+        timestamp: "2024-04-22T08:45:20.911Z",
+        data: {
+          txs: 5
+        }
+    }
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check timespan value
+500: Internal Server Error
+```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -470,6 +470,12 @@ GET /transactions/history?timespan=1h
         data: {
           txs: 5
         }
+    },
+    {
+        timestamp: "2024-04-22T08:50:20.911Z",
+        data: {
+          txs: 13
+        }
     }, ...
 ]
 ```

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -36,7 +36,7 @@ class TransactionsController {
 
     const possibleValues = ['1h', '24h', '3d', '1w']
 
-    if (['1h', '24h', '3d', '1w'].indexOf(timespan) === -1) {
+    if (possibleValues.indexOf(timespan) === -1) {
       return response.status(400)
         .send({ message: `invalid timespan value ${timespan}. only one of '${possibleValues}' is valid` })
     }

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -31,6 +31,21 @@ class TransactionsController {
     response.send(transactions)
   }
 
+  getTransactionHistory = async (request, response) => {
+    const { timespan = '1h' } = request.query
+
+    const possibleValues = ['1h', '24h', '3d', '1w']
+
+    if (['1h', '24h', '3d', '1w'].indexOf(timespan) === -1) {
+      return response.status(400)
+        .send({ message: `invalid timespan value ${timespan}. only one of '${possibleValues}' is valid` })
+    }
+
+    const timeSeries = await this.transactionsDAO.getHistorySeries(timespan)
+
+    response.send(timeSeries)
+  }
+
   decode = async (request, reply) => {
     const { base64 } = request.body
 

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -1,5 +1,6 @@
 const Transaction = require('../models/Transaction')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
+const SeriesData = require('../models/SeriesData')
 
 module.exports = class TransactionsDAO {
   constructor (knex) {
@@ -28,7 +29,7 @@ module.exports = class TransactionsDAO {
     const subquery = this.knex('state_transitions')
       .select(this.knex('state_transitions').count('hash').as('total_count'), 'state_transitions.hash as tx_hash',
         'state_transitions.data as data', 'state_transitions.type as type', 'state_transitions.index as index',
-        'state_transitions.block_hash as block_hash')
+        'state_transitions.block_hash as block_hash', 'state_transitions.id as id')
       .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
       .as('state_transitions')
 
@@ -37,12 +38,48 @@ module.exports = class TransactionsDAO {
         'blocks.height as block_height', 'blocks.timestamp as timestamp')
       .leftJoin('blocks', 'blocks.hash', 'block_hash')
       .whereBetween('rank', [fromRank, toRank])
-      .orderBy('block_height', order)
-
+      .orderBy('state_transitions.id', order)
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 
     const resultSet = rows.map((row) => Transaction.fromRow(row))
 
     return new PaginatedResultSet(resultSet, page, limit, totalCount)
+  }
+
+  getHistorySeries = async (timespan) => {
+    const interval = {
+      '1h': {offset: '1 hour', step: '5 minute'},
+      '24h': {offset: '24 hour', step: '2 hour'},
+      '3d': {offset: '3 day', step: '6 hour'},
+      '1w': {offset: '1 week', step: '14 hour'},
+    }[timespan]
+
+    const ranges = this.knex
+      .from(this.knex.raw(`generate_series(now() - interval \'${interval.offset}\', now(), interval  '${interval.step}') date_to`))
+      .select('date_to', this.knex.raw('LAG(date_to, 1) over (order by date_to asc) date_from'))
+
+    const rows = await this.knex.with('ranges', ranges)
+      .select(this.knex.raw(`COALESCE(date_from, now() - interval \'${interval.offset}\') date_from`), 'date_to')
+      .select(
+        this.knex('state_transitions')
+          .leftJoin('blocks', 'state_transitions.block_hash', 'blocks.hash')
+          .whereRaw('blocks.timestamp > date_from and blocks.timestamp <= date_to')
+          .count('*')
+          .as('tx_count')
+      )
+      .select(
+        this.knex('blocks')
+          .whereRaw('blocks.timestamp > date_from and blocks.timestamp <= date_to')
+          .select('hash')
+          .orderBy('blocks.height')
+          .limit(1)
+          .as('block_hash')
+      )
+      .from('ranges')
+
+    return rows
+      .slice(1)
+      .map(row => ({ timestamp: row.date_from, data: { txs: parseInt(row.tx_count) } }))
+      .map(({ timestamp, data }) => new SeriesData(timestamp, data))
   }
 }

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -75,11 +75,26 @@ module.exports = class TransactionsDAO {
           .limit(1)
           .as('block_hash')
       )
+      .select(
+        this.knex('blocks')
+          .whereRaw('blocks.timestamp > date_from and blocks.timestamp <= date_to')
+          .select('height')
+          .orderBy('height')
+          .limit(1)
+          .as('block_height')
+      )
       .from('ranges')
 
     return rows
       .slice(1)
-      .map(row => ({ timestamp: row.date_from, data: { txs: parseInt(row.tx_count) } }))
+      .map(row => ({
+        timestamp: row.date_from,
+        data: {
+          txs: parseInt(row.tx_count),
+          blockHeight: row.block_height,
+          blockHash: row.block_hash
+        }
+      }))
       .map(({ timestamp, data }) => new SeriesData(timestamp, data))
   }
 }

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -48,18 +48,18 @@ module.exports = class TransactionsDAO {
 
   getHistorySeries = async (timespan) => {
     const interval = {
-      '1h': {offset: '1 hour', step: '5 minute'},
-      '24h': {offset: '24 hour', step: '2 hour'},
-      '3d': {offset: '3 day', step: '6 hour'},
-      '1w': {offset: '1 week', step: '14 hour'},
+      '1h': { offset: '1 hour', step: '5 minute' },
+      '24h': { offset: '24 hour', step: '2 hour' },
+      '3d': { offset: '3 day', step: '6 hour' },
+      '1w': { offset: '1 week', step: '14 hour' }
     }[timespan]
 
     const ranges = this.knex
-      .from(this.knex.raw(`generate_series(now() - interval \'${interval.offset}\', now(), interval  '${interval.step}') date_to`))
+      .from(this.knex.raw(`generate_series(now() - interval '${interval.offset}', now(), interval  '${interval.step}') date_to`))
       .select('date_to', this.knex.raw('LAG(date_to, 1) over (order by date_to asc) date_from'))
 
     const rows = await this.knex.with('ranges', ranges)
-      .select(this.knex.raw(`COALESCE(date_from, now() - interval \'${interval.offset}\') date_from`), 'date_to')
+      .select(this.knex.raw(`COALESCE(date_from, now() - interval '${interval.offset}') date_from`), 'date_to')
       .select(
         this.knex('state_transitions')
           .leftJoin('blocks', 'state_transitions.block_hash', 'blocks.hash')

--- a/packages/api/src/models/SeriesData.js
+++ b/packages/api/src/models/SeriesData.js
@@ -6,5 +6,4 @@ module.exports = class SeriesData {
     this.timestamp = timestamp ?? null
     this.data = data ?? null
   }
-
 }

--- a/packages/api/src/models/SeriesData.js
+++ b/packages/api/src/models/SeriesData.js
@@ -1,0 +1,10 @@
+module.exports = class SeriesData {
+  timestamp
+  data
+
+  constructor (timestamp, data) {
+    this.timestamp = timestamp ?? null
+    this.data = data ?? null
+  }
+
+}

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -91,6 +91,11 @@ module.exports = ({ fastify, mainController, blocksController, transactionsContr
       path: '/transaction/decode',
       method: 'POST',
       handler: transactionsController.decode
+    },
+    {
+      path: '/transactions/history',
+      method: 'GET',
+      handler: transactionsController.getTransactionHistory
     }
   ]
 

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -183,7 +183,7 @@ describe('Transaction routes', () => {
       assert.equal(body.pagination.limit, 3)
 
       const expectedTransactions = transactions
-        .sort((a, b) => a.block.height - b.block.height)
+        .sort((a, b) => a.transaction.id - b.transaction.id)
         .slice(6, 9)
         .map(transaction => ({
           blockHash: transaction.block.hash,

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -37,7 +37,7 @@ describe('Transaction routes', () => {
       })
 
       const transaction = await fixtures.transaction(knex, {
-        block_hash: block.hash, data: '{}', type: StateTransitionEnum.DATA_CONTRACT_CREATE, owner: identity.identifier,
+        block_hash: block.hash, data: '{}', type: StateTransitionEnum.DATA_CONTRACT_CREATE, owner: identity.identifier
       })
 
       transactions.push({ transaction, block })

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -16,28 +16,49 @@ describe('Transaction routes', () => {
   let transactions
 
   before(async () => {
+    const startDate = new Date(new Date() - 1000 * 60 * 60)
+
     app = await server.start()
     client = supertest(app.server)
     knex = getKnex()
 
     await fixtures.cleanup(knex)
 
-    block = await fixtures.block(knex, { height: 1 })
+    block = await fixtures.block(knex, {
+      height: 1, timestamp: startDate
+    })
     identity = await fixtures.identity(knex, { block_hash: block.hash })
 
     transactions = [{ transaction: identity.transaction, block }]
 
     for (let i = 1; i < 30; i++) {
-      const block = await fixtures.block(knex, { height: i + 1 })
+      const block = await fixtures.block(knex, {
+        height: i + 1, timestamp: new Date(startDate.getTime() + i * 1000 * 60)
+      })
 
       const transaction = await fixtures.transaction(knex, {
-        block_hash: block.hash,
-        data: '{}',
-        type: StateTransitionEnum.DATA_CONTRACT_CREATE,
-        owner: identity.identifier
+        block_hash: block.hash, data: '{}', type: StateTransitionEnum.DATA_CONTRACT_CREATE, owner: identity.identifier,
       })
 
       transactions.push({ transaction, block })
+    }
+
+    for (let i = 30; i < 60; i++) {
+      const block = await fixtures.block(knex, {
+        height: i + 1, timestamp: new Date(startDate.getTime() + i * 1000 * 60)
+      })
+
+      for (let j = 0; j < Math.ceil(Math.random() * 30); j++) {
+        const transaction = await fixtures.transaction(knex, {
+          block_hash: block.hash,
+          data: '{}',
+          type: StateTransitionEnum.DATA_CONTRACT_CREATE,
+          owner: identity.identifier,
+          index: j
+        })
+
+        transactions.push({ transaction, block })
+      }
     }
   })
 
@@ -80,7 +101,7 @@ describe('Transaction routes', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       assert.equal(body.resultSet.length, 10)
-      assert.equal(body.pagination.total, 30)
+      assert.equal(body.pagination.total, transactions.length)
       assert.equal(body.pagination.page, 1)
       assert.equal(body.pagination.limit, 10)
 
@@ -105,12 +126,12 @@ describe('Transaction routes', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       assert.equal(body.resultSet.length, 10)
-      assert.equal(body.pagination.total, 30)
+      assert.equal(body.pagination.total, transactions.length)
       assert.equal(body.pagination.page, 1)
       assert.equal(body.pagination.limit, 10)
 
       const expectedTransactions = transactions
-        .sort((a, b) => b.block.height - a.block.height)
+        .sort((a, b) => b.transaction.id - a.transaction.id)
         .slice(0, 10)
         .map(transaction => ({
           blockHash: transaction.block.hash,
@@ -131,12 +152,12 @@ describe('Transaction routes', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       assert.equal(body.resultSet.length, 3)
-      assert.equal(body.pagination.total, 30)
+      assert.equal(body.pagination.total, transactions.length)
       assert.equal(body.pagination.page, 3)
       assert.equal(body.pagination.limit, 3)
 
       const expectedTransactions = transactions
-        .sort((a, b) => b.block.height - a.block.height)
+        .sort((a, b) => b.transaction.id - a.transaction.id)
         .slice(6, 9)
         .map(transaction => ({
           blockHash: transaction.block.hash,
@@ -157,7 +178,7 @@ describe('Transaction routes', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       assert.equal(body.resultSet.length, 3)
-      assert.equal(body.pagination.total, 30)
+      assert.equal(body.pagination.total, transactions.length)
       assert.equal(body.pagination.page, 3)
       assert.equal(body.pagination.limit, 3)
 
@@ -175,6 +196,64 @@ describe('Transaction routes', () => {
         }))
 
       assert.deepEqual(expectedTransactions, body.resultSet)
+    })
+  })
+
+  describe('getHistorySeries()', async () => {
+    it('should return default series set', async () => {
+      const { body } = await client.get('/transactions/history')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 12)
+
+      // todo add assert expected data series
+      // didn't find a correct to do this yet
+      // assert.deepEqual(expectedSeriesData, body)
+    })
+    it('should return default series set timespan 1h', async () => {
+      const { body } = await client.get('/transactions/history?timespan=1h')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 12)
+
+      // todo add assert expected data series
+      // didn't find a correct to do this yet
+      // assert.deepEqual(expectedSeriesData, body)
+    })
+    it('should return default series set timespan 24h', async () => {
+      const { body } = await client.get('/transactions/history?timespan=24h')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 12)
+
+      // todo add assert expected data series
+      // didn't find a correct to do this yet
+      // assert.deepEqual(expectedSeriesData, body)
+    })
+    it('should return default series set timespan 3d', async () => {
+      const { body } = await client.get('/transactions/history?timespan=3d')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 12)
+
+      // todo add assert expected data series
+      // didn't find a correct to do this yet
+      // assert.deepEqual(expectedSeriesData, body)
+    })
+    it('should return default series set timespan 1w', async () => {
+      const { body } = await client.get('/transactions/history?timespan=1w')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 12)
+
+      // todo add assert expected data series
+      // didn't find a correct to do this yet
+      // assert.deepEqual(expectedSeriesData, body)
     })
   })
 })

--- a/packages/api/test/utils/fixtures.js
+++ b/packages/api/test/utils/fixtures.js
@@ -45,9 +45,9 @@ const fixtures = {
       index: index ?? 0
     }
 
-    await knex('state_transitions').insert(row)
+    const [result] = await knex('state_transitions').insert(row).returning('id')
 
-    return row
+    return { ...row, id: result.id }
   },
   identity: async (knex, { identifier, block_hash, state_transition_hash, revision, owner, is_system } = {}) => {
     if (!identifier) {

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -440,7 +440,7 @@ GET /transactions/history?timespan=1h
         data: {
           txs: 5
         }
-    }
+    }, ...
 ]
 ```
 Response codes:

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -429,3 +429,23 @@ Response codes:
 200: OK
 500: Internal Server Error
 ```
+
+### Transactions history
+Return a series data for the amount of transactions chart with variable timespan (1h, 24h, 3d, 1w)
+```
+GET /transactions/history?timespan=1h
+[
+    {
+        timestamp: "2024-04-22T08:45:20.911Z",
+        data: {
+          txs: 5
+        }
+    }
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check timespan value
+500: Internal Server Error
+```

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -429,7 +429,6 @@ Response codes:
 200: OK
 500: Internal Server Error
 ```
-
 ### Transactions history
 Return a series data for the amount of transactions chart with variable timespan (1h, 24h, 3d, 1w)
 ```
@@ -439,6 +438,12 @@ GET /transactions/history?timespan=1h
         timestamp: "2024-04-22T08:45:20.911Z",
         data: {
           txs: 5
+        }
+    },
+    {
+        timestamp: "2024-04-22T08:50:20.911Z",
+        data: {
+          txs: 13
         }
     }, ...
 ]

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -438,12 +438,16 @@ GET /transactions/history?timespan=1h
         timestamp: "2024-04-22T08:45:20.911Z",
         data: {
           txs: 5
+          blockHeight: 2,
+          blockHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
         }
     },
     {
         timestamp: "2024-04-22T08:50:20.911Z",
         data: {
-          txs: 13
+          txs: 13,
+          blockHeight: 7,
+          blockHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
         }
     }, ...
 ]

--- a/packages/indexer/migrations/V27__make_blocks_timestamps_zoned.sql
+++ b/packages/indexer/migrations/V27__make_blocks_timestamps_zoned.sql
@@ -1,0 +1,5 @@
+ALTER TABLE blocks
+ALTER COLUMN timestamp TYPE TIMESTAMP with time zone;
+
+ALTER TABLE blocks
+ALTER COLUMN created_at TYPE TIMESTAMP with time zone;


### PR DESCRIPTION
# Issue

https://github.com/pshenmic/platform-explorer/pull/107 introduces a transaction history chart, hence we need an backend API that will return points representing historical data.

# Things done
* Add /transaction/history route path (1h, 24h, 3d, 1w timespans)
* Alter block timestamps columns to timestamp with timezone
* Add an integration tests for implemented path (no asserts)