### PR TITLE
Add documents count in the data contract lists

### DIFF
--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -56,6 +56,7 @@ module.exports = class DataContractsDAO {
       .select('data_contracts.identifier as identifier', 'data_contracts.owner as owner',
         'data_contracts.schema as schema', 'data_contracts.is_system as is_system',
         'data_contracts.version as version', 'state_transitions.hash as tx_hash', 'blocks.timestamp as timestamp')
+      .select(this.knex('documents').count('*').whereRaw('documents.data_contract_id = id').as('documents_count'))
       .leftJoin('state_transitions', 'data_contracts.state_transition_hash', 'state_transitions.hash')
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
       .where('data_contracts.identifier', identifier)

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -152,7 +152,8 @@ module.exports = class IdentitiesDAO {
       .as('data_contracts')
 
     const rows = await this.knex(filteredDataContracts)
-      .select('identifier', 'data_contract_owner', 'version', 'tx_hash', 'rank', 'total_count', 'row_number', 'is_system', 'blocks.timestamp as timestamp')
+      .select('data_contracts.id as id', 'identifier', 'data_contract_owner', 'version', 'tx_hash', 'rank', 'total_count', 'row_number', 'is_system', 'blocks.timestamp as timestamp')
+      .select(this.knex('documents').count('*').whereRaw('documents.data_contract_id = id').as('documents_count'))
       .leftJoin('state_transitions', 'state_transitions.hash', 'tx_hash')
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
       .whereBetween('row_number', [fromRank, toRank])

--- a/packages/api/src/models/DataContract.js
+++ b/packages/api/src/models/DataContract.js
@@ -6,8 +6,9 @@ module.exports = class DataContract {
   txHash
   timestamp
   isSystem
+  documentsCount
 
-  constructor (identifier, owner, schema, version, txHash, timestamp, isSystem) {
+  constructor (identifier, owner, schema, version, txHash, timestamp, isSystem, documentsCount) {
     this.identifier = identifier ? identifier.trim() : null
     this.owner = owner ? owner.trim() : null
     this.schema = schema ?? null
@@ -15,10 +16,11 @@ module.exports = class DataContract {
     this.txHash = txHash ?? null
     this.timestamp = timestamp ?? null
     this.isSystem = isSystem ?? null
+    this.documentsCount = documentsCount ?? null
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow ({ identifier, owner, schema, version, tx_hash, timestamp, is_system }) {
-    return new DataContract(identifier, owner, schema ? JSON.stringify(schema) : null, version, tx_hash, timestamp, is_system)
+  static fromRow ({ identifier, owner, schema, version, tx_hash, timestamp, is_system, documents_count }) {
+    return new DataContract(identifier, owner, schema ? JSON.stringify(schema) : null, version, tx_hash, timestamp, is_system, Number(documents_count))
   }
 }

--- a/packages/api/test/integration/data.contracts.spec.js
+++ b/packages/api/test/integration/data.contracts.spec.js
@@ -101,7 +101,8 @@ describe('DataContracts routes', () => {
           version: 0,
           txHash: dataContract.is_system ? null : transaction.hash,
           timestamp: dataContract.is_system ? null : block.timestamp.toISOString(),
-          isSystem: dataContract.is_system
+          isSystem: dataContract.is_system,
+          documentsCount: 0
         }))
 
       assert.equal(body.resultSet.length, 10)
@@ -127,7 +128,8 @@ describe('DataContracts routes', () => {
           version: 0,
           txHash: dataContract.is_system ? null : transaction.hash,
           timestamp: dataContract.is_system ? null : block.timestamp.toISOString(),
-          isSystem: dataContract.is_system
+          isSystem: dataContract.is_system,
+          documentsCount: 0
         }))
 
       assert.equal(body.resultSet.length, 10)
@@ -153,7 +155,8 @@ describe('DataContracts routes', () => {
           version: 0,
           txHash: dataContract.is_system ? null : transaction.hash,
           timestamp: dataContract.is_system ? null : block.timestamp.toISOString(),
-          isSystem: dataContract.is_system
+          isSystem: dataContract.is_system,
+          documentsCount: 0
         }))
 
       assert.equal(body.resultSet.length, 6)
@@ -179,7 +182,8 @@ describe('DataContracts routes', () => {
           version: 0,
           txHash: dataContract.is_system ? null : transaction.hash,
           timestamp: dataContract.is_system ? null : block.timestamp.toISOString(),
-          isSystem: dataContract.is_system
+          isSystem: dataContract.is_system,
+          documentsCount: 0
         }))
 
       assert.equal(body.resultSet.length, 6)
@@ -207,7 +211,8 @@ describe('DataContracts routes', () => {
         version: 0,
         txHash: dataContract.is_system ? null : transaction.hash,
         timestamp: dataContract.is_system ? null : block.timestamp.toISOString(),
-        isSystem: dataContract.is_system
+        isSystem: dataContract.is_system,
+        documentsCount: 0
       }))
 
     assert.equal(body.resultSet.length, 10)
@@ -233,7 +238,8 @@ describe('DataContracts routes', () => {
         version: 0,
         txHash: null,
         timestamp: null,
-        isSystem: true
+        isSystem: true,
+        documentsCount: 0
       }
 
       assert.deepEqual(body, expectedDataContract)

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -358,7 +358,8 @@ describe('Identities routes', () => {
         schema: null,
         txHash: _dataContract.transaction.hash,
         timestamp: _dataContract.block.timestamp.toISOString(),
-        isSystem: false
+        isSystem: false,
+        documentsCount: 0
       }))
       assert.deepEqual(body.resultSet, expectedDataContracts)
     })
@@ -401,7 +402,8 @@ describe('Identities routes', () => {
           schema: null,
           txHash: _dataContract.transaction.hash,
           timestamp: _dataContract.block.timestamp.toISOString(),
-          isSystem: false
+          isSystem: false,
+          documentsCount: 0
         }))
       assert.deepEqual(body.resultSet, expectedDataContracts)
     })
@@ -444,7 +446,8 @@ describe('Identities routes', () => {
           schema: null,
           txHash: _dataContract.transaction.hash,
           timestamp: _dataContract.block.timestamp.toISOString(),
-          isSystem: false
+          isSystem: false,
+          documentsCount: 0
         }))
       assert.deepEqual(body.resultSet, expectedDataContracts)
     })
@@ -487,7 +490,8 @@ describe('Identities routes', () => {
           schema: null,
           txHash: _dataContract.transaction.hash,
           timestamp: _dataContract.block.timestamp.toISOString(),
-          isSystem: false
+          isSystem: false,
+          documentsCount: 0
         }))
       assert.deepEqual(body.resultSet, expectedDataContracts)
     })


### PR DESCRIPTION
# Issue

To represent trending data contracts we need to also supply documents count to show it in the list on the page. This PR adds a `documentsCount` field in the data contracts in the API

# Things done
* Added documents count in getDataContractByIdentifier(), getDataContracts() and getDataContractsByIdentity()
* Fixed tests