### PR TITLE
Fix sorting by documents count implementation

### DIFF
--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -155,7 +155,7 @@ describe('Other routes', () => {
         txHash: dataContractTransaction.hash,
         timestamp: block.timestamp.toISOString(),
         isSystem: false,
-        documentsCount: 0
+        documentsCount: 1
       }
 
       assert.deepEqual({ dataContract: expectedDataContract }, body)

--- a/packages/api/test/utils/fixtures.js
+++ b/packages/api/test/utils/fixtures.js
@@ -81,7 +81,7 @@ const fixtures = {
 
     return { ...row, txHash: state_transition_hash ?? transaction.hash, id: result[0].id, transaction }
   },
-  dataContract: async (knex, { identifier, schema, version, state_transition_hash, owner, is_system } = {}) => {
+  dataContract: async (knex, { identifier, schema, version, state_transition_hash, owner, is_system, documents = [] } = {}) => {
     if (!identifier) {
       identifier = generateIdentifier()
     }
@@ -101,7 +101,7 @@ const fixtures = {
 
     const result = await knex('data_contracts').insert(row).returning('id')
 
-    return { ...row, id: result[0].id, documents: [] }
+    return { ...row, id: result[0].id, documents }
   },
   document: async (knex, {
     identifier,


### PR DESCRIPTION
# Issue

Recently merged in sortBy feature https://github.com/pshenmic/platform-explorer/pull/121 contains severe issue - sortBy is counting documents of data contracts by database id, rather than its identifier, thus it incorrectly counts amount of documents, if they were submitted in different data contract revisions. This PR fixes `documentsCount` field to include documents from all data contract's revisions

# Things done
Implemented correct SQL documents count calculation in:
* getDataContractByIdentifier()
* getDataContracts() 
* getDataContractsByIdentity()
* Added test cases in data.contracts.spec integration tests