### PR TITLE
Parse initial identity balance from L1 transaction assetlock

### DIFF
--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -92,8 +92,15 @@ impl PSQLProcessor {
 
     pub async fn handle_identity_create(&self, state_transition: IdentityCreateTransition, st_hash: String) -> () {
         let identity = Identity::from(state_transition);
+        let transfer = Transfer {
+            id: None,
+            sender: None,
+            recipient: Some(identity.identifier),
+            amount: identity.balance.expect("Balance missing from identity")
+        };
 
         self.dao.create_identity(identity, Some(st_hash.clone())).await.unwrap();
+        self.dao.create_transfer(transfer, st_hash.clone()).await.unwrap();
     }
 
     pub async fn handle_identity_update(&self, state_transition: IdentityUpdateTransition, st_hash: String) -> () {


### PR DESCRIPTION
# Issue

When you are creating identities, you always have some initial credit balance based on amount you send from L1 transaction. PE did not include that in the indexer by simply creating identities with zero balance which lead to incorrect identity balance.

# Things done

* Implemented balance parses from AssetLock for IdentityCreateTransition transactions
* Added a transfer creatign just identity creation in handle_identity_create handler