### PR TITLE
Add `identifier` and `owner` columns indexes

### DIFF
--- a/packages/indexer/migrations/V32__owner_indexes.sql
+++ b/packages/indexer/migrations/V32__owner_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX state_transition_owner ON state_transitions(owner);
+CREATE INDEX data_contract_owner ON data_contracts(owner);
+CREATE INDEX document_owner ON documents(owner);

--- a/packages/indexer/migrations/V33__identifier_indexes.sql
+++ b/packages/indexer/migrations/V33__identifier_indexes.sql
@@ -1,0 +1,3 @@
+CREATE INDEX identity_identifier ON identities(identifier);
+CREATE INDEX document_identifier ON documents(identifier);
+

--- a/packages/indexer/migrations/V34__add_data_contracts_name.sql
+++ b/packages/indexer/migrations/V34__add_data_contracts_name.sql
@@ -1,2 +1,0 @@
-ALTER TABLE data_contracts
-ADD COLUMN "name" TEXT DEFAULT NULL;

--- a/packages/indexer/migrations/V34__add_data_contracts_name.sql
+++ b/packages/indexer/migrations/V34__add_data_contracts_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE data_contracts
+ADD COLUMN "name" TEXT DEFAULT NULL;


### PR DESCRIPTION
# Issue
Platform explorer experience some perfomance issue after heavy load in the network. After investigating the queries, missing indexes on `owner` and `identifier` fields are missing in some tables.


# Things done

* Added `identifier` column SQL index on `identities` table 
* Added `identifier` column SQL index on `documents` table 
* Added `owner` column SQL index on `state_transitions` table 
* Added `owner` column SQL index on `data_contracts` table 
* Added `owner` column SQL index on `documents` table 