### PR TITLE
Add data_contract_id index

### DIFF
--- a/packages/indexer/migrations/V34__data_contract_id_indexes.sql
+++ b/packages/indexer/migrations/V34__data_contract_id_indexes.sql
@@ -1,0 +1,2 @@
+CREATE INDEX document_data_contract_id ON documents(data_contract_id);
+


### PR DESCRIPTION
# Issue

`data_contract_id` is used inside left join, but there isn't an index for that.


# Things done

* Added SQL index on `data_contract_id` on documents table 