### PR TITLE
Add transaction fee, status and error message

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -128,6 +128,9 @@ GET /blocks
 ---
 ### Transaction by hash
 Get a transaction (state transition) by hash
+
+Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appear in the `error` field as Base64 string
+
 ```
 GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
 
@@ -138,7 +141,10 @@ GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEE
     hash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
     index: 0,
     timestamp: "2024-03-18T10:13:54.150Z",
-    type: 0
+    type: 0,
+    gasUsed: 1337000,
+    status: "SUCCESS",
+    error: null
 }
 ```
 
@@ -151,6 +157,9 @@ Response codes:
 ---
 ### Transactions
 Return transaction set paged
+
+Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appear in the `error` field as Base64 string
+
 ```
 GET /transactions?=1&limit=10&order=asc
 
@@ -168,7 +177,10 @@ GET /transactions?=1&limit=10&order=asc
         hash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
         index: 0,
         timestamp: "2024-03-18T10:13:54.150Z",
-        type: 0
+        type: 0,
+        gasUsed: 1337000,
+        status: "SUCCESS",
+        error: null
     }, ...
     ]
 }
@@ -419,6 +431,9 @@ Response codes:
 ---
 ### Transactions by Identity
 Return all transactions made by the given identity
+
+Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appear in the `error` field as Base64 string
+
 ```
 GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/transactions?page=1&limit=10&order=asc
 
@@ -437,6 +452,9 @@ GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/transactions?page=1
         type: 0,
         data: null,
         timestamp: "2024-03-18T10:13:54.150Z",
+        gasUsed: 1337000,
+        status: "SUCCESS",
+        error: null
     }, ...
     ]
 }

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -224,8 +224,8 @@ module.exports = class IdentitiesDAO {
     const subquery = this.knex('state_transitions')
       .select('state_transitions.id as state_transition_id', 'state_transitions.hash as tx_hash',
         'state_transitions.index as index', 'state_transitions.type as type', 'state_transitions.block_hash as block_hash',
-        'state_transitions.gas_used as gas_used','state_transitions.status as status','state_transitions.error as error',
-        )
+        'state_transitions.gas_used as gas_used', 'state_transitions.status as status', 'state_transitions.error as error'
+      )
       .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
       .where('state_transitions.owner', '=', identifier)
 

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -222,13 +222,16 @@ module.exports = class IdentitiesDAO {
     const toRank = fromRank + limit - 1
 
     const subquery = this.knex('state_transitions')
-      .select('state_transitions.id as state_transition_id', 'state_transitions.hash as tx_hash', 'state_transitions.index as index',
-        'state_transitions.type as type', 'state_transitions.block_hash as block_hash')
+      .select('state_transitions.id as state_transition_id', 'state_transitions.hash as tx_hash',
+        'state_transitions.index as index', 'state_transitions.type as type', 'state_transitions.block_hash as block_hash',
+        'state_transitions.gas_used as gas_used','state_transitions.status as status','state_transitions.error as error',
+        )
       .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
       .where('state_transitions.owner', '=', identifier)
 
     const rows = await this.knex.with('with_alias', subquery)
       .select('state_transition_id', 'tx_hash', 'index', 'block_hash', 'type', 'rank',
+        'gas_used', 'status', 'gas_used',
         'blocks.timestamp as timestamp', 'blocks.height as block_height')
       .select(this.knex('with_alias').count('*').as('total_count'))
       .leftJoin('blocks', 'blocks.hash', 'block_hash')

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -10,7 +10,7 @@ module.exports = class TransactionsDAO {
   getTransactionByHash = async (hash) => {
     const [row] = await this.knex('state_transitions')
       .select('state_transitions.hash as tx_hash', 'state_transitions.data as data',
-        'state_transitions.gas_used as gas_used','state_transitions.status as status','state_transitions.error as error',
+        'state_transitions.gas_used as gas_used', 'state_transitions.status as status', 'state_transitions.error as error',
         'state_transitions.type as type', 'state_transitions.index as index', 'blocks.height as block_height',
         'blocks.hash as block_hash', 'blocks.timestamp as timestamp')
       .where('state_transitions.hash', hash)
@@ -30,7 +30,7 @@ module.exports = class TransactionsDAO {
     const subquery = this.knex('state_transitions')
       .select(this.knex('state_transitions').count('hash').as('total_count'), 'state_transitions.hash as tx_hash',
         'state_transitions.data as data', 'state_transitions.type as type', 'state_transitions.index as index',
-        'state_transitions.gas_used as gas_used','state_transitions.status as status','state_transitions.error as error',
+        'state_transitions.gas_used as gas_used', 'state_transitions.status as status', 'state_transitions.error as error',
         'state_transitions.block_hash as block_hash', 'state_transitions.id as id')
       .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
       .as('state_transitions')

--- a/packages/api/src/models/Transaction.js
+++ b/packages/api/src/models/Transaction.js
@@ -6,8 +6,11 @@ module.exports = class Transaction {
   type
   data
   timestamp
+  gasUsed
+  status
+  error
 
-  constructor (hash, index, blockHash, blockHeight, type, data, timestamp) {
+  constructor (hash, index, blockHash, blockHeight, type, data, timestamp, gasUsed, status, error) {
     this.hash = hash ?? null
     this.index = index ?? null
     this.blockHash = blockHash ?? null
@@ -15,10 +18,13 @@ module.exports = class Transaction {
     this.type = type ?? null
     this.data = data ?? null
     this.timestamp = timestamp ?? null
+    this.gasUsed = gasUsed ?? null
+    this.status = status ?? null
+    this.error = error ?? null
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow ({ tx_hash, index, block_hash, block_height, type, data, timestamp }) {
-    return new Transaction(tx_hash, index, block_hash, block_height, type, data, timestamp)
+  static fromRow ({ tx_hash, index, block_hash, block_height, type, data, timestamp, gas_used, status, error }) {
+    return new Transaction(tx_hash, index, block_hash, block_height, type, data, timestamp, parseInt(gas_used), status, error)
   }
 }

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -755,7 +755,10 @@ describe('Identities routes', () => {
           blockHeight: _transaction.block.height,
           type: i === 0 ? StateTransitionEnum.IDENTITY_CREATE : StateTransitionEnum.DOCUMENTS_BATCH,
           data: null,
-          timestamp: _transaction.block.timestamp.toISOString()
+          timestamp: _transaction.block.timestamp.toISOString(),
+          gasUsed: _transaction.transaction.gas_used,
+          status: _transaction.transaction.status,
+          error: _transaction.transaction.error
         }))
 
       assert.deepEqual(body.resultSet, expectedTransactions)
@@ -795,7 +798,10 @@ describe('Identities routes', () => {
           blockHeight: _transaction.block.height,
           type: StateTransitionEnum.DOCUMENTS_BATCH,
           data: null,
-          timestamp: _transaction.block.timestamp.toISOString()
+          timestamp: _transaction.block.timestamp.toISOString(),
+          gasUsed: _transaction.transaction.gas_used,
+          status: _transaction.transaction.status,
+          error: _transaction.transaction.error
         }))
 
       assert.deepEqual(body.resultSet, expectedTransactions)
@@ -835,7 +841,10 @@ describe('Identities routes', () => {
           blockHeight: _transaction.block.height,
           type: StateTransitionEnum.DOCUMENTS_BATCH,
           data: null,
-          timestamp: _transaction.block.timestamp.toISOString()
+          timestamp: _transaction.block.timestamp.toISOString(),
+          gasUsed: _transaction.transaction.gas_used,
+          status: _transaction.transaction.status,
+          error: _transaction.transaction.error
         }))
 
       assert.deepEqual(body.resultSet, expectedTransactions)
@@ -875,7 +884,10 @@ describe('Identities routes', () => {
           blockHeight: _transaction.block.height,
           type: StateTransitionEnum.DOCUMENTS_BATCH,
           data: null,
-          timestamp: _transaction.block.timestamp.toISOString()
+          timestamp: _transaction.block.timestamp.toISOString(),
+          gasUsed: _transaction.transaction.gas_used,
+          status: _transaction.transaction.status,
+          error: _transaction.transaction.error
         }))
 
       assert.deepEqual(body.resultSet, expectedTransactions)

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -115,7 +115,10 @@ describe('Other routes', () => {
         blockHeight: block.height,
         type: dataContractTransaction.type,
         data: JSON.stringify(dataContractTransaction.data),
-        timestamp: block.timestamp.toISOString()
+        timestamp: block.timestamp.toISOString(),
+        gasUsed: dataContractTransaction.gas_used,
+        status: dataContractTransaction.status,
+        error: dataContractTransaction.error
       }
 
       assert.deepEqual({ transaction: expectedTransaction }, body)

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -33,11 +33,14 @@ describe('Transaction routes', () => {
 
     // error tx
     const errorTx = await fixtures.transaction(knex, {
-      block_hash: block.hash, data: '{}', type: StateTransitionEnum.DOCUMENTS_BATCH,
+      block_hash: block.hash,
+      data: '{}',
+      type: StateTransitionEnum.DOCUMENTS_BATCH,
       owner: identity.identifier,
-      error: 'fake_err', status: 'FAIL'
+      error: 'fake_err',
+      status: 'FAIL'
     })
-    transactions.push({transaction: errorTx, block})
+    transactions.push({ transaction: errorTx, block })
 
     for (let i = 2; i < 30; i++) {
       const block = await fixtures.block(knex, {
@@ -99,7 +102,7 @@ describe('Transaction routes', () => {
     })
 
     it('should error transaction', async () => {
-      const [,transaction] = transactions
+      const [, transaction] = transactions
       const { body } = await client.get(`/transaction/${transaction.transaction.hash}`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -31,7 +31,15 @@ describe('Transaction routes', () => {
 
     transactions = [{ transaction: identity.transaction, block }]
 
-    for (let i = 1; i < 30; i++) {
+    // error tx
+    const errorTx = await fixtures.transaction(knex, {
+      block_hash: block.hash, data: '{}', type: StateTransitionEnum.DOCUMENTS_BATCH,
+      owner: identity.identifier,
+      error: 'fake_err', status: 'FAIL'
+    })
+    transactions.push({transaction: errorTx, block})
+
+    for (let i = 2; i < 30; i++) {
       const block = await fixtures.block(knex, {
         height: i + 1, timestamp: new Date(startDate.getTime() + i * 1000 * 60)
       })
@@ -81,7 +89,32 @@ describe('Transaction routes', () => {
         hash: transaction.transaction.hash,
         index: transaction.transaction.index,
         timestamp: transaction.block.timestamp.toISOString(),
-        type: transaction.transaction.type
+        type: transaction.transaction.type,
+        gasUsed: transaction.transaction.gas_used,
+        status: transaction.transaction.status,
+        error: transaction.transaction.error
+      }
+
+      assert.deepEqual(expectedTransaction, body)
+    })
+
+    it('should error transaction', async () => {
+      const [,transaction] = transactions
+      const { body } = await client.get(`/transaction/${transaction.transaction.hash}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedTransaction = {
+        blockHash: transaction.block.hash,
+        blockHeight: transaction.block.height,
+        data: '{}',
+        hash: transaction.transaction.hash,
+        index: transaction.transaction.index,
+        timestamp: transaction.block.timestamp.toISOString(),
+        type: transaction.transaction.type,
+        gasUsed: 0,
+        status: 'FAIL',
+        error: 'fake_err'
       }
 
       assert.deepEqual(expectedTransaction, body)
@@ -114,7 +147,10 @@ describe('Transaction routes', () => {
           hash: transaction.transaction.hash,
           index: transaction.transaction.index,
           timestamp: transaction.block.timestamp.toISOString(),
-          type: transaction.transaction.type
+          type: transaction.transaction.type,
+          gasUsed: transaction.transaction.gas_used,
+          status: transaction.transaction.status,
+          error: transaction.transaction.error
         }))
 
       assert.deepEqual(expectedTransactions, body.resultSet)
@@ -140,7 +176,10 @@ describe('Transaction routes', () => {
           hash: transaction.transaction.hash,
           index: transaction.transaction.index,
           timestamp: transaction.block.timestamp.toISOString(),
-          type: transaction.transaction.type
+          type: transaction.transaction.type,
+          gasUsed: transaction.transaction.gas_used,
+          status: transaction.transaction.status,
+          error: transaction.transaction.error
         }))
 
       assert.deepEqual(expectedTransactions, body.resultSet)
@@ -166,7 +205,10 @@ describe('Transaction routes', () => {
           hash: transaction.transaction.hash,
           index: transaction.transaction.index,
           timestamp: transaction.block.timestamp.toISOString(),
-          type: transaction.transaction.type
+          type: transaction.transaction.type,
+          gasUsed: transaction.transaction.gas_used,
+          status: transaction.transaction.status,
+          error: transaction.transaction.error
         }))
 
       assert.deepEqual(expectedTransactions, body.resultSet)
@@ -192,7 +234,10 @@ describe('Transaction routes', () => {
           hash: transaction.transaction.hash,
           index: transaction.transaction.index,
           timestamp: transaction.block.timestamp.toISOString(),
-          type: transaction.transaction.type
+          type: transaction.transaction.type,
+          gasUsed: transaction.transaction.gas_used,
+          status: transaction.transaction.status,
+          error: transaction.transaction.error
         }))
 
       assert.deepEqual(expectedTransactions, body.resultSet)

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -97,6 +97,9 @@ GET /blocks
 ---
 ### Transaction by hash
 Get a transaction (state transition) by hash
+
+Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appear in the `error` field as Base64 string
+
 ```
 GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
 
@@ -107,7 +110,10 @@ GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEE
     hash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
     index: 0,
     timestamp: "2024-03-18T10:13:54.150Z",
-    type: 0
+    type: 0,
+    gasUsed: 1337000,
+    status: "SUCCESS",
+    error: null
 }
 ```
 
@@ -120,6 +126,9 @@ Response codes:
 ---
 ### Transactions
 Return transaction set paged
+
+Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appear in the `error` field as Base64 string
+
 ```
 GET /transactions?=1&limit=10&order=asc
 
@@ -137,7 +146,10 @@ GET /transactions?=1&limit=10&order=asc
         hash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
         index: 0,
         timestamp: "2024-03-18T10:13:54.150Z",
-        type: 0
+        type: 0,
+        gasUsed: 1337000,
+        status: "SUCCESS",
+        error: null
     }, ...
     ]
 }
@@ -388,6 +400,9 @@ Response codes:
 ---
 ### Transactions by Identity
 Return all transactions made by the given identity
+
+Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appear in the `error` field as Base64 string
+
 ```
 GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/transactions?page=1&limit=10&order=asc
 
@@ -406,6 +421,9 @@ GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/transactions?page=1
         type: 0,
         data: null,
         timestamp: "2024-03-18T10:13:54.150Z",
+        gasUsed: 1337000,
+        status: "SUCCESS",
+        error: null
     }, ...
     ]
 }


### PR DESCRIPTION
# Issue

Transaction fees, status and error messages were introduced in the https://github.com/pshenmic/platform-explorer/pull/141. This PR adds such data in the SQL queries so this information is now available in the API.

# Things done

* Added `gasUsed`, `status`, `error` fields in the getTransactionByHash route
* Added `gasUsed`, `status`, `error` fields in the getTransactions() route
* Added `gasUsed`, `status`, `error` fields in the getIdentityTransactions() route
* Updated README