### PR TITLE
Improve network status block

### DIFF
--- a/packages/frontend/src/app/home/Home.js
+++ b/packages/frontend/src/app/home/Home.js
@@ -169,8 +169,8 @@ function Home () {
       </Container>
 
       <TotalInfo
-        blocks={status.data?.blocksCount}
-        transactions={status.data?.txCount}
+        blocks={status.data?.apiHeight}
+        transactions={status.data?.transactionsCount}
         dataContracts={status.data?.dataContractsCount}
         documents={status.data?.documentsCount}
         transfers={status.data?.transfersCount}

--- a/packages/frontend/src/app/home/Home.js
+++ b/packages/frontend/src/app/home/Home.js
@@ -169,7 +169,7 @@ function Home () {
       </Container>
 
       <TotalInfo
-        blocks={status.data?.apiHeight}
+        blocks={status?.data?.api?.block?.height}
         transactions={status.data?.transactionsCount}
         dataContracts={status.data?.dataContractsCount}
         documents={status.data?.documentsCount}

--- a/packages/frontend/src/components/networkStatus/NetworkStatus.scss
+++ b/packages/frontend/src/components/networkStatus/NetworkStatus.scss
@@ -25,6 +25,7 @@
     &__InfoItem {
         position: relative;
         display: flex;
+        flex-wrap: wrap;
         margin-bottom: 15px;
 
         &:last-child {
@@ -48,6 +49,10 @@
         font-size: 18px;
         color: var(--chakra-colors-brand-deep);
         margin-right: 12px;
+
+        &--Api {
+            margin-right: 2px;
+        }
     }
 
     &__Value {

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -6,7 +6,9 @@ import './NetworkStatus.scss'
 function NetworkStatus ({ status }) {
   const msFromLastBlock = new Date() - new Date(status?.data?.latestBlock?.header?.timestamp)
   const networkStatus = msFromLastBlock && msFromLastBlock / 1000 / 60 < 15
-  const apiStatus = status?.data?.apiHeight === status?.data?.tenderdashChainHeight
+  const apiStatus = status?.data?.apiHeight &&
+    status?.data?.tenderdashChainHeight &&
+    status?.data?.apiHeight === status?.data?.tenderdashChainHeight
 
   const NetworkStatusIcon = networkStatus
     ? <CheckCircleIcon color={'green.500'} ml={2}/>

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -98,7 +98,7 @@ function NetworkStatus ({ status }) {
                       <Tooltip
                           label={`${apiStatus
                               ? 'API appears operational'
-                              : 'API works intermittently'
+                              : 'API indexing disrupted'
                           }`}
                           aria-label={'API status'}
                           placement={'top'}

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -6,8 +6,7 @@ import './NetworkStatus.scss'
 function NetworkStatus ({ status }) {
   const msFromLastBlock = new Date() - new Date(status?.data?.latestBlock?.header?.timestamp)
   const networkStatus = msFromLastBlock && msFromLastBlock / 1000 / 60 < 15
-  const apiStatus = status?.data?.apiHeight &&
-    status?.data?.tenderdashChainHeight &&
+  const apiStatus = typeof status?.data?.apiHeight === 'number' &&
     status?.data?.apiHeight === status?.data?.tenderdashChainHeight
 
   const NetworkStatusIcon = networkStatus

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -4,10 +4,9 @@ import Link from 'next/link'
 import './NetworkStatus.scss'
 
 function NetworkStatus ({ status }) {
-  const msFromLastBlock = new Date() - new Date(status?.data?.latestBlock?.header?.timestamp)
+  const msFromLastBlock = new Date() - new Date(status?.data?.tenderdash?.block?.timestamp)
   const networkStatus = msFromLastBlock && msFromLastBlock / 1000 / 60 < 15
-  const apiStatus = typeof status?.data?.apiHeight === 'number' &&
-    status?.data?.apiHeight === status?.data?.tenderdashChainHeight
+  const apiStatus = status?.data?.api?.block?.timestamp === status?.data?.tenderdash?.block?.timestamp
 
   const NetworkStatusIcon = networkStatus
     ? <CheckCircleIcon color={'green.500'} ml={2}/>
@@ -16,8 +15,6 @@ function NetworkStatus ({ status }) {
   const ApiStatusIcon = apiStatus
     ? <CheckCircleIcon color={'green.500'} ml={2}/>
     : <WarningTwoIcon color={'yellow.400'} ml={2}/>
-
-  console.log('status', status)
 
   function getLastBlocktimeString () {
     if (!status?.data?.latestBlock?.header?.timestamp) return 'n/a'

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -81,11 +81,11 @@ function NetworkStatus ({ status }) {
                   <div className={'NetworkStatus__Title NetworkStatus__Title--Api'}>API:</div>
                   <div className={'NetworkStatus__Value'}>
                       <Tooltip
-                          label={`${networkStatus
+                          label={`${apiStatus
                               ? 'API appears operational'
                               : 'API works intermittently'
                           }`}
-                          aria-label={'Network status'}
+                          aria-label={'API status'}
                           placement={'top'}
                           hasArrow
                           bg={'gray.700'}

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -57,6 +57,20 @@ function NetworkStatus ({ status }) {
             </div>
 
             <div className={`NetworkStatus__InfoItem ${status?.loading ? 'NetworkStatus__InfoItem--Loading' : ''}`}>
+                <div className={'NetworkStatus__Title'}>Platform version:</div>
+                <div className={'NetworkStatus__Value'}>
+                    <span>{status?.data?.platform?.version !== undefined ? `#${status.data.platform.version}` : '-'}</span>
+                </div>
+            </div>
+
+            <div className={`NetworkStatus__InfoItem ${status?.loading ? 'NetworkStatus__InfoItem--Loading' : ''}`}>
+                <div className={'NetworkStatus__Title'}>Tenderdash version:</div>
+                <div className={'NetworkStatus__Value'}>
+                    <span>{status?.data?.tenderdash?.version !== undefined ? `#${status.data.tenderdash.version}` : '-'}</span>
+                </div>
+            </div>
+
+            <div className={`NetworkStatus__InfoItem ${status?.loading ? 'NetworkStatus__InfoItem--Loading' : ''}`}>
                 <Flex mr={6}>
                   <div className={'NetworkStatus__Title'}>Network:</div>
                   <div className={'NetworkStatus__Value'}>

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -60,14 +60,14 @@ function NetworkStatus ({ status }) {
             <div className={`NetworkStatus__InfoItem ${status?.loading ? 'NetworkStatus__InfoItem--Loading' : ''}`}>
                 <div className={'NetworkStatus__Title'}>Platform version:</div>
                 <div className={'NetworkStatus__Value'}>
-                    <span>{status?.data?.platform?.version !== undefined ? `#${status.data.platform.version}` : '-'}</span>
+                    <span>{status?.data?.platform?.version !== undefined ? `v${status.data.platform.version}` : '-'}</span>
                 </div>
             </div>
 
             <div className={`NetworkStatus__InfoItem ${status?.loading ? 'NetworkStatus__InfoItem--Loading' : ''}`}>
                 <div className={'NetworkStatus__Title'}>Tenderdash version:</div>
                 <div className={'NetworkStatus__Value'}>
-                    <span>{status?.data?.tenderdash?.version !== undefined ? `#${status.data.tenderdash.version}` : '-'}</span>
+                    <span>{status?.data?.tenderdash?.version !== undefined ? `v${status.data.tenderdash.version}` : '-'}</span>
                 </div>
             </div>
 

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -6,7 +6,8 @@ import './NetworkStatus.scss'
 function NetworkStatus ({ status }) {
   const msFromLastBlock = new Date() - new Date(status?.data?.tenderdash?.block?.timestamp)
   const networkStatus = msFromLastBlock && msFromLastBlock / 1000 / 60 < 15
-  const apiStatus = status?.data?.api?.block?.timestamp === status?.data?.tenderdash?.block?.timestamp
+  const apiStatus = typeof status?.data?.api?.block?.timestamp === 'string' &&
+    status?.data?.api?.block?.timestamp === status?.data?.tenderdash?.block?.timestamp
 
   const NetworkStatusIcon = networkStatus
     ? <CheckCircleIcon color={'green.500'} ml={2}/>

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -1,14 +1,22 @@
 import { InfoIcon, CheckCircleIcon, WarningTwoIcon } from '@chakra-ui/icons'
-import { Container, Tooltip } from '@chakra-ui/react'
+import { Container, Tooltip, Flex } from '@chakra-ui/react'
 import Link from 'next/link'
 import './NetworkStatus.scss'
 
 function NetworkStatus ({ status }) {
   const msFromLastBlock = new Date() - new Date(status?.data?.latestBlock?.header?.timestamp)
   const networkStatus = msFromLastBlock && msFromLastBlock / 1000 / 60 < 15
+  const apiStatus = status?.data?.apiHeight === status?.data?.tenderdashChainHeight
+
   const NetworkStatusIcon = networkStatus
     ? <CheckCircleIcon color={'green.500'} ml={2}/>
     : <WarningTwoIcon color={'yellow.400'} ml={2}/>
+
+  const ApiStatusIcon = apiStatus
+    ? <CheckCircleIcon color={'green.500'} ml={2}/>
+    : <WarningTwoIcon color={'yellow.400'} ml={2}/>
+
+  console.log('status', status)
 
   function getLastBlocktimeString () {
     if (!status?.data?.latestBlock?.header?.timestamp) return 'n/a'
@@ -51,24 +59,44 @@ function NetworkStatus ({ status }) {
             </div>
 
             <div className={`NetworkStatus__InfoItem ${status?.loading ? 'NetworkStatus__InfoItem--Loading' : ''}`}>
-                <div className={'NetworkStatus__Title'}>Network:</div>
-                <div className={'NetworkStatus__Value'}>
-                    <span>{status?.data?.network !== undefined ? `${status.data.network}` : 'n/a'}</span>
+                <Flex mr={6}>
+                  <div className={'NetworkStatus__Title'}>Network:</div>
+                  <div className={'NetworkStatus__Value'}>
+                      <span>{status?.data?.network !== undefined ? `${status.data.network}` : 'n/a'}</span>
 
-                    <Tooltip
-                        label={`${networkStatus
-                            ? 'Network appears operational'
-                            : 'Chain propagation degraded'
-                        }`}
-                        aria-label={'Network status'}
-                        placement={'top'}
-                        hasArrow
-                        bg={'gray.700'}
-                        color={'white'}
-                    >
-                        {NetworkStatusIcon}
-                    </Tooltip>
-                </div>
+                      <Tooltip
+                          label={`${networkStatus
+                              ? 'Network appears operational'
+                              : 'Chain propagation degraded'
+                          }`}
+                          aria-label={'Network status'}
+                          placement={'top'}
+                          hasArrow
+                          bg={'gray.700'}
+                          color={'white'}
+                      >
+                          {NetworkStatusIcon}
+                      </Tooltip>
+                  </div>
+                </Flex>
+                <Flex>
+                  <div className={'NetworkStatus__Title NetworkStatus__Title--Api'}>API:</div>
+                  <div className={'NetworkStatus__Value'}>
+                      <Tooltip
+                          label={`${networkStatus
+                              ? 'API appears operational'
+                              : 'API works intermittently'
+                          }`}
+                          aria-label={'Network status'}
+                          placement={'top'}
+                          hasArrow
+                          bg={'gray.700'}
+                          color={'white'}
+                      >
+                          {ApiStatusIcon}
+                      </Tooltip>
+                  </div>
+                </Flex>
             </div>
 
             <div className={`NetworkStatus__InfoItem ${status?.loading ? 'NetworkStatus__InfoItem--Loading' : ''}`}>


### PR DESCRIPTION
# Issue
Currently, only chain of the API is counted on the homepage when showing user a network status. However, sometimes PE indexer may halt, while network itself continue to propagate. https://github.com/pshenmic/platform-explorer/issues/146

# Things done
- Updated status properties name еo fit the new format https://github.com/pshenmic/platform-explorer/pull/145
- Added API status
- Added Platform and Tenderdash versions