### PR TITLE
Add tenderdash block timestamp in the status

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -67,7 +67,7 @@ Returns basic stats and epoch info
 HTTP /status
 
 {
-   epoch: {
+    epoch: {
         index: 3,
         startTime: "2024-04-08T14:00:00.000Z",
         endTime: "2024-04-09T14:00:00.000Z"
@@ -77,6 +77,27 @@ HTTP /status
     dataContractsCount: 1,
     documentsCount: 1,
     network: "dash-testnet-40",
+    api: {
+        version: "1.0.0",
+        block: {
+            height: 20153,
+            timestamp: "2024-06-06T21:50:20.949Z"
+        }
+    }
+    platform: {
+        version: "1.0.0-dev.12"
+    },
+    tenderdash: {
+        version: "0.14.0-dev.6",
+        block: {
+            height: 20154,
+            timestamp: "2024-06-06T21:53:27.947Z"
+         }
+    }     
+}
+    
+    
+    
     tenderdashVersion: "0.14.4"
     platformVersion: "v1.0.0-dev.12"
     apiHeight: 420,

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -95,15 +95,6 @@ HTTP /status
          }
     }     
 }
-    
-    
-    
-    tenderdashVersion: "0.14.4"
-    platformVersion: "v1.0.0-dev.12"
-    apiHeight: 420,
-    maxPeerHeight: 1337,
-    tenderdashChainHeight: 1337,
-}
 ```
 ---
 ### Block by hash

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -5,6 +5,9 @@ const DocumentsDAO = require('../dao/DocumentsDAO')
 const IdentitiesDAO = require('../dao/IdentitiesDAO')
 const TenderdashRPC = require('../tenderdashRpc')
 
+const API_VERSION = require('../../package.json').version
+const PLATFORM_VERSION = '1' + require('../../package.json').dependencies.dash.substring(1)
+
 class MainController {
   constructor (knex) {
     this.blocksDAO = new BlocksDAO(knex)
@@ -44,11 +47,23 @@ class MainController {
       dataContractsCount: stats?.dataContractsCount,
       documentsCount: stats?.documentsCount,
       network: tdStatus?.network ?? null,
-      tenderdashVersion: tdStatus?.tenderdashVersion ?? null,
-      platformVersion: tdStatus?.platformVersion ?? null,
-      apiHeight: currentBlock?.header?.height ?? null,
-      maxPeerHeight: tdStatus?.maxPeerHeight ?? null,
-      tenderdashChainHeight: tdStatus?.tenderdashChainHeight ?? null
+      api: {
+        version: API_VERSION,
+        block: {
+          height: currentBlock?.header?.height,
+          timestamp: currentBlock?.header?.timestamp.toISOString()
+        }
+      },
+      platform: {
+        version: PLATFORM_VERSION
+      },
+      tenderdash: {
+        version: tdStatus?.version ?? null,
+        block: {
+          height: tdStatus?.highestBlock.height,
+          timestamp: tdStatus?.highestBlock.timestamp
+        }
+      }
     })
   }
 

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -60,8 +60,8 @@ class MainController {
       tenderdash: {
         version: tdStatus?.version ?? null,
         block: {
-          height: tdStatus?.highestBlock.height,
-          timestamp: tdStatus?.highestBlock.timestamp
+          height: tdStatus?.highestBlock?.height ?? null,
+          timestamp: tdStatus?.highestBlock?.timestamp ?? null
         }
       }
     })

--- a/packages/api/src/tenderdashRpc.js
+++ b/packages/api/src/tenderdashRpc.js
@@ -1,7 +1,6 @@
 const fetch = require('node-fetch')
 const ServiceNotAvailableError = require('./errors/ServiceNotAvailableError')
 
-const PLATFORM_VERSION = '1' + require('../package.json').dependencies.dash.substring(1)
 const BASE_URL = process.env.BASE_URL
 
 const call = async (path, method, body) => {
@@ -80,17 +79,16 @@ class TenderdashRPC {
 
   static async getStatus () {
     const { sync_info: syncInfo, node_info: nodeInfo } = await call('status', 'GET')
-    const { latest_block_height: tenderdashChainHeight, max_peer_block_height: maxPeerHeight } = syncInfo
-    const { network } = nodeInfo
-
-    const tenderdashVersion = nodeInfo.version
+    const { latest_block_height: latestBlockHeight, latest_block_time: latestBlockTime } = syncInfo
+    const { network, version } = nodeInfo
 
     return {
       network,
-      tenderdashVersion,
-      platformVersion: PLATFORM_VERSION,
-      maxPeerHeight,
-      tenderdashChainHeight
+      version,
+      highestBlock: {
+        height: parseInt(latestBlockHeight),
+        timestamp: latestBlockTime
+      }
     }
   }
 

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -16,6 +16,7 @@ describe('Other routes', () => {
   let knex
 
   let block
+  let blocks
   let identityTransaction
   let identity
   let dataContractTransaction
@@ -27,6 +28,7 @@ describe('Other routes', () => {
     client = supertest(app.server)
 
     knex = getKnex()
+    blocks = []
 
     await fixtures.cleanup(knex)
 
@@ -36,6 +38,7 @@ describe('Other routes', () => {
 
     const identityIdentifier = fixtures.identifier()
     block = await fixtures.block(knex, { timestamp: new Date(genesisTime + blockDiffTime) })
+    blocks.push(block)
 
     identityTransaction = await fixtures.transaction(knex, {
       block_hash: block.hash,
@@ -72,7 +75,8 @@ describe('Other routes', () => {
     // prepare for get status
 
     for (let i = 1; i < 10; i++) {
-      await fixtures.block(knex, { height: i + 1, timestamp: new Date(block.timestamp.getTime() + blockDiffTime * i) })
+      const newBlock = await fixtures.block(knex, { height: i + 1, timestamp: new Date(block.timestamp.getTime() + blockDiffTime * i) })
+      blocks.push(newBlock)
     }
   })
 
@@ -81,120 +85,121 @@ describe('Other routes', () => {
     await knex.destroy()
   })
 
-  // describe('search()', async () => {
-  //   it('should search block by hash', async () => {
-  //     const { body } = await client.get(`/search?query=${block.hash}`)
-  //       .expect(200)
-  //       .expect('Content-Type', 'application/json; charset=utf-8')
-  //
-  //     const expectedBlock = {
-  //       header: {
-  //         hash: block.hash,
-  //         height: block.height,
-  //         timestamp: block.timestamp.toISOString(),
-  //         blockVersion: block.block_version,
-  //         appVersion: block.app_version,
-  //         l1LockedHeight: block.l1_locked_height,
-  //         validator: block.validator
-  //       },
-  //       txs: [identityTransaction.hash, dataContractTransaction.hash, documentTransaction.hash]
-  //     }
-  //
-  //     assert.deepEqual({ block: expectedBlock }, body)
-  //   })
-  //
-  //   it('should search transaction by hash', async () => {
-  //     const { body } = await client.get(`/search?query=${dataContractTransaction.hash}`)
-  //       .expect(200)
-  //       .expect('Content-Type', 'application/json; charset=utf-8')
-  //
-  //     const expectedTransaction = {
-  //       hash: dataContractTransaction.hash,
-  //       index: dataContractTransaction.index,
-  //       blockHash: dataContractTransaction.block_hash,
-  //       blockHeight: block.height,
-  //       type: dataContractTransaction.type,
-  //       data: JSON.stringify(dataContractTransaction.data),
-  //       timestamp: block.timestamp.toISOString(),
-  //       gasUsed: dataContractTransaction.gas_used,
-  //       status: dataContractTransaction.status,
-  //       error: dataContractTransaction.error
-  //     }
-  //
-  //     assert.deepEqual({ transaction: expectedTransaction }, body)
-  //   })
-  //
-  //   it('should search block by height', async () => {
-  //     const { body } = await client.get(`/search?query=${block.height}`)
-  //       .expect(200)
-  //       .expect('Content-Type', 'application/json; charset=utf-8')
-  //
-  //     const expectedBlock = {
-  //       header: {
-  //         hash: block.hash,
-  //         height: block.height,
-  //         timestamp: block.timestamp.toISOString(),
-  //         blockVersion: block.block_version,
-  //         appVersion: block.app_version,
-  //         l1LockedHeight: block.l1_locked_height,
-  //         validator: block.validator
-  //       },
-  //       txs: [identityTransaction.hash, dataContractTransaction.hash, documentTransaction.hash]
-  //     }
-  //
-  //     assert.deepEqual({ block: expectedBlock }, body)
-  //   })
-  //
-  //   it('should search by data contract', async () => {
-  //     const { body } = await client.get(`/search?query=${dataContract.identifier}`)
-  //       .expect(200)
-  //       .expect('Content-Type', 'application/json; charset=utf-8')
-  //
-  //     const expectedDataContract = {
-  //       identifier: dataContract.identifier,
-  //       owner: identity.identifier.trim(),
-  //       schema: JSON.stringify(dataContract.schema),
-  //       version: 0,
-  //       txHash: dataContractTransaction.hash,
-  //       timestamp: block.timestamp.toISOString(),
-  //       isSystem: false,
-  //       documentsCount: 1
-  //     }
-  //
-  //     assert.deepEqual({ dataContract: expectedDataContract }, body)
-  //   })
-  //
-  //   it('should search by identity', async () => {
-  //     const { body } = await client.get(`/search?query=${identity.identifier}`)
-  //       .expect(200)
-  //       .expect('Content-Type', 'application/json; charset=utf-8')
-  //
-  //     const expectedIdentity = {
-  //       identifier: identity.identifier,
-  //       revision: 0,
-  //       balance: 0,
-  //       timestamp: block.timestamp.toISOString(),
-  //       txHash: identityTransaction.hash,
-  //       totalTxs: 3,
-  //       totalTransfers: 0,
-  //       totalDocuments: 1,
-  //       totalDataContracts: 1,
-  //       isSystem: false,
-  //       owner: identity.identifier
-  //     }
-  //
-  //     assert.deepEqual({ identity: expectedIdentity }, body)
-  //   })
-  // })
+  describe('search()', async () => {
+    it('should search block by hash', async () => {
+      const { body } = await client.get(`/search?query=${block.hash}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedBlock = {
+        header: {
+          hash: block.hash,
+          height: block.height,
+          timestamp: block.timestamp.toISOString(),
+          blockVersion: block.block_version,
+          appVersion: block.app_version,
+          l1LockedHeight: block.l1_locked_height,
+          validator: block.validator
+        },
+        txs: [identityTransaction.hash, dataContractTransaction.hash, documentTransaction.hash]
+      }
+
+      assert.deepEqual({ block: expectedBlock }, body)
+    })
+
+    it('should search transaction by hash', async () => {
+      const { body } = await client.get(`/search?query=${dataContractTransaction.hash}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedTransaction = {
+        hash: dataContractTransaction.hash,
+        index: dataContractTransaction.index,
+        blockHash: dataContractTransaction.block_hash,
+        blockHeight: block.height,
+        type: dataContractTransaction.type,
+        data: JSON.stringify(dataContractTransaction.data),
+        timestamp: block.timestamp.toISOString(),
+        gasUsed: dataContractTransaction.gas_used,
+        status: dataContractTransaction.status,
+        error: dataContractTransaction.error
+      }
+
+      assert.deepEqual({ transaction: expectedTransaction }, body)
+    })
+
+    it('should search block by height', async () => {
+      const { body } = await client.get(`/search?query=${block.height}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedBlock = {
+        header: {
+          hash: block.hash,
+          height: block.height,
+          timestamp: block.timestamp.toISOString(),
+          blockVersion: block.block_version,
+          appVersion: block.app_version,
+          l1LockedHeight: block.l1_locked_height,
+          validator: block.validator
+        },
+        txs: [identityTransaction.hash, dataContractTransaction.hash, documentTransaction.hash]
+      }
+
+      assert.deepEqual({ block: expectedBlock }, body)
+    })
+
+    it('should search by data contract', async () => {
+      const { body } = await client.get(`/search?query=${dataContract.identifier}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedDataContract = {
+        identifier: dataContract.identifier,
+        owner: identity.identifier.trim(),
+        schema: JSON.stringify(dataContract.schema),
+        version: 0,
+        txHash: dataContractTransaction.hash,
+        timestamp: block.timestamp.toISOString(),
+        isSystem: false,
+        documentsCount: 1
+      }
+
+      assert.deepEqual({ dataContract: expectedDataContract }, body)
+    })
+
+    it('should search by identity', async () => {
+      const { body } = await client.get(`/search?query=${identity.identifier}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedIdentity = {
+        identifier: identity.identifier,
+        revision: 0,
+        balance: 0,
+        timestamp: block.timestamp.toISOString(),
+        txHash: identityTransaction.hash,
+        totalTxs: 3,
+        totalTransfers: 0,
+        totalDocuments: 1,
+        totalDataContracts: 1,
+        isSystem: false,
+        owner: identity.identifier
+      }
+
+      assert.deepEqual({ identity: expectedIdentity }, body)
+    })
+  })
 
   describe('getStatus()', async () => {
     it('should return status', async () => {
       process.env.EPOCH_CHANGE_TIME = 60000
       const mockTDStatus = {
-        tenderdashVersion: 'v2.0.0',
-        platformVersion: 'v1.0.0',
-        maxPeerHeight: 1337,
-        tenderdashChainHeight: 420
+        version: 'v2.0.0',
+        highestBlock: {
+          height: 1337,
+          timestamp: new Date().toISOString()
+        }
       }
 
       mock.method(tenderdashRpc, 'getGenesis', async () => ({ genesis_time: new Date(0) }))
@@ -215,11 +220,23 @@ describe('Other routes', () => {
         dataContractsCount: 1,
         documentsCount: 1,
         network: null,
-        apiHeight: 10,
-        tenderdashChainHeight: mockTDStatus.tenderdashChainHeight,
-        tenderdashVersion: mockTDStatus.tenderdashVersion,
-        platformVersion: mockTDStatus.platformVersion,
-        maxPeerHeight: mockTDStatus.maxPeerHeight
+        api: {
+          version: require('../../package.json').version,
+          block: {
+            height: 10,
+            timestamp: blocks[blocks.length - 1].timestamp.toISOString()
+          }
+        },
+        platform: {
+          version: '1' + require('../../package.json').dependencies.dash.substring(1)
+        },
+        tenderdash: {
+          version: mockTDStatus?.version ?? null,
+          block: {
+            height: mockTDStatus?.highestBlock?.height,
+            timestamp: mockTDStatus?.highestBlock?.timestamp
+          }
+        }
       }
 
       assert.deepEqual(body, expectedStats)

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -36,7 +36,7 @@ Returns basic stats and epoch info
 HTTP /status
 
 {
-   epoch: {
+    epoch: {
         index: 3,
         startTime: "2024-04-08T14:00:00.000Z",
         endTime: "2024-04-09T14:00:00.000Z"
@@ -46,6 +46,27 @@ HTTP /status
     dataContractsCount: 1,
     documentsCount: 1,
     network: "dash-testnet-40",
+    api: {
+        version: "1.0.0",
+        block: {
+            height: 20153,
+            timestamp: "2024-06-06T21:50:20.949Z"
+        }
+    }
+    platform: {
+        version: "1.0.0-dev.12"
+    },
+    tenderdash: {
+        version: "0.14.0-dev.6",
+        block: {
+            height: 20154,
+            timestamp: "2024-06-06T21:53:27.947Z"
+         }
+    }     
+}
+    
+    
+    
     tenderdashVersion: "0.14.4"
     platformVersion: "v1.0.0-dev.12"
     apiHeight: 420,

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -64,15 +64,6 @@ HTTP /status
          }
     }     
 }
-    
-    
-    
-    tenderdashVersion: "0.14.4"
-    platformVersion: "v1.0.0-dev.12"
-    apiHeight: 420,
-    maxPeerHeight: 1337,
-    tenderdashChainHeight: 1337,
-}
 ```
 ---
 ### Block by hash


### PR DESCRIPTION
# Issue

For more accurate network status check on the homepage, we need to also return timestamp of the latest block in tenderdash network. This PR also adds platform version in the reponse

# Things done

* Removed maxPeerHeight
* Added api, platform, and tenderdash status blocks (and added version about each one)
* Added tenderdash network block timestamp in the status