### PR TITLE
Replace block_results with async map + tx_result

### DIFF
--- a/packages/indexer/src/indexer/mod.rs
+++ b/packages/indexer/src/indexer/mod.rs
@@ -114,7 +114,7 @@ impl Indexer {
         let transactions = block.block.data.txs.iter().enumerate().map(|(i, tx_string)| {
             let tx_result = tx_results.get(i)
                 .expect(&format!("tx result at index {} should exist in block results of block with hash {}",
-                                 i, block.block_id.hash.clone())).clone();
+                                 i, &block_hash)).clone();
 
             return match tx_result.code {
                 None => {

--- a/packages/indexer/src/indexer/mod.rs
+++ b/packages/indexer/src/indexer/mod.rs
@@ -114,7 +114,7 @@ impl Indexer {
         let transactions = block.block.data.txs.iter().enumerate().map(|(i, tx_string)| {
             let tx_result = tx_results.get(i)
                 .expect(&format!("tx result at index {} should exist in block results of block with hash {}",
-                                 i, &block_hash)).clone();
+                                 i, &block_hash));
 
             return match tx_result.code {
                 None => {

--- a/packages/indexer/src/indexer/mod.rs
+++ b/packages/indexer/src/indexer/mod.rs
@@ -6,6 +6,8 @@ use crate::entities::block::Block;
 use crate::entities::block_header::BlockHeader;
 use crate::processor::psql::{ProcessorError, PSQLProcessor};
 use base64::{Engine as _, engine::{general_purpose}};
+use futures::future;
+use sha256::digest;
 use crate::decoder::decoder::StateTransitionDecoder;
 use crate::models::{TransactionResult, TransactionStatus};
 use crate::utils::TenderdashRpcApi;
@@ -104,38 +106,39 @@ impl Indexer {
 
     async fn index_block(&self, block_height: i32) -> Result<(), ProcessorError> {
         let block = self.tenderdash_rpc.get_block_by_height(block_height.clone()).await?;
-        let block_results = self.tenderdash_rpc.get_block_results_by_height(block_height.clone()).await?;
         let validators = self.tenderdash_rpc.get_validators_by_block_height(block_height.clone()).await?;
 
         let block_hash = block.block_id.hash;
 
-        let transactions = block.block.data.txs.iter().enumerate().map(|(i, tx_string)| {
-            let tx_results = block_results.txs_results
-                .expect(&format!("There is no tx_results in block with hash {} [{}]",
-                                 block_hash.clone(), block_height.clone()));
-            let tx_result = tx_results.get(i).expect(&format!("tx result at index {} should exist", i)).clone();
+        let transactions = future::try_join_all(block.block.data.txs.iter().enumerate().map(|(i, tx_string)| async {
+            let data = general_purpose::STANDARD.decode(tx_string.clone().as_bytes().to_vec()).expect("Could not decode tx string");
+            let hash = digest(data).to_uppercase();
+
+            let transaction = self.tenderdash_rpc.get_transaction_by_hash(hash).await?;
+            let tx_result = transaction.tx_result;
 
             return match tx_result.code {
                 None => {
-                    TransactionResult {
+                    Ok::<TransactionResult, reqwest::Error>(TransactionResult {
                         data: tx_string.clone(),
                         gas_used: tx_result.gas_used.clone(),
                         status: TransactionStatus::SUCCESS,
                         code: None,
                         error: None,
-                    }
+                    })
                 }
                 Some(_) => {
-                    TransactionResult {
+                    Ok(TransactionResult {
                         data: tx_string.clone(),
                         gas_used: tx_result.gas_used.clone(),
                         status: TransactionStatus::FAIL,
                         code: tx_result.code.clone(),
                         error: tx_result.info.clone(),
-                    }
+                    })
                 }
             };
-        }).collect::<Vec<TransactionResult>>();
+        })
+        ).await.unwrap();
 
         let txs = transactions.into_iter().filter(|tx| {
             let bytes = general_purpose::STANDARD.decode(tx.data.clone()).unwrap();

--- a/packages/indexer/src/models/mod.rs
+++ b/packages/indexer/src/models/mod.rs
@@ -75,6 +75,12 @@ pub struct TenderdashRPCBlockResultsResponse {
     pub txs_results: Option<Vec<TDTxResult>>,
 }
 
+#[derive(Deserialize)]
+pub struct TenderdashRPCTransactionResponse {
+    pub hash: String,
+    pub tx_result: TDTxResult,
+}
+
 #[derive(Clone)]
 pub enum TransactionStatus {
     FAIL,

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -1,6 +1,5 @@
 mod dao;
 
-use std::convert::identity;
 use std::num::ParseIntError;
 use dpp::state_transition::{StateTransition, StateTransitionLike};
 use deadpool_postgres::{PoolError};
@@ -9,7 +8,7 @@ use crate::processor::psql::dao::PostgresDAO;
 use base64::{Engine as _, engine::{general_purpose}};
 use data_contracts::SystemDataContract;
 use dpp::identifier::Identifier;
-use dpp::platform_value::{platform_value, BinaryData, Value};
+use dpp::platform_value::{platform_value, BinaryData};
 use dpp::platform_value::btreemap_extensions::BTreeValueMapPathHelper;
 use dpp::platform_value::string_encoding::Encoding::Base58;
 use dpp::serialization::PlatformSerializable;
@@ -23,7 +22,6 @@ use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTr
 use dpp::state_transition::identity_credit_withdrawal_transition::IdentityCreditWithdrawalTransition;
 use dpp::state_transition::identity_topup_transition::IdentityTopUpTransition;
 use dpp::state_transition::identity_update_transition::IdentityUpdateTransition;
-use dpp::util::json_value::JsonValueExt;
 use crate::decoder::decoder::StateTransitionDecoder;
 use crate::entities::block::Block;
 use crate::entities::data_contract::DataContract;

--- a/packages/indexer/src/utils.rs
+++ b/packages/indexer/src/utils.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 use reqwest::{Client, Error};
 use crate::entities::validator::Validator;
-use crate::models::{TenderdashRPCBlockResponse, TenderdashRPCBlockResultsResponse, TenderdashRPCStatusResponse, TenderdashRPCValidatorsResponse};
+use crate::models::{TenderdashRPCBlockResponse, TenderdashRPCBlockResultsResponse, TenderdashRPCStatusResponse, TenderdashRPCTransactionResponse, TenderdashRPCValidatorsResponse};
 
 pub struct TenderdashRpcApi {
     client: Client,
@@ -56,6 +56,20 @@ impl TenderdashRpcApi {
 
         let resp = res
             .json::<TenderdashRPCBlockResultsResponse>()
+            .await?;
+
+        Ok(resp)
+    }
+    pub async fn get_transaction_by_hash(&self, hash: String) -> Result<TenderdashRPCTransactionResponse, Error> {
+        let url = format!("{}/tx?hash={}", self.backend_url, hash);
+
+        let res = self.client
+            .get(url)
+            .send()
+            .await?;
+
+        let resp = res
+            .json::<TenderdashRPCTransactionResponse>()
             .await?;
 
         Ok(resp)


### PR DESCRIPTION
# Issue

Indexer started to fails often in the production, because of the fragile method of getting block_results as_ref inside the closure. This PR adds a fallback item for block_results, so it is available in the closure correctly.


# Things done

* Added /tx?hash=$hash query to the TD on each transaction
* Replaced block_results mapping with async map 