### PR TITLE
Fix timeframe cache in firefox

### DIFF
--- a/packages/frontend/src/app/home/Home.js
+++ b/packages/frontend/src/app/home/Home.js
@@ -209,7 +209,7 @@ function Home () {
                               <select
                                   className={'ChartBlock__TimeframeSelector'}
                                   onChange={(e) => setTransactionsTimespan(e.target.value)}
-                                  defaultValue={transactionsChartConfig.timespan.default}
+                                  value={transactionsTimespan}
                               >
                                   {transactionsChartConfig.timespan.values.map(timespan => {
                                     return <option value={timespan} key={'ts' + timespan}>{timespan}</option>


### PR DESCRIPTION
# Issue
After refreshing the Home page in Firefox, timeframe select element saves selected option, but chart display initial timeframe.

# Things done
Setting initial state using the `value` attribute from `useState` timeframe value.