### PR TITLE
Add block hash in the /status route

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -81,6 +81,7 @@ HTTP /status
         version: "1.0.0",
         block: {
             height: 20153,
+            hash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
             timestamp: "2024-06-06T21:50:20.949Z"
         }
     }
@@ -91,6 +92,7 @@ HTTP /status
         version: "0.14.0-dev.6",
         block: {
             height: 20154,
+            hash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
             timestamp: "2024-06-06T21:53:27.947Z"
          }
     }     

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -29,7 +29,7 @@ class MainController {
 
     const currentBlocktime = currentBlock.header.timestamp.getTime()
     const epochChangeTime = Number(process.env.EPOCH_CHANGE_TIME)
-    const genesisTime = new Date(genesis.genesis_time).getTime()
+    const genesisTime = new Date(genesis?.genesis_time).getTime()
     const epochIndex = Math.floor((currentBlocktime - genesisTime) / epochChangeTime)
     const startEpochTime = Math.floor(genesisTime + epochChangeTime * epochIndex)
     const nextEpochTime = Math.floor(genesisTime + epochChangeTime * (epochIndex + 1))
@@ -51,6 +51,7 @@ class MainController {
         version: API_VERSION,
         block: {
           height: currentBlock?.header?.height,
+          hash: currentBlock?.header?.hash,
           timestamp: currentBlock?.header?.timestamp.toISOString()
         }
       },
@@ -61,6 +62,7 @@ class MainController {
         version: tdStatus?.version ?? null,
         block: {
           height: tdStatus?.highestBlock?.height ?? null,
+          hash: tdStatus?.highestBlock?.hash ?? null,
           timestamp: tdStatus?.highestBlock?.timestamp ?? null
         }
       }

--- a/packages/api/src/tenderdashRpc.js
+++ b/packages/api/src/tenderdashRpc.js
@@ -79,7 +79,11 @@ class TenderdashRPC {
 
   static async getStatus () {
     const { sync_info: syncInfo, node_info: nodeInfo } = await call('status', 'GET')
-    const { latest_block_height: latestBlockHeight, latest_block_time: latestBlockTime } = syncInfo
+    const {
+      latest_block_height: latestBlockHeight,
+      latest_block_hash: latestBlockHash,
+      latest_block_time: latestBlockTime
+    } = syncInfo
     const { network, version } = nodeInfo
 
     return {
@@ -87,6 +91,7 @@ class TenderdashRPC {
       version,
       highestBlock: {
         height: parseInt(latestBlockHeight),
+        hash: latestBlockHash,
         timestamp: latestBlockTime
       }
     }

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -199,6 +199,7 @@ describe('Other routes', () => {
         version: 'v2.0.0',
         highestBlock: {
           height: 1337,
+          hash: 'DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF',
           timestamp: new Date().toISOString()
         }
       }
@@ -225,6 +226,7 @@ describe('Other routes', () => {
           version: require('../../package.json').version,
           block: {
             height: 10,
+            hash: blocks[blocks.length - 1].hash,
             timestamp: blocks[blocks.length - 1].timestamp.toISOString()
           }
         },
@@ -235,6 +237,7 @@ describe('Other routes', () => {
           version: mockTDStatus?.version ?? null,
           block: {
             height: mockTDStatus?.highestBlock?.height,
+            hash: mockTDStatus?.highestBlock?.hash,
             timestamp: mockTDStatus?.highestBlock?.timestamp
           }
         }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -50,6 +50,7 @@ HTTP /status
         version: "1.0.0",
         block: {
             height: 20153,
+            hash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
             timestamp: "2024-06-06T21:50:20.949Z"
         }
     }
@@ -60,6 +61,7 @@ HTTP /status
         version: "0.14.0-dev.6",
         block: {
             height: 20154,
+            hash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
             timestamp: "2024-06-06T21:53:27.947Z"
          }
     }     


### PR DESCRIPTION
# Issue

To correctly show and update link to the latest block hash on the homepage, we need to also supply a block hash together with height and timestamp

# Things done

* Fixed missing optional chaining for genesis time in case TD is not available
* Added `hash` to the info about latest blocks in the getStatus() api method