### PR TITLE
Extend returning info in the getValidators() API

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -174,6 +174,41 @@ GET /blocks
 }
 ```
 ---
+### Validators
+Return all validators with pagination info
+```
+GET /validators
+
+{
+  resultSet: [
+    {
+      proTxHash: '35513037C3476ADDE0B23903A1A1E50660D076370F62F79F0E24212F29088044',
+      latestHeight: 5,
+      latestTimestamp: '2024-06-22T12:42:06.112Z',
+      blocksCount: 4
+    }, ...
+  ],
+  pagination: { 
+    page: 1, 
+    limit: 10, 
+    total: 30 
+  }
+}
+```
+---
+### Validator by ProTxHash
+Get validator by ProTxHash
+```
+GET /validator/35513037C3476ADDE0B23903A1A1E50660D076370F62F79F0E24212F29088044
+
+{
+  proTxHash: '5F1BBB3E5E546BC84731E08679C45A467DD38793B84B575601A56411DD279E34',
+  latestHeight: 5,
+  latestTimestamp: '2024-06-22T12:47:47.359Z',
+  blocksCount: 4
+}
+```
+---
 ### Transaction by hash
 Get a transaction (state transition) by hash
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -183,7 +183,7 @@ GET /validators
   resultSet: [
     {
       "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
-      "blocksCount": 5,
+      "proposedBlocksAmount": 5,
       "lastProposedBlockHeader": {
         "height": 5,
         "timestamp": "2024-06-23T13:51:44.154Z",
@@ -191,6 +191,7 @@ GET /validators
         "l1LockedHeight": 1337,
         "appVersion": 1,
         "blockVersion": 13
+        "validator": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0"
       }
     }, ...
   ],
@@ -209,14 +210,15 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
 {
   "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
-  "blocksCount": 5,
+  "proposedBlocksAmount": 5,
   "lastProposedBlockHeader": {
     "height": 5,
     "timestamp": "2024-06-23T13:51:44.154Z",
     "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
     "l1LockedHeight": 1337,
     "appVersion": 1,
-    "blockVersion": 13
+    "blockVersion": 13,
+    "validator": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0"
   }
 }
 ```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -183,12 +183,12 @@ GET /validators
   resultSet: [
     {
       "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
+      "blocksCount": 5,
       "propsedBlock": {
         "header": {
-          "latestHeight": 5,
-          "latestTimestamp": "2024-06-23T13:51:44.154Z",
-          "blocksCount": 5,
-          "blockHash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+          "height": 5,
+          "timestamp": "2024-06-23T13:51:44.154Z",
+          "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
           "l1LockedHeight": 1337,
           "appVersion": 1,
           "blockVersion": 13
@@ -211,12 +211,12 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
 {
   "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
+  "blocksCount": 5,
   "propsedBlock": {
     "header": {
-        "latestHeight": 5,
-        "latestTimestamp": "2024-06-23T13:51:44.154Z",
-        "blocksCount": 5,
-        "blockHash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+        "height": 5,
+        "timestamp": "2024-06-23T13:51:44.154Z",
+        "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
         "l1LockedHeight": 1337,
         "appVersion": 1,
         "blockVersion": 13

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -184,15 +184,13 @@ GET /validators
     {
       "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
       "blocksCount": 5,
-      "propsedBlock": {
-        "header": {
-          "height": 5,
-          "timestamp": "2024-06-23T13:51:44.154Z",
-          "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
-          "l1LockedHeight": 1337,
-          "appVersion": 1,
-          "blockVersion": 13
-        }
+      "lastProposedBlockHeader": {
+        "height": 5,
+        "timestamp": "2024-06-23T13:51:44.154Z",
+        "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+        "l1LockedHeight": 1337,
+        "appVersion": 1,
+        "blockVersion": 13
       }
     }, ...
   ],
@@ -212,15 +210,13 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 {
   "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
   "blocksCount": 5,
-  "propsedBlock": {
-    "header": {
-        "height": 5,
-        "timestamp": "2024-06-23T13:51:44.154Z",
-        "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
-        "l1LockedHeight": 1337,
-        "appVersion": 1,
-        "blockVersion": 13
-    }
+  "lastProposedBlockHeader": {
+    "height": 5,
+    "timestamp": "2024-06-23T13:51:44.154Z",
+    "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+    "l1LockedHeight": 1337,
+    "appVersion": 1,
+    "blockVersion": 13
   }
 }
 ```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -182,10 +182,18 @@ GET /validators
 {
   resultSet: [
     {
-      proTxHash: '35513037C3476ADDE0B23903A1A1E50660D076370F62F79F0E24212F29088044',
-      latestHeight: 5,
-      latestTimestamp: '2024-06-22T12:42:06.112Z',
-      blocksCount: 4
+      "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
+      "propsedBlock": {
+        "header": {
+          "latestHeight": 5,
+          "latestTimestamp": "2024-06-23T13:51:44.154Z",
+          "blocksCount": 5,
+          "blockHash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+          "l1LockedHeight": 1337,
+          "appVersion": 1,
+          "blockVersion": 13
+        }
+      }
     }, ...
   ],
   pagination: { 
@@ -199,13 +207,21 @@ GET /validators
 ### Validator by ProTxHash
 Get validator by ProTxHash
 ```
-GET /validator/35513037C3476ADDE0B23903A1A1E50660D076370F62F79F0E24212F29088044
+GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
 {
-  proTxHash: '5F1BBB3E5E546BC84731E08679C45A467DD38793B84B575601A56411DD279E34',
-  latestHeight: 5,
-  latestTimestamp: '2024-06-22T12:47:47.359Z',
-  blocksCount: 4
+  "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
+  "propsedBlock": {
+    "header": {
+        "latestHeight": 5,
+        "latestTimestamp": "2024-06-23T13:51:44.154Z",
+        "blocksCount": 5,
+        "blockHash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+        "l1LockedHeight": 1337,
+        "appVersion": 1,
+        "blockVersion": 13
+    }
+  }
 }
 ```
 ---

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -175,7 +175,8 @@ GET /blocks
 ```
 ---
 ### Validators
-Return all validators with pagination info
+Return all validators with pagination info.
+* `lastProposedBlockHeader` field is nullable
 ```
 GET /validators
 
@@ -204,7 +205,8 @@ GET /validators
 ```
 ---
 ### Validator by ProTxHash
-Get validator by ProTxHash
+Get validator by ProTxHash.
+* `lastProposedBlockHeader` field is nullable
 ```
 GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -1,29 +1,31 @@
 const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 module.exports = class ValidatorsDAO {
-  constructor (knex) {
+  constructor(knex) {
     this.knex = knex
   }
 
   getValidatorByProTxHash = async (proTxHash) => {
     const [row] = await this.knex('validators')
-      .select('validators.pro_tx_hash as pro_tx_hash')
+      .select(
+        'validators.pro_tx_hash as pro_tx_hash',
+        this.knex('blocks')
+          .where('validator', proTxHash)
+          .select(this.knex.raw('MAX(timestamp) as latest_timestamp'),).as('latest_timestamp'),
+        this.knex('blocks')
+          .where('validator', proTxHash)
+          .select(this.knex.raw('MAX(height) as latest_height'),).as('latest_height'),
+        this.knex('blocks')
+          .where('validator', proTxHash)
+          .select(this.knex.raw('CAST( COUNT(*) as INT) as blocks_count'),).as('blocks_count')
+      )
       .where('validators.pro_tx_hash', proTxHash)
 
     if (!row) {
       return null
     }
 
-    const [proposedBlocks] = await this.knex('blocks')
-      .where('validator', row.pro_tx_hash)
-      .select(
-        'validator as pro_tx_hash',
-        this.knex.raw('MAX(timestamp) as latest_timestamp'),
-        this.knex.raw('MAX(height) as latest_height'),
-        this.knex.raw('CAST( COUNT(*) as INT) as blocks_count '))
-      .groupBy('pro_tx_hash')
-
-    return Validator.fromRow(proposedBlocks)
+    return Validator.fromRow(row)
   }
 
   getValidators = async (page, limit, order) => {
@@ -31,31 +33,31 @@ module.exports = class ValidatorsDAO {
     const toRank = fromRank + limit - 1
 
     const subquery = this.knex('validators')
-      .select(this.knex('validators').count('pro_tx_hash').as('total_count'),
-        'validators.pro_tx_hash as pro_tx_hash', 'id')
+      .select(
+        this.knex('validators').count('pro_tx_hash').as('total_count'),
+        'validators.pro_tx_hash as pro_tx_hash',
+        'id',
+        this.knex('blocks')
+          .whereRaw('pro_tx_hash = validator')
+          .select(this.knex.raw('MAX(timestamp) as latest_timestamp'),).as('latest_timestamp'),
+        this.knex('blocks')
+          .whereRaw('pro_tx_hash = validator')
+          .select(this.knex.raw('MAX(height) as latest_height'),).as('latest_height'),
+        this.knex('blocks')
+          .whereRaw('pro_tx_hash = validator')
+          .select(this.knex.raw('CAST( COUNT(*) as INT) as blocks_count'),).as('blocks_count'))
       .select(this.knex.raw(`rank() over (order by id ${order}) rank`))
       .as('validators')
 
     const rows = await this.knex(subquery)
-      .select('id', 'rank', 'total_count', 'pro_tx_hash')
+      .select('id', 'rank', 'total_count', 'pro_tx_hash', 'blocks_count', 'latest_height', 'latest_timestamp')
       .whereBetween('rank', [fromRank, toRank])
       .orderBy('id', order)
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 
-    const proTxHashes = rows.map((row) => row.pro_tx_hash)
-
-    const proposedBlocks = await this.knex('blocks')
-      .whereIn('validator', proTxHashes)
-      .select(
-        'validator as pro_tx_hash',
-        this.knex.raw('MAX(timestamp) as latest_timestamp'),
-        this.knex.raw('MAX(height) as latest_height'),
-        this.knex.raw('CAST( COUNT(*) as INT) as blocks_count '))
-      .groupBy('pro_tx_hash')
-
     const resultSet = rows.map((row) =>
-      Validator.fromRow(proposedBlocks.find((block) => block.pro_tx_hash === row.pro_tx_hash))
+      Validator.fromRow(row)
     )
 
     return new PaginatedResultSet(resultSet, page, limit, totalCount)

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -1,7 +1,7 @@
 const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 module.exports = class ValidatorsDAO {
-  constructor(knex) {
+  constructor (knex) {
     this.knex = knex
   }
 
@@ -11,13 +11,13 @@ module.exports = class ValidatorsDAO {
         'validators.pro_tx_hash as pro_tx_hash',
         this.knex('blocks')
           .where('validator', proTxHash)
-          .select(this.knex.raw('MAX(timestamp) as latest_timestamp'),).as('latest_timestamp'),
+          .select(this.knex.raw('MAX(timestamp) as latest_timestamp')).as('latest_timestamp'),
         this.knex('blocks')
           .where('validator', proTxHash)
-          .select(this.knex.raw('MAX(height) as latest_height'),).as('latest_height'),
+          .select(this.knex.raw('MAX(height) as latest_height')).as('latest_height'),
         this.knex('blocks')
           .where('validator', proTxHash)
-          .select(this.knex.raw('CAST( COUNT(*) as INT) as blocks_count'),).as('blocks_count')
+          .select(this.knex.raw('CAST( COUNT(*) as INT) as blocks_count')).as('blocks_count')
       )
       .where('validators.pro_tx_hash', proTxHash)
 
@@ -39,13 +39,13 @@ module.exports = class ValidatorsDAO {
         'id',
         this.knex('blocks')
           .whereRaw('pro_tx_hash = validator')
-          .select(this.knex.raw('MAX(timestamp) as latest_timestamp'),).as('latest_timestamp'),
+          .select(this.knex.raw('MAX(timestamp) as latest_timestamp')).as('latest_timestamp'),
         this.knex('blocks')
           .whereRaw('pro_tx_hash = validator')
-          .select(this.knex.raw('MAX(height) as latest_height'),).as('latest_height'),
+          .select(this.knex.raw('MAX(height) as latest_height')).as('latest_height'),
         this.knex('blocks')
           .whereRaw('pro_tx_hash = validator')
-          .select(this.knex.raw('CAST( COUNT(*) as INT) as blocks_count'),).as('blocks_count'))
+          .select(this.knex.raw('CAST( COUNT(*) as INT) as blocks_count')).as('blocks_count'))
       .select(this.knex.raw(`rank() over (order by id ${order}) rank`))
       .as('validators')
 

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -2,7 +2,7 @@ const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 
 module.exports = class ValidatorsDAO {
-  constructor(knex) {
+  constructor (knex) {
     this.knex = knex
   }
 

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -1,6 +1,5 @@
 const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-//
 module.exports = class ValidatorsDAO {
   constructor (knex) {
     this.knex = knex

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -2,7 +2,7 @@ const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 
 module.exports = class ValidatorsDAO {
-  constructor(knex) {
+  constructor (knex) {
     this.knex = knex
   }
 
@@ -23,7 +23,7 @@ module.exports = class ValidatorsDAO {
           .as('proposed_block_hash')
       )
       .where('validators.pro_tx_hash', proTxHash) // Добавляем это условие, чтобы искать только по нужному pro_tx_hash
-      .as('validators');
+      .as('validators')
 
     const subquery = this.knex(validatorsSubquery)
       .select(
@@ -38,7 +38,7 @@ module.exports = class ValidatorsDAO {
         'blocks.block_version as block_version'
       )
       .leftJoin('blocks', 'blocks.hash', 'proposed_block_hash')
-      .as('blocks');
+      .as('blocks')
 
     const [row] = await this.knex(subquery)
       .select(
@@ -52,8 +52,8 @@ module.exports = class ValidatorsDAO {
         'app_version',
         'block_version'
       )
-      .where('pro_tx_hash', proTxHash) 
-    
+      .where('pro_tx_hash', proTxHash)
+
     if (!row) {
       return null
     }

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -2,7 +2,7 @@ const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 
 module.exports = class ValidatorsDAO {
-  constructor (knex) {
+  constructor(knex) {
     this.knex = knex
   }
 
@@ -30,23 +30,7 @@ module.exports = class ValidatorsDAO {
       return null
     }
 
-    const lastProposedBlockHeader = row.block_hash
-      ? {
-          hash: row.block_hash,
-          height: row.latest_height,
-          timestamp: row.latest_timestamp,
-          l1_locked_height: row.l1_locked_height,
-          app_version: row.app_version,
-          block_version: row.block_version,
-          validator: row.pro_tx_hash
-        }
-      : null
-
-    return Validator.fromRow({
-      pro_tx_hash: row.pro_tx_hash,
-      proposed_blocks_amount: row.proposed_blocks_amount,
-      last_proposed_block_header: lastProposedBlockHeader
-    })
+    return Validator.fromRow(row)
   }
 
   getValidators = async (page, limit, order) => {
@@ -106,24 +90,8 @@ module.exports = class ValidatorsDAO {
       .orderBy('id', order)
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
-    const resultSet = rows.map((row) => {
-      const lastProposedBlockHeader = row.block_hash
-        ? {
-            hash: row.block_hash,
-            height: row.latest_height,
-            timestamp: row.latest_timestamp,
-            l1_locked_height: row.l1_locked_height,
-            app_version: row.app_version,
-            block_version: row.block_version,
-            validator: row.pro_tx_hash
-          }
-        : null
-      return Validator.fromRow({
-        pro_tx_hash: row.pro_tx_hash,
-        proposed_blocks_amount: row.proposed_blocks_amount,
-        last_proposed_block_header: lastProposedBlockHeader
-      })
-    })
+    const resultSet = rows.map((row) => Validator.fromRow(row))
+
     return new PaginatedResultSet(resultSet, page, limit, totalCount)
   }
 }

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -1,26 +1,63 @@
 const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 module.exports = class ValidatorsDAO {
-  constructor (knex) {
+  constructor(knex) {
     this.knex = knex
   }
 
   getValidatorByProTxHash = async (proTxHash) => {
     const [row] = await this.knex('validators')
+      .leftJoin('blocks', 'validators.pro_tx_hash', 'blocks.validator')
       .select(
         'validators.pro_tx_hash as pro_tx_hash',
         this.knex('blocks')
+          .select('timestamp')
           .where('validator', proTxHash)
-          .select(this.knex.raw('MAX(timestamp) as latest_timestamp')).as('latest_timestamp'),
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('latest_timestamp'),
+        this.knex('blocks')
+          .select('height')
+          .where('validator', proTxHash)
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('latest_height'),
         this.knex('blocks')
           .where('validator', proTxHash)
-          .select(this.knex.raw('MAX(height) as latest_height')).as('latest_height'),
+          .count('*')
+          .as('blocks_count'),
         this.knex('blocks')
-          .where('validator', proTxHash)
-          .select(this.knex.raw('CAST( COUNT(*) as INT) as blocks_count')).as('blocks_count')
+          .where('blocks.height', this.knex('blocks').max('height').where('validator', proTxHash))
+          .select('hash')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('block_hash'),
+        this.knex('blocks')
+          .where('blocks.height', this.knex('blocks').max('height').where('validator', proTxHash))
+          .select('l1_locked_height')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('l1_locked_height'),
+        this.knex('blocks')
+          .where('blocks.height', this.knex('blocks').max('height').where('validator', proTxHash))
+          .select('created_at')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('created_at'),
+        this.knex('blocks')
+          .where('blocks.height', this.knex('blocks').max('height').where('validator', proTxHash))
+          .select('app_version')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('app_version'),
+        this.knex('blocks')
+          .where('blocks.height', this.knex('blocks').max('height').where('validator', proTxHash))
+          .select('block_version')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('block_version'),
       )
       .where('validators.pro_tx_hash', proTxHash)
-
     if (!row) {
       return null
     }
@@ -38,28 +75,78 @@ module.exports = class ValidatorsDAO {
         'validators.pro_tx_hash as pro_tx_hash',
         'id',
         this.knex('blocks')
-          .whereRaw('pro_tx_hash = validator')
-          .select(this.knex.raw('MAX(timestamp) as latest_timestamp')).as('latest_timestamp'),
+          .count('*')
+          .whereRaw('validators.pro_tx_hash = blocks.validator')
+          .as('blocks_count'),
         this.knex('blocks')
-          .whereRaw('pro_tx_hash = validator')
-          .select(this.knex.raw('MAX(height) as latest_height')).as('latest_height'),
+          .select('height')
+          .whereRaw('validators.pro_tx_hash = blocks.validator')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('latest_height'),
         this.knex('blocks')
-          .whereRaw('pro_tx_hash = validator')
-          .select(this.knex.raw('CAST( COUNT(*) as INT) as blocks_count')).as('blocks_count'))
+          .select('timestamp')
+          .whereRaw('validators.pro_tx_hash = blocks.validator')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('latest_timestamp'),
+        this.knex('blocks')
+          .select('hash')
+          .whereRaw('validators.pro_tx_hash = blocks.validator')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('block_hash'),
+        this.knex('blocks')
+          .select('l1_locked_height')
+          .whereRaw('validators.pro_tx_hash = blocks.validator')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('l1_locked_height'),
+        this.knex('blocks')
+          .select('created_at')
+          .whereRaw('validators.pro_tx_hash = blocks.validator')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('created_at'),
+        this.knex('blocks')
+          .select('app_version')
+          .whereRaw('validators.pro_tx_hash = blocks.validator')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('app_version'),
+        this.knex('blocks')
+          .select('block_version')
+          .whereRaw('validators.pro_tx_hash = blocks.validator')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('block_version'),
+      )
       .select(this.knex.raw(`rank() over (order by id ${order}) rank`))
       .as('validators')
 
     const rows = await this.knex(subquery)
-      .select('id', 'rank', 'total_count', 'pro_tx_hash', 'blocks_count', 'latest_height', 'latest_timestamp')
+      .select(
+        'id',
+        'rank',
+        'pro_tx_hash',
+        'total_count',
+        'latest_height',
+        'latest_timestamp',
+        'blocks_count',
+        'block_hash',
+        'l1_locked_height',
+        'created_at',
+        'app_version',
+        'block_version'
+      )
       .whereBetween('rank', [fromRank, toRank])
       .orderBy('id', order)
 
-    const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 
+    const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
     const resultSet = rows.map((row) =>
       Validator.fromRow(row)
     )
-
     return new PaginatedResultSet(resultSet, page, limit, totalCount)
   }
 }

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -1,7 +1,7 @@
 const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 module.exports = class ValidatorsDAO {
-  constructor(knex) {
+  constructor (knex) {
     this.knex = knex
   }
 
@@ -55,7 +55,7 @@ module.exports = class ValidatorsDAO {
           .select('block_version')
           .orderBy('height', 'desc')
           .limit(1)
-          .as('block_version'),
+          .as('block_version')
       )
       .where('validators.pro_tx_hash', proTxHash)
     if (!row) {
@@ -119,7 +119,7 @@ module.exports = class ValidatorsDAO {
           .whereRaw('validators.pro_tx_hash = blocks.validator')
           .orderBy('height', 'desc')
           .limit(1)
-          .as('block_version'),
+          .as('block_version')
       )
       .select(this.knex.raw(`rank() over (order by id ${order}) rank`))
       .as('validators')
@@ -141,7 +141,6 @@ module.exports = class ValidatorsDAO {
       )
       .whereBetween('rank', [fromRank, toRank])
       .orderBy('id', order)
-
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
     const resultSet = rows.map((row) =>

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -3,7 +3,7 @@ const PaginatedResultSet = require('../models/PaginatedResultSet')
 const { validator } = require('../../test/utils/fixtures')
 
 module.exports = class ValidatorsDAO {
-  constructor(knex) {
+  constructor (knex) {
     this.knex = knex
   }
 

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -2,30 +2,58 @@ const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 
 module.exports = class ValidatorsDAO {
-  constructor (knex) {
+  constructor(knex) {
     this.knex = knex
   }
 
   getValidatorByProTxHash = async (proTxHash) => {
-    const [row] = await this.knex('validators')
+    const validatorsSubquery = this.knex('validators')
       .select(
         'validators.pro_tx_hash as pro_tx_hash',
+        'validators.id',
         this.knex('blocks')
-          .where('validator', proTxHash)
           .count('*')
+          .whereRaw('blocks.validator = validators.pro_tx_hash')
           .as('proposed_blocks_amount'),
-        'blocks.timestamp as latest_timestamp',
-        'blocks.hash as block_hash',
-        'blocks.l1_locked_height as l1_locked_height',
-        'blocks.created_at as created_at',
-        'blocks.app_version as app_version',
-        'blocks.block_version as block_version',
-        'blocks.height as latest_height'
+        this.knex('blocks')
+          .select('hash')
+          .whereRaw('pro_tx_hash = blocks.validator')
+          .orderBy('height', 'desc')
+          .limit(1)
+          .as('proposed_block_hash')
       )
-      .rightJoin('blocks', 'blocks.validator', 'pro_tx_hash')
-      .orderBy('blocks.height', 'desc')
-      .where('validators.pro_tx_hash', proTxHash)
+      .where('validators.pro_tx_hash', proTxHash) // Добавляем это условие, чтобы искать только по нужному pro_tx_hash
+      .as('validators');
 
+    const subquery = this.knex(validatorsSubquery)
+      .select(
+        'pro_tx_hash',
+        'id',
+        'proposed_blocks_amount',
+        'blocks.hash as block_hash',
+        'blocks.height as latest_height',
+        'blocks.timestamp as latest_timestamp',
+        'blocks.l1_locked_height as l1_locked_height',
+        'blocks.app_version as app_version',
+        'blocks.block_version as block_version'
+      )
+      .leftJoin('blocks', 'blocks.hash', 'proposed_block_hash')
+      .as('blocks');
+
+    const [row] = await this.knex(subquery)
+      .select(
+        'id',
+        'pro_tx_hash',
+        'proposed_blocks_amount',
+        'block_hash',
+        'latest_height',
+        'latest_timestamp',
+        'l1_locked_height',
+        'app_version',
+        'block_version'
+      )
+      .where('pro_tx_hash', proTxHash) 
+    
     if (!row) {
       return null
     }

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -1,6 +1,5 @@
 const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-const { validator } = require('../../test/utils/fixtures')
 
 module.exports = class ValidatorsDAO {
   constructor (knex) {
@@ -45,10 +44,10 @@ module.exports = class ValidatorsDAO {
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 
-    const pro_tx_hashes = rows.map((row) => row.pro_tx_hash)
+    const proTxHashes = rows.map((row) => row.pro_tx_hash)
 
     const proposedBlocks = await this.knex('blocks')
-      .whereIn('validator', pro_tx_hashes)
+      .whereIn('validator', proTxHashes)
       .select(
         'validator as pro_tx_hash',
         this.knex.raw('MAX(timestamp) as latest_timestamp'),

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -22,10 +22,10 @@ module.exports = class ValidatorsDAO {
           .limit(1)
           .as('proposed_block_hash')
       )
-      .where('validators.pro_tx_hash', proTxHash) // Добавляем это условие, чтобы искать только по нужному pro_tx_hash
+      .where('validators.pro_tx_hash', proTxHash)
       .as('validators')
 
-    const subquery = this.knex(validatorsSubquery)
+    const [row] = await this.knex(validatorsSubquery)
       .select(
         'pro_tx_hash',
         'id',
@@ -38,20 +38,6 @@ module.exports = class ValidatorsDAO {
         'blocks.block_version as block_version'
       )
       .leftJoin('blocks', 'blocks.hash', 'proposed_block_hash')
-      .as('blocks')
-
-    const [row] = await this.knex(subquery)
-      .select(
-        'id',
-        'pro_tx_hash',
-        'proposed_blocks_amount',
-        'block_hash',
-        'latest_height',
-        'latest_timestamp',
-        'l1_locked_height',
-        'app_version',
-        'block_version'
-      )
       .where('pro_tx_hash', proTxHash)
 
     if (!row) {

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -1,6 +1,6 @@
 const Validator = require('../models/Validator')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-
+//
 module.exports = class ValidatorsDAO {
   constructor (knex) {
     this.knex = knex

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -1,7 +1,7 @@
 module.exports = class Validator {
   proTxHash
+  blocksCount
   propsedBlock
-
   constructor (
     proTxHash,
     latestHeight,
@@ -13,12 +13,12 @@ module.exports = class Validator {
     blockVersion
   ) {
     this.proTxHash = proTxHash
+    this.blocksCount = Number(blocksCount)
     this.propsedBlock = {
       header: {
-        latestHeight,
-        latestTimestamp,
-        blocksCount: Number(blocksCount),
-        blockHash,
+        hash: blockHash,
+        height: latestHeight,
+        timestamp: latestTimestamp,
         l1LockedHeight,
         appVersion,
         blockVersion

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -1,65 +1,26 @@
+const BlockHeader = require('./BlockHeader')
+
 module.exports = class Validator {
   proTxHash
-  blocksCount
+  proposedBlocksAmount
   lastProposedBlockHeader
-  constructor (
-    proTxHash,
-    latestHeight,
-    latestTimestamp,
-    blocksCount,
-    blockHash,
-    l1LockedHeight,
-    appVersion,
-    blockVersion
-  ) {
+
+  constructor (proTxHash, proposedBlocksAmount, lastProposedBlockHeader) {
     this.proTxHash = proTxHash
-    this.blocksCount = Number(blocksCount)
-    this.lastProposedBlockHeader = blockHash
-      ? {
-          hash: blockHash,
-          height: latestHeight,
-          timestamp: latestTimestamp,
-          l1LockedHeight,
-          appVersion,
-          blockVersion
-        }
-      : null
+    this.proposedBlocksAmount = Number(proposedBlocksAmount)
+    this.lastProposedBlockHeader = lastProposedBlockHeader ?? null
   }
-  // хедер оставь
-  // мы транзакции не грузим
-  // и не пропозд
-  // а lastProposedBlock
-  // можно lastProposedBlockHeader
-  // Вебкам-форель [bmd.GG] — Сегодня, в 20:11
-  // хорошо
-  // pshenmic — Сегодня, в 20:11
-  // все равно не правильно
-  // ну вернее
-  // короче сделаешь чтобы опциональное поле было
-  // pshenmic — Сегодня, в 20:11
-  // по этому полю проверяй
-  // либо нулл, либо объект типа блокхедер
 
   /* eslint-disable camelcase */
   static fromRow ({
     pro_tx_hash,
-    latest_height,
-    latest_timestamp,
-    blocks_count,
-    block_hash,
-    l1_locked_height,
-    app_version,
-    block_version
+    proposed_blocks_amount,
+    last_proposed_block_header
   }) {
     return new Validator(
       pro_tx_hash,
-      latest_height,
-      latest_timestamp,
-      blocks_count,
-      block_hash,
-      l1_locked_height,
-      app_version,
-      block_version
+      proposed_blocks_amount,
+      last_proposed_block_header ? BlockHeader.fromRow(last_proposed_block_header) : null
     )
   }
   /* eslint-disable camelcase */

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -4,7 +4,7 @@ module.exports = class Validator {
   latestTimestamp
   blocksCount
 
-  constructor(proTxHash, latestHeight, latestTimestamp, blocksCount) {
+  constructor (proTxHash, latestHeight, latestTimestamp, blocksCount) {
     this.proTxHash = proTxHash
     this.latestHeight = latestHeight
     this.latestTimestamp = latestTimestamp
@@ -12,7 +12,7 @@ module.exports = class Validator {
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow({ pro_tx_hash, latest_height, latest_timestamp, blocks_count }) {
+  static fromRow ({ pro_tx_hash, latest_height, latest_timestamp, blocks_count }) {
     return new Validator(pro_tx_hash, latest_height, latest_timestamp, blocks_count)
   }
 }

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -1,18 +1,51 @@
 module.exports = class Validator {
   proTxHash
-  latestHeight
-  latestTimestamp
-  blocksCount
+  propsedBlock
 
-  constructor (proTxHash, latestHeight, latestTimestamp, blocksCount) {
+  constructor(
+    proTxHash,
+    latestHeight,
+    latestTimestamp,
+    blocksCount,
+    blockHash,
+    l1LockedHeight,
+    appVersion,
+    blockVersion
+  ) {
     this.proTxHash = proTxHash
-    this.latestHeight = latestHeight
-    this.latestTimestamp = latestTimestamp
-    this.blocksCount = blocksCount
+    this.propsedBlock = {
+      header: {
+        latestHeight: latestHeight,
+        latestTimestamp: latestTimestamp,
+        blocksCount: Number(blocksCount),
+        blockHash: blockHash,
+        l1LockedHeight: l1LockedHeight,
+        appVersion: appVersion,
+        blockVersion: blockVersion
+      }
+    }
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow ({ pro_tx_hash, latest_height, latest_timestamp, blocks_count }) {
-    return new Validator(pro_tx_hash, latest_height, latest_timestamp, blocks_count)
+  static fromRow({
+    pro_tx_hash,
+    latest_height,
+    latest_timestamp,
+    blocks_count,
+    block_hash,
+    l1_locked_height,
+    app_version,
+    block_version
+  }) {
+    return new Validator(
+      pro_tx_hash,
+      latest_height,
+      latest_timestamp,
+      blocks_count,
+      block_hash,
+      l1_locked_height,
+      app_version,
+      block_version
+    )
   }
 }

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -26,7 +26,7 @@ module.exports = class Validator {
     }
   }
 
-  // eslint-disable-next-line camelcase
+  /* eslint-disable camelcase */
   static fromRow ({
     pro_tx_hash,
     latest_height,
@@ -48,4 +48,5 @@ module.exports = class Validator {
       block_version
     )
   }
+  /* eslint-disable camelcase */
 }

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -1,12 +1,18 @@
 module.exports = class Validator {
   proTxHash
+  latestHeight
+  latestTimestamp
+  blocksCount
 
-  constructor (proTxHash) {
+  constructor(proTxHash, latestHeight, latestTimestamp, blocksCount) {
     this.proTxHash = proTxHash
+    this.latestHeight = latestHeight
+    this.latestTimestamp = latestTimestamp
+    this.blocksCount = blocksCount
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow ({ pro_tx_hash }) {
-    return new Validator(pro_tx_hash)
+  static fromRow({ pro_tx_hash, latest_height, latest_timestamp, blocks_count }) {
+    return new Validator(pro_tx_hash, latest_height, latest_timestamp, blocks_count)
   }
 }

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -2,7 +2,7 @@ module.exports = class Validator {
   proTxHash
   propsedBlock
 
-  constructor(
+  constructor (
     proTxHash,
     latestHeight,
     latestTimestamp,
@@ -15,19 +15,19 @@ module.exports = class Validator {
     this.proTxHash = proTxHash
     this.propsedBlock = {
       header: {
-        latestHeight: latestHeight,
-        latestTimestamp: latestTimestamp,
+        latestHeight,
+        latestTimestamp,
         blocksCount: Number(blocksCount),
-        blockHash: blockHash,
-        l1LockedHeight: l1LockedHeight,
-        appVersion: appVersion,
-        blockVersion: blockVersion
+        blockHash,
+        l1LockedHeight,
+        appVersion,
+        blockVersion
       }
     }
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow({
+  static fromRow ({
     pro_tx_hash,
     latest_height,
     latest_timestamp,

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -1,3 +1,4 @@
+/* eslint-disable camelcase */
 const BlockHeader = require('./BlockHeader')
 
 module.exports = class Validator {
@@ -10,12 +11,11 @@ module.exports = class Validator {
     proposedBlocksAmount,
     lastProposedBlockHeader
   ) {
-    this.proTxHash = proTxHash
-    this.proposedBlocksAmount = Number(proposedBlocksAmount)
-    this.lastProposedBlockHeader = lastProposedBlockHeader
+    this.proTxHash = proTxHash ?? null
+    this.proposedBlocksAmount = proposedBlocksAmount ?? null
+    this.lastProposedBlockHeader = lastProposedBlockHeader ?? null
   }
 
-  /* eslint-disable camelcase */
   static fromRow ({
     pro_tx_hash,
     proposed_blocks_amount,
@@ -28,19 +28,19 @@ module.exports = class Validator {
   }) {
     return new Validator(
       pro_tx_hash,
-      proposed_blocks_amount,
+      Number(proposed_blocks_amount),
       block_hash
         ? BlockHeader.fromRow({
           hash: block_hash,
-          height: latest_height,
+          height: Number(latest_height),
           timestamp: latest_timestamp,
-          block_version,
-          app_version,
-          l1_locked_height,
+          block_version: Number(block_version),
+          app_version: Number(app_version),
+          l1_locked_height: Number(l1_locked_height),
           validator: pro_tx_hash
         })
         : null
     )
   }
-  /* eslint-disable camelcase */
 }
+/* eslint-disable camelcase */

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -1,7 +1,7 @@
 module.exports = class Validator {
   proTxHash
   blocksCount
-  propsedBlock
+  lastProposedBlockHeader
   constructor (
     proTxHash,
     latestHeight,
@@ -14,17 +14,31 @@ module.exports = class Validator {
   ) {
     this.proTxHash = proTxHash
     this.blocksCount = Number(blocksCount)
-    this.propsedBlock = {
-      header: {
-        hash: blockHash,
-        height: latestHeight,
-        timestamp: latestTimestamp,
-        l1LockedHeight,
-        appVersion,
-        blockVersion
-      }
-    }
+    this.lastProposedBlockHeader = blockHash
+      ? {
+          hash: blockHash,
+          height: latestHeight,
+          timestamp: latestTimestamp,
+          l1LockedHeight,
+          appVersion,
+          blockVersion
+        }
+      : null
   }
+  // хедер оставь
+  // мы транзакции не грузим
+  // и не пропозд
+  // а lastProposedBlock
+  // можно lastProposedBlockHeader
+  // Вебкам-форель [bmd.GG] — Сегодня, в 20:11
+  // хорошо
+  // pshenmic — Сегодня, в 20:11
+  // все равно не правильно
+  // ну вернее
+  // короче сделаешь чтобы опциональное поле было
+  // pshenmic — Сегодня, в 20:11
+  // по этому полю проверяй
+  // либо нулл, либо объект типа блокхедер
 
   /* eslint-disable camelcase */
   static fromRow ({

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -5,22 +5,39 @@ module.exports = class Validator {
   proposedBlocksAmount
   lastProposedBlockHeader
 
-  constructor (proTxHash, proposedBlocksAmount, lastProposedBlockHeader) {
+  constructor(
+    proTxHash,
+    proposedBlocksAmount,
+    lastProposedBlockHeader,
+  ) {
     this.proTxHash = proTxHash
     this.proposedBlocksAmount = Number(proposedBlocksAmount)
-    this.lastProposedBlockHeader = lastProposedBlockHeader ?? null
+    this.lastProposedBlockHeader = lastProposedBlockHeader
   }
 
   /* eslint-disable camelcase */
-  static fromRow ({
+  static fromRow({
     pro_tx_hash,
     proposed_blocks_amount,
-    last_proposed_block_header
+    latest_height,
+    latest_timestamp,
+    block_hash,
+    l1_locked_height,
+    app_version,
+    block_version
   }) {
     return new Validator(
       pro_tx_hash,
       proposed_blocks_amount,
-      last_proposed_block_header ? BlockHeader.fromRow(last_proposed_block_header) : null
+      block_hash ? BlockHeader.fromRow({
+        hash: block_hash,
+        height: latest_height,
+        timestamp: latest_timestamp,
+        block_version,
+        app_version,
+        l1_locked_height,
+        validator: pro_tx_hash
+      }) : null
     )
   }
   /* eslint-disable camelcase */

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -5,10 +5,10 @@ module.exports = class Validator {
   proposedBlocksAmount
   lastProposedBlockHeader
 
-  constructor(
+  constructor (
     proTxHash,
     proposedBlocksAmount,
-    lastProposedBlockHeader,
+    lastProposedBlockHeader
   ) {
     this.proTxHash = proTxHash
     this.proposedBlocksAmount = Number(proposedBlocksAmount)
@@ -16,7 +16,7 @@ module.exports = class Validator {
   }
 
   /* eslint-disable camelcase */
-  static fromRow({
+  static fromRow ({
     pro_tx_hash,
     proposed_blocks_amount,
     latest_height,
@@ -29,15 +29,17 @@ module.exports = class Validator {
     return new Validator(
       pro_tx_hash,
       proposed_blocks_amount,
-      block_hash ? BlockHeader.fromRow({
-        hash: block_hash,
-        height: latest_height,
-        timestamp: latest_timestamp,
-        block_version,
-        app_version,
-        l1_locked_height,
-        validator: pro_tx_hash
-      }) : null
+      block_hash
+        ? BlockHeader.fromRow({
+          hash: block_hash,
+          height: latest_height,
+          timestamp: latest_timestamp,
+          block_version,
+          app_version,
+          l1_locked_height,
+          validator: pro_tx_hash
+        })
+        : null
     )
   }
   /* eslint-disable camelcase */

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -11,6 +11,7 @@ describe('Validators routes', () => {
   let knex
 
   let validators
+  let blocks
 
   before(async () => {
     app = await server.start()
@@ -18,12 +19,17 @@ describe('Validators routes', () => {
 
     knex = getKnex()
     validators = []
+    blocks = []
 
     await fixtures.cleanup(knex)
 
-    for (let i = 0; i < 30; i++) {
+    for (let i = 1; i < 31; i++) {
       const validator = await fixtures.validator(knex)
       validators.push(validator)
+      for (let b = 1; b < 5; b++) {
+        const block = await fixtures.block(knex, { validator: validator.pro_tx_hash, height: i * b + 1 })
+        blocks.push(block)
+      }
     }
   })
 
@@ -40,8 +46,15 @@ describe('Validators routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
+
+      const lastBlocks = blocks.filter((block) => block.validator === body.proTxHash).sort((a, b) => b.height - a.height)
+      const [lastBlock] = lastBlocks
+
       const expectedValidator = {
-        proTxHash: validator.pro_tx_hash
+        proTxHash: validator.pro_tx_hash,
+        latestHeight: lastBlock.height,
+        latestTimestamp: lastBlock.timestamp.toISOString(),
+        blocksCount: lastBlocks.length,
       }
 
       assert.deepEqual(expectedValidator, body)
@@ -67,9 +80,16 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(0, 10)
-        .map(row => ({
-          proTxHash: row.pro_tx_hash
-        }))
+        .map(row => {
+          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
+          const [lastBlock] = lastBlocks
+          return ({
+            proTxHash: row.pro_tx_hash,
+            latestHeight: lastBlock.height,
+            latestTimestamp: lastBlock.timestamp.toISOString(),
+            blocksCount: lastBlocks.length,
+          })
+        })
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -87,9 +107,16 @@ describe('Validators routes', () => {
       const expectedValidators = validators
         .slice(validators.length - 10, validators.length)
         .sort((a, b) => b.id - a.id)
-        .map(row => ({
-          proTxHash: row.pro_tx_hash
-        }))
+        .map(row => {
+          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
+          const [lastBlock] = lastBlocks
+          return ({
+            proTxHash: row.pro_tx_hash,
+            latestHeight: lastBlock.height,
+            latestTimestamp: lastBlock.timestamp.toISOString(),
+            blocksCount: lastBlocks.length,
+          })
+        })
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -106,9 +133,16 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(10, 20)
-        .map(row => ({
-          proTxHash: row.pro_tx_hash
-        }))
+        .map(row => {
+          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
+          const [lastBlock] = lastBlocks
+          return ({
+            proTxHash: row.pro_tx_hash,
+            latestHeight: lastBlock.height,
+            latestTimestamp: lastBlock.timestamp.toISOString(),
+            blocksCount: lastBlocks.length,
+          })
+        })
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -125,9 +159,16 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(0, 7)
-        .map(row => ({
-          proTxHash: row.pro_tx_hash
-        }))
+        .map(row => {
+          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
+          const [lastBlock] = lastBlocks
+          return ({
+            proTxHash: row.pro_tx_hash,
+            latestHeight: lastBlock.height,
+            latestTimestamp: lastBlock.timestamp.toISOString(),
+            blocksCount: lastBlocks.length,
+          })
+        })
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -144,9 +185,16 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(7, 14)
-        .map(row => ({
-          proTxHash: row.pro_tx_hash
-        }))
+        .map(row => {
+          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
+          const [lastBlock] = lastBlocks
+          return ({
+            proTxHash: row.pro_tx_hash,
+            latestHeight: lastBlock.height,
+            latestTimestamp: lastBlock.timestamp.toISOString(),
+            blocksCount: lastBlocks.length,
+          })
+        })
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -164,9 +212,16 @@ describe('Validators routes', () => {
       const expectedValidators = validators
         .sort((a, b) => b.id - a.id)
         .slice(21, 28)
-        .map(row => ({
-          proTxHash: row.pro_tx_hash
-        }))
+        .map(row => {
+          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
+          const [lastBlock] = lastBlocks
+          return ({
+            proTxHash: row.pro_tx_hash,
+            latestHeight: lastBlock.height,
+            latestTimestamp: lastBlock.timestamp.toISOString(),
+            blocksCount: lastBlocks.length,
+          })
+        })
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -184,9 +239,16 @@ describe('Validators routes', () => {
       const expectedValidators = validators
         .sort((a, b) => b.id - a.id)
         .slice(28, 30)
-        .map(row => ({
-          proTxHash: row.pro_tx_hash
-        }))
+        .map(row => {
+          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
+          const [lastBlock] = lastBlocks
+          return ({
+            proTxHash: row.pro_tx_hash,
+            latestHeight: lastBlock.height,
+            latestTimestamp: lastBlock.timestamp.toISOString(),
+            blocksCount: lastBlocks.length,
+          })
+        })
       assert.deepEqual(expectedValidators, body.resultSet)
     })
 

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -56,11 +56,16 @@ describe('Validators routes', () => {
         proposedBlocksAmount: blocks.filter((block) => block.validator === validator.pro_tx_hash).length,
         lastProposedBlockHeader: blocks
           .filter((block) => block.validator === validator.pro_tx_hash)
-          .map((block) => {
-            const { ...blockHeader } = BlockHeader.fromRow(block)
-            blockHeader.timestamp = blockHeader.timestamp.toISOString()
-            return blockHeader
-          })
+          .map((block) => BlockHeader.fromRow(block))
+          .map((blockHeader) => ({
+            hash: blockHeader.hash,
+            height: blockHeader.height,
+            timestamp: blockHeader.timestamp.toISOString(),
+            blockVersion: blockHeader.blockVersion,
+            appVersion: blockHeader.appVersion,
+            l1LockedHeight: blockHeader.l1LockedHeight,
+            validator: blockHeader.validator
+          }))
           .toReversed()[0] ?? null
       }
 
@@ -92,11 +97,16 @@ describe('Validators routes', () => {
           proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
           lastProposedBlockHeader: blocks
             .filter((block) => block.validator === row.pro_tx_hash)
-            .map((block) => {
-              const { ...blockHeader } = BlockHeader.fromRow(block)
-              blockHeader.timestamp = blockHeader.timestamp.toISOString()
-              return blockHeader
-            })
+            .map((block) => BlockHeader.fromRow(block))
+            .map((blockHeader) => ({
+              hash: blockHeader.hash,
+              height: blockHeader.height,
+              timestamp: blockHeader.timestamp.toISOString(),
+              blockVersion: blockHeader.blockVersion,
+              appVersion: blockHeader.appVersion,
+              l1LockedHeight: blockHeader.l1LockedHeight,
+              validator: blockHeader.validator
+            }))
             .toReversed()[0] ?? null
         }))
 
@@ -116,20 +126,23 @@ describe('Validators routes', () => {
       const expectedValidators = validators
         .slice(validators.length - 10, validators.length)
         .sort((a, b) => b.id - a.id)
-        .map(row => {
-          return {
-            proTxHash: row.pro_tx_hash,
-            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            lastProposedBlockHeader: blocks
-              .filter((block) => block.validator === row.pro_tx_hash)
-              .map((block) => {
-                const { ...blockHeader } = BlockHeader.fromRow(block)
-                blockHeader.timestamp = blockHeader.timestamp.toISOString()
-                return blockHeader
-              })
-              .toReversed()[0] ?? null
-          }
-        })
+        .map(row => ({
+          proTxHash: row.pro_tx_hash,
+          proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+          lastProposedBlockHeader: blocks
+            .filter((block) => block.validator === row.pro_tx_hash)
+            .map((block) => BlockHeader.fromRow(block))
+            .map((blockHeader) => ({
+              hash: blockHeader.hash,
+              height: blockHeader.height,
+              timestamp: blockHeader.timestamp.toISOString(),
+              blockVersion: blockHeader.blockVersion,
+              appVersion: blockHeader.appVersion,
+              l1LockedHeight: blockHeader.l1LockedHeight,
+              validator: blockHeader.validator
+            }))
+            .toReversed()[0] ?? null
+        }))
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -151,14 +164,18 @@ describe('Validators routes', () => {
           proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
           lastProposedBlockHeader: blocks
             .filter((block) => block.validator === row.pro_tx_hash)
-            .map((block) => {
-              const { ...blockHeader } = BlockHeader.fromRow(block)
-              blockHeader.timestamp = blockHeader.timestamp.toISOString()
-              return blockHeader
-            })
+            .map((block) => BlockHeader.fromRow(block))
+            .map((blockHeader) => ({
+              hash: blockHeader.hash,
+              height: blockHeader.height,
+              timestamp: blockHeader.timestamp.toISOString(),
+              blockVersion: blockHeader.blockVersion,
+              appVersion: blockHeader.appVersion,
+              l1LockedHeight: blockHeader.l1LockedHeight,
+              validator: blockHeader.validator
+            }))
             .toReversed()[0] ?? null
-        })
-        )
+        }))
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -180,11 +197,16 @@ describe('Validators routes', () => {
           proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
           lastProposedBlockHeader: blocks
             .filter((block) => block.validator === row.pro_tx_hash)
-            .map((block) => {
-              const { ...blockHeader } = BlockHeader.fromRow(block)
-              blockHeader.timestamp = blockHeader.timestamp.toISOString()
-              return blockHeader
-            })
+            .map((block) => BlockHeader.fromRow(block))
+            .map((blockHeader) => ({
+              hash: blockHeader.hash,
+              height: blockHeader.height,
+              timestamp: blockHeader.timestamp.toISOString(),
+              blockVersion: blockHeader.blockVersion,
+              appVersion: blockHeader.appVersion,
+              l1LockedHeight: blockHeader.l1LockedHeight,
+              validator: blockHeader.validator
+            }))
             .toReversed()[0] ?? null
         }))
 
@@ -208,11 +230,16 @@ describe('Validators routes', () => {
           proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
           lastProposedBlockHeader: blocks
             .filter((block) => block.validator === row.pro_tx_hash)
-            .map((block) => {
-              const { ...blockHeader } = BlockHeader.fromRow(block)
-              blockHeader.timestamp = blockHeader.timestamp.toISOString()
-              return blockHeader
-            })
+            .map((block) => BlockHeader.fromRow(block))
+            .map((blockHeader) => ({
+              hash: blockHeader.hash,
+              height: blockHeader.height,
+              timestamp: blockHeader.timestamp.toISOString(),
+              blockVersion: blockHeader.blockVersion,
+              appVersion: blockHeader.appVersion,
+              l1LockedHeight: blockHeader.l1LockedHeight,
+              validator: blockHeader.validator
+            }))
             .toReversed()[0] ?? null
         }))
 
@@ -237,11 +264,16 @@ describe('Validators routes', () => {
           proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
           lastProposedBlockHeader: blocks
             .filter((block) => block.validator === row.pro_tx_hash)
-            .map((block) => {
-              const { ...blockHeader } = BlockHeader.fromRow(block)
-              blockHeader.timestamp = blockHeader.timestamp.toISOString()
-              return blockHeader
-            })
+            .map((block) => BlockHeader.fromRow(block))
+            .map((blockHeader) => ({
+              hash: blockHeader.hash,
+              height: blockHeader.height,
+              timestamp: blockHeader.timestamp.toISOString(),
+              blockVersion: blockHeader.blockVersion,
+              appVersion: blockHeader.appVersion,
+              l1LockedHeight: blockHeader.l1LockedHeight,
+              validator: blockHeader.validator
+            }))
             .toReversed()[0] ?? null
         }))
 
@@ -265,11 +297,16 @@ describe('Validators routes', () => {
           proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
           lastProposedBlockHeader: blocks
             .filter((block) => block.validator === row.pro_tx_hash)
-            .map((block) => {
-              const { ...blockHeader } = BlockHeader.fromRow(block)
-              blockHeader.timestamp = blockHeader.timestamp.toISOString()
-              return blockHeader
-            })
+            .map((block) => BlockHeader.fromRow(block))
+            .map((blockHeader) => ({
+              hash: blockHeader.hash,
+              height: blockHeader.height,
+              timestamp: blockHeader.timestamp.toISOString(),
+              blockVersion: blockHeader.blockVersion,
+              appVersion: blockHeader.appVersion,
+              l1LockedHeight: blockHeader.l1LockedHeight,
+              validator: blockHeader.validator
+            }))
             .toReversed()[0] ?? null
         }))
 

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -4,6 +4,7 @@ const supertest = require('supertest')
 const server = require('../../src/server')
 const fixtures = require('../utils/fixtures')
 const { getKnex } = require('../../src/utils')
+const BlockHeader = require('../../src/models/BlockHeader')
 
 describe('Validators routes', () => {
   let app
@@ -31,7 +32,6 @@ describe('Validators routes', () => {
     for (let i = 1; i <= 50; i++) {
       const block = await fixtures.block(
         knex,
-        // { validator: validators[i % 2].pro_tx_hash, height: i }
         { validator: validators[i % 24].pro_tx_hash, height: i }
       )
       blocks.push(block)
@@ -51,22 +51,17 @@ describe('Validators routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      const [latestBlock] = blocks.filter((block) => block.validator === validator.pro_tx_hash).toReversed()
-
       const expectedValidator = {
         proTxHash: validator.pro_tx_hash,
         proposedBlocksAmount: blocks.filter((block) => block.validator === validator.pro_tx_hash).length,
-        lastProposedBlockHeader: latestBlock
-          ? {
-              hash: latestBlock.hash,
-              height: latestBlock.height,
-              timestamp: latestBlock.timestamp.toISOString(),
-              l1LockedHeight: latestBlock.l1_locked_height,
-              appVersion: latestBlock.app_version,
-              blockVersion: latestBlock.block_version,
-              validator: latestBlock.validator
-            }
-          : null
+        lastProposedBlockHeader: blocks
+          .filter((block) => block.validator === validator.pro_tx_hash)
+          .map((block) => {
+            const { ...blockHeader } = BlockHeader.fromRow(block)
+            blockHeader.timestamp = blockHeader.timestamp.toISOString()
+            return blockHeader
+          })
+          .toReversed()[0] ?? null
       }
 
       assert.deepEqual(expectedValidator, body)
@@ -92,25 +87,18 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(0, 10)
-        .map(row => {
-          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
-
-          return {
-            proTxHash: row.pro_tx_hash,
-            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            lastProposedBlockHeader: latestBlock
-              ? {
-                  hash: latestBlock.hash,
-                  height: latestBlock.height,
-                  timestamp: latestBlock.timestamp.toISOString(),
-                  l1LockedHeight: latestBlock.l1_locked_height,
-                  appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version,
-                  validator: latestBlock.validator
-                }
-              : null
-          }
-        })
+        .map(row => ({
+          proTxHash: row.pro_tx_hash,
+          proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+          lastProposedBlockHeader: blocks
+            .filter((block) => block.validator === row.pro_tx_hash)
+            .map((block) => {
+              const { ...blockHeader } = BlockHeader.fromRow(block)
+              blockHeader.timestamp = blockHeader.timestamp.toISOString()
+              return blockHeader
+            })
+            .toReversed()[0] ?? null
+        }))
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -129,22 +117,17 @@ describe('Validators routes', () => {
         .slice(validators.length - 10, validators.length)
         .sort((a, b) => b.id - a.id)
         .map(row => {
-          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
-
           return {
             proTxHash: row.pro_tx_hash,
             proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            lastProposedBlockHeader: latestBlock
-              ? {
-                  hash: latestBlock.hash,
-                  height: latestBlock.height,
-                  timestamp: latestBlock.timestamp.toISOString(),
-                  l1LockedHeight: latestBlock.l1_locked_height,
-                  appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version,
-                  validator: latestBlock.validator
-                }
-              : null
+            lastProposedBlockHeader: blocks
+              .filter((block) => block.validator === row.pro_tx_hash)
+              .map((block) => {
+                const { ...blockHeader } = BlockHeader.fromRow(block)
+                blockHeader.timestamp = blockHeader.timestamp.toISOString()
+                return blockHeader
+              })
+              .toReversed()[0] ?? null
           }
         })
 
@@ -163,25 +146,19 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(10, 20)
-        .map(row => {
-          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
-
-          return {
-            proTxHash: row.pro_tx_hash,
-            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            lastProposedBlockHeader: latestBlock
-              ? {
-                  hash: latestBlock.hash,
-                  height: latestBlock.height,
-                  timestamp: latestBlock.timestamp.toISOString(),
-                  l1LockedHeight: latestBlock.l1_locked_height,
-                  appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version,
-                  validator: latestBlock.validator
-                }
-              : null
-          }
+        .map(row => ({
+          proTxHash: row.pro_tx_hash,
+          proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+          lastProposedBlockHeader: blocks
+            .filter((block) => block.validator === row.pro_tx_hash)
+            .map((block) => {
+              const { ...blockHeader } = BlockHeader.fromRow(block)
+              blockHeader.timestamp = blockHeader.timestamp.toISOString()
+              return blockHeader
+            })
+            .toReversed()[0] ?? null
         })
+        )
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -198,25 +175,18 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(0, 7)
-        .map(row => {
-          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
-
-          return {
-            proTxHash: row.pro_tx_hash,
-            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            lastProposedBlockHeader: latestBlock
-              ? {
-                  hash: latestBlock.hash,
-                  height: latestBlock.height,
-                  timestamp: latestBlock.timestamp.toISOString(),
-                  l1LockedHeight: latestBlock.l1_locked_height,
-                  appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version,
-                  validator: latestBlock.validator
-                }
-              : null
-          }
-        })
+        .map(row => ({
+          proTxHash: row.pro_tx_hash,
+          proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+          lastProposedBlockHeader: blocks
+            .filter((block) => block.validator === row.pro_tx_hash)
+            .map((block) => {
+              const { ...blockHeader } = BlockHeader.fromRow(block)
+              blockHeader.timestamp = blockHeader.timestamp.toISOString()
+              return blockHeader
+            })
+            .toReversed()[0] ?? null
+        }))
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -233,25 +203,18 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(7, 14)
-        .map(row => {
-          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
-
-          return {
-            proTxHash: row.pro_tx_hash,
-            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            lastProposedBlockHeader: latestBlock
-              ? {
-                  hash: latestBlock.hash,
-                  height: latestBlock.height,
-                  timestamp: latestBlock.timestamp.toISOString(),
-                  l1LockedHeight: latestBlock.l1_locked_height,
-                  appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version,
-                  validator: latestBlock.validator
-                }
-              : null
-          }
-        })
+        .map(row => ({
+          proTxHash: row.pro_tx_hash,
+          proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+          lastProposedBlockHeader: blocks
+            .filter((block) => block.validator === row.pro_tx_hash)
+            .map((block) => {
+              const { ...blockHeader } = BlockHeader.fromRow(block)
+              blockHeader.timestamp = blockHeader.timestamp.toISOString()
+              return blockHeader
+            })
+            .toReversed()[0] ?? null
+        }))
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -269,25 +232,18 @@ describe('Validators routes', () => {
       const expectedValidators = validators
         .sort((a, b) => b.id - a.id)
         .slice(15, 20)
-        .map(row => {
-          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
-
-          return {
-            proTxHash: row.pro_tx_hash,
-            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            lastProposedBlockHeader: latestBlock
-              ? {
-                  hash: latestBlock.hash,
-                  height: latestBlock.height,
-                  timestamp: latestBlock.timestamp.toISOString(),
-                  l1LockedHeight: latestBlock.l1_locked_height,
-                  appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version,
-                  validator: latestBlock.validator
-                }
-              : null
-          }
-        })
+        .map(row => ({
+          proTxHash: row.pro_tx_hash,
+          proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+          lastProposedBlockHeader: blocks
+            .filter((block) => block.validator === row.pro_tx_hash)
+            .map((block) => {
+              const { ...blockHeader } = BlockHeader.fromRow(block)
+              blockHeader.timestamp = blockHeader.timestamp.toISOString()
+              return blockHeader
+            })
+            .toReversed()[0] ?? null
+        }))
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })
@@ -304,25 +260,18 @@ describe('Validators routes', () => {
 
       const expectedValidators = validators
         .slice(20, 25)
-        .map(row => {
-          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
-
-          return {
-            proTxHash: row.pro_tx_hash,
-            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            lastProposedBlockHeader: latestBlock
-              ? {
-                  hash: latestBlock.hash,
-                  height: latestBlock.height,
-                  timestamp: latestBlock.timestamp.toISOString(),
-                  l1LockedHeight: latestBlock.l1_locked_height,
-                  appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version,
-                  validator: latestBlock.validator
-                }
-              : null
-          }
-        })
+        .map(row => ({
+          proTxHash: row.pro_tx_hash,
+          proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+          lastProposedBlockHeader: blocks
+            .filter((block) => block.validator === row.pro_tx_hash)
+            .map((block) => {
+              const { ...blockHeader } = BlockHeader.fromRow(block)
+              blockHeader.timestamp = blockHeader.timestamp.toISOString()
+              return blockHeader
+            })
+            .toReversed()[0] ?? null
+        }))
 
       assert.deepEqual(expectedValidators, body.resultSet)
     })

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -26,8 +26,8 @@ describe('Validators routes', () => {
     for (let i = 1; i < 31; i++) {
       const validator = await fixtures.validator(knex)
       validators.push(validator)
-      for (let b = 1; b < 5; b++) {
-        const block = await fixtures.block(knex, { validator: validator.pro_tx_hash, height: i * b + 1 })
+      for (let j = 1; j <= 5; j++) {
+        const block = await fixtures.block(knex, { validator: validator.pro_tx_hash, height: (i - 1) * 4 + j })
         blocks.push(block)
       }
     }
@@ -46,14 +46,21 @@ describe('Validators routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      const lastBlocks = blocks.filter((block) => block.validator === body.proTxHash).sort((a, b) => b.height - a.height)
-      const [lastBlock] = lastBlocks
+      const [latestBlock] = blocks.filter((block) => block.validator === validator.pro_tx_hash).toReversed()
 
       const expectedValidator = {
         proTxHash: validator.pro_tx_hash,
-        latestHeight: lastBlock.height,
-        latestTimestamp: lastBlock.timestamp.toISOString(),
-        blocksCount: lastBlocks.length
+        propsedBlock: {
+          header: {
+            latestHeight: latestBlock.height,
+            latestTimestamp: latestBlock.timestamp.toISOString(),
+            blocksCount: blocks.filter((block) => block.validator === validator.pro_tx_hash).length,
+            blockHash: latestBlock.hash,
+            l1LockedHeight: latestBlock.l1_locked_height,
+            appVersion: latestBlock.app_version,
+            blockVersion: latestBlock.block_version
+          }
+        }
       }
 
       assert.deepEqual(expectedValidator, body)
@@ -76,18 +83,26 @@ describe('Validators routes', () => {
       assert.equal(body.pagination.limit, 10)
       assert.equal(body.pagination.total, validators.length)
       assert.equal(body.resultSet.length, 10)
-
+      
       const expectedValidators = validators
         .slice(0, 10)
         .map(row => {
-          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
-          const [lastBlock] = lastBlocks
-          return ({
+          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
+
+          return {
             proTxHash: row.pro_tx_hash,
-            latestHeight: lastBlock.height,
-            latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length
-          })
+            propsedBlock: {
+              header: {
+                latestHeight: latestBlock.height,
+                latestTimestamp: latestBlock.timestamp.toISOString(),
+                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+                blockHash: latestBlock.hash,
+                l1LockedHeight: latestBlock.l1_locked_height,
+                appVersion: latestBlock.app_version,
+                blockVersion: latestBlock.block_version
+              }
+            }
+          }
         })
 
       assert.deepEqual(expectedValidators, body.resultSet)
@@ -107,14 +122,22 @@ describe('Validators routes', () => {
         .slice(validators.length - 10, validators.length)
         .sort((a, b) => b.id - a.id)
         .map(row => {
-          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
-          const [lastBlock] = lastBlocks
-          return ({
+          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
+
+          return {
             proTxHash: row.pro_tx_hash,
-            latestHeight: lastBlock.height,
-            latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length
-          })
+            propsedBlock: {
+              header: {
+                latestHeight: latestBlock.height,
+                latestTimestamp: latestBlock.timestamp.toISOString(),
+                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+                blockHash: latestBlock.hash,
+                l1LockedHeight: latestBlock.l1_locked_height,
+                appVersion: latestBlock.app_version,
+                blockVersion: latestBlock.block_version
+              }
+            }
+          }
         })
 
       assert.deepEqual(expectedValidators, body.resultSet)
@@ -133,14 +156,22 @@ describe('Validators routes', () => {
       const expectedValidators = validators
         .slice(10, 20)
         .map(row => {
-          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
-          const [lastBlock] = lastBlocks
-          return ({
+          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
+
+          return {
             proTxHash: row.pro_tx_hash,
-            latestHeight: lastBlock.height,
-            latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length
-          })
+            propsedBlock: {
+              header: {
+                latestHeight: latestBlock.height,
+                latestTimestamp: latestBlock.timestamp.toISOString(),
+                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+                blockHash: latestBlock.hash,
+                l1LockedHeight: latestBlock.l1_locked_height,
+                appVersion: latestBlock.app_version,
+                blockVersion: latestBlock.block_version
+              }
+            }
+          }
         })
 
       assert.deepEqual(expectedValidators, body.resultSet)
@@ -159,14 +190,22 @@ describe('Validators routes', () => {
       const expectedValidators = validators
         .slice(0, 7)
         .map(row => {
-          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
-          const [lastBlock] = lastBlocks
-          return ({
+          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
+
+          return {
             proTxHash: row.pro_tx_hash,
-            latestHeight: lastBlock.height,
-            latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length
-          })
+            propsedBlock: {
+              header: {
+                latestHeight: latestBlock.height,
+                latestTimestamp: latestBlock.timestamp.toISOString(),
+                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+                blockHash: latestBlock.hash,
+                l1LockedHeight: latestBlock.l1_locked_height,
+                appVersion: latestBlock.app_version,
+                blockVersion: latestBlock.block_version
+              }
+            }
+          }
         })
 
       assert.deepEqual(expectedValidators, body.resultSet)
@@ -185,14 +224,22 @@ describe('Validators routes', () => {
       const expectedValidators = validators
         .slice(7, 14)
         .map(row => {
-          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
-          const [lastBlock] = lastBlocks
-          return ({
+          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
+
+          return {
             proTxHash: row.pro_tx_hash,
-            latestHeight: lastBlock.height,
-            latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length
-          })
+            propsedBlock: {
+              header: {
+                latestHeight: latestBlock.height,
+                latestTimestamp: latestBlock.timestamp.toISOString(),
+                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+                blockHash: latestBlock.hash,
+                l1LockedHeight: latestBlock.l1_locked_height,
+                appVersion: latestBlock.app_version,
+                blockVersion: latestBlock.block_version
+              }
+            }
+          }
         })
 
       assert.deepEqual(expectedValidators, body.resultSet)
@@ -212,14 +259,22 @@ describe('Validators routes', () => {
         .sort((a, b) => b.id - a.id)
         .slice(21, 28)
         .map(row => {
-          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
-          const [lastBlock] = lastBlocks
-          return ({
+          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
+
+          return {
             proTxHash: row.pro_tx_hash,
-            latestHeight: lastBlock.height,
-            latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length
-          })
+            propsedBlock: {
+              header: {
+                latestHeight: latestBlock.height,
+                latestTimestamp: latestBlock.timestamp.toISOString(),
+                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+                blockHash: latestBlock.hash,
+                l1LockedHeight: latestBlock.l1_locked_height,
+                appVersion: latestBlock.app_version,
+                blockVersion: latestBlock.block_version
+              }
+            }
+          }
         })
 
       assert.deepEqual(expectedValidators, body.resultSet)
@@ -239,15 +294,24 @@ describe('Validators routes', () => {
         .sort((a, b) => b.id - a.id)
         .slice(28, 30)
         .map(row => {
-          const lastBlocks = blocks.filter((block) => block.validator === row.pro_tx_hash).sort((a, b) => b.height - a.height)
-          const [lastBlock] = lastBlocks
-          return ({
+          const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
+
+          return {
             proTxHash: row.pro_tx_hash,
-            latestHeight: lastBlock.height,
-            latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length
-          })
+            propsedBlock: {
+              header: {
+                latestHeight: latestBlock.height,
+                latestTimestamp: latestBlock.timestamp.toISOString(),
+                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+                blockHash: latestBlock.hash,
+                l1LockedHeight: latestBlock.l1_locked_height,
+                appVersion: latestBlock.app_version,
+                blockVersion: latestBlock.block_version
+              }
+            }
+          }
         })
+
       assert.deepEqual(expectedValidators, body.resultSet)
     })
 

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -50,12 +50,12 @@ describe('Validators routes', () => {
 
       const expectedValidator = {
         proTxHash: validator.pro_tx_hash,
+        blocksCount: blocks.filter((block) => block.validator === validator.pro_tx_hash).length,
         propsedBlock: {
           header: {
-            latestHeight: latestBlock.height,
-            latestTimestamp: latestBlock.timestamp.toISOString(),
-            blocksCount: blocks.filter((block) => block.validator === validator.pro_tx_hash).length,
-            blockHash: latestBlock.hash,
+            hash: latestBlock.hash,
+            height: latestBlock.height,
+            timestamp: latestBlock.timestamp.toISOString(),
             l1LockedHeight: latestBlock.l1_locked_height,
             appVersion: latestBlock.app_version,
             blockVersion: latestBlock.block_version
@@ -91,12 +91,12 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
+            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             propsedBlock: {
               header: {
-                latestHeight: latestBlock.height,
-                latestTimestamp: latestBlock.timestamp.toISOString(),
-                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-                blockHash: latestBlock.hash,
+                hash: latestBlock.hash,
+                height: latestBlock.height,
+                timestamp: latestBlock.timestamp.toISOString(),
                 l1LockedHeight: latestBlock.l1_locked_height,
                 appVersion: latestBlock.app_version,
                 blockVersion: latestBlock.block_version
@@ -126,12 +126,12 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
+            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             propsedBlock: {
               header: {
-                latestHeight: latestBlock.height,
-                latestTimestamp: latestBlock.timestamp.toISOString(),
-                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-                blockHash: latestBlock.hash,
+                hash: latestBlock.hash,
+                height: latestBlock.height,
+                timestamp: latestBlock.timestamp.toISOString(),
                 l1LockedHeight: latestBlock.l1_locked_height,
                 appVersion: latestBlock.app_version,
                 blockVersion: latestBlock.block_version
@@ -160,12 +160,12 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
+            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             propsedBlock: {
               header: {
-                latestHeight: latestBlock.height,
-                latestTimestamp: latestBlock.timestamp.toISOString(),
-                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-                blockHash: latestBlock.hash,
+                hash: latestBlock.hash,
+                height: latestBlock.height,
+                timestamp: latestBlock.timestamp.toISOString(),
                 l1LockedHeight: latestBlock.l1_locked_height,
                 appVersion: latestBlock.app_version,
                 blockVersion: latestBlock.block_version
@@ -194,12 +194,12 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
+            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             propsedBlock: {
               header: {
-                latestHeight: latestBlock.height,
-                latestTimestamp: latestBlock.timestamp.toISOString(),
-                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-                blockHash: latestBlock.hash,
+                hash: latestBlock.hash,
+                height: latestBlock.height,
+                timestamp: latestBlock.timestamp.toISOString(),
                 l1LockedHeight: latestBlock.l1_locked_height,
                 appVersion: latestBlock.app_version,
                 blockVersion: latestBlock.block_version
@@ -228,12 +228,12 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
+            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             propsedBlock: {
               header: {
-                latestHeight: latestBlock.height,
-                latestTimestamp: latestBlock.timestamp.toISOString(),
-                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-                blockHash: latestBlock.hash,
+                hash: latestBlock.hash,
+                height: latestBlock.height,
+                timestamp: latestBlock.timestamp.toISOString(),
                 l1LockedHeight: latestBlock.l1_locked_height,
                 appVersion: latestBlock.app_version,
                 blockVersion: latestBlock.block_version
@@ -263,12 +263,12 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
+            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             propsedBlock: {
               header: {
-                latestHeight: latestBlock.height,
-                latestTimestamp: latestBlock.timestamp.toISOString(),
-                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-                blockHash: latestBlock.hash,
+                hash: latestBlock.hash,
+                height: latestBlock.height,
+                timestamp: latestBlock.timestamp.toISOString(),
                 l1LockedHeight: latestBlock.l1_locked_height,
                 appVersion: latestBlock.app_version,
                 blockVersion: latestBlock.block_version
@@ -298,12 +298,12 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
+            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             propsedBlock: {
               header: {
-                latestHeight: latestBlock.height,
-                latestTimestamp: latestBlock.timestamp.toISOString(),
-                blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-                blockHash: latestBlock.hash,
+                hash: latestBlock.hash,
+                height: latestBlock.height,
+                timestamp: latestBlock.timestamp.toISOString(),
                 l1LockedHeight: latestBlock.l1_locked_height,
                 appVersion: latestBlock.app_version,
                 blockVersion: latestBlock.block_version

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -55,7 +55,7 @@ describe('Validators routes', () => {
 
       const expectedValidator = {
         proTxHash: validator.pro_tx_hash,
-        blocksCount: blocks.filter((block) => block.validator === validator.pro_tx_hash).length,
+        proposedBlocksAmount: blocks.filter((block) => block.validator === validator.pro_tx_hash).length,
         lastProposedBlockHeader: latestBlock
           ? {
               hash: latestBlock.hash,
@@ -63,7 +63,8 @@ describe('Validators routes', () => {
               timestamp: latestBlock.timestamp.toISOString(),
               l1LockedHeight: latestBlock.l1_locked_height,
               appVersion: latestBlock.app_version,
-              blockVersion: latestBlock.block_version
+              blockVersion: latestBlock.block_version,
+              validator: latestBlock.validator
             }
           : null
       }
@@ -96,7 +97,7 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
-            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             lastProposedBlockHeader: latestBlock
               ? {
                   hash: latestBlock.hash,
@@ -104,7 +105,8 @@ describe('Validators routes', () => {
                   timestamp: latestBlock.timestamp.toISOString(),
                   l1LockedHeight: latestBlock.l1_locked_height,
                   appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version
+                  blockVersion: latestBlock.block_version,
+                  validator: latestBlock.validator
                 }
               : null
           }
@@ -131,7 +133,7 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
-            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             lastProposedBlockHeader: latestBlock
               ? {
                   hash: latestBlock.hash,
@@ -139,7 +141,8 @@ describe('Validators routes', () => {
                   timestamp: latestBlock.timestamp.toISOString(),
                   l1LockedHeight: latestBlock.l1_locked_height,
                   appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version
+                  blockVersion: latestBlock.block_version,
+                  validator: latestBlock.validator
                 }
               : null
           }
@@ -165,7 +168,7 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
-            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             lastProposedBlockHeader: latestBlock
               ? {
                   hash: latestBlock.hash,
@@ -173,7 +176,8 @@ describe('Validators routes', () => {
                   timestamp: latestBlock.timestamp.toISOString(),
                   l1LockedHeight: latestBlock.l1_locked_height,
                   appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version
+                  blockVersion: latestBlock.block_version,
+                  validator: latestBlock.validator
                 }
               : null
           }
@@ -199,7 +203,7 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
-            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             lastProposedBlockHeader: latestBlock
               ? {
                   hash: latestBlock.hash,
@@ -207,7 +211,8 @@ describe('Validators routes', () => {
                   timestamp: latestBlock.timestamp.toISOString(),
                   l1LockedHeight: latestBlock.l1_locked_height,
                   appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version
+                  blockVersion: latestBlock.block_version,
+                  validator: latestBlock.validator
                 }
               : null
           }
@@ -233,7 +238,7 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
-            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             lastProposedBlockHeader: latestBlock
               ? {
                   hash: latestBlock.hash,
@@ -241,7 +246,8 @@ describe('Validators routes', () => {
                   timestamp: latestBlock.timestamp.toISOString(),
                   l1LockedHeight: latestBlock.l1_locked_height,
                   appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version
+                  blockVersion: latestBlock.block_version,
+                  validator: latestBlock.validator
                 }
               : null
           }
@@ -268,7 +274,7 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
-            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             lastProposedBlockHeader: latestBlock
               ? {
                   hash: latestBlock.hash,
@@ -276,7 +282,8 @@ describe('Validators routes', () => {
                   timestamp: latestBlock.timestamp.toISOString(),
                   l1LockedHeight: latestBlock.l1_locked_height,
                   appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version
+                  blockVersion: latestBlock.block_version,
+                  validator: latestBlock.validator
                 }
               : null
           }
@@ -302,7 +309,7 @@ describe('Validators routes', () => {
 
           return {
             proTxHash: row.pro_tx_hash,
-            blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
+            proposedBlocksAmount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
             lastProposedBlockHeader: latestBlock
               ? {
                   hash: latestBlock.hash,
@@ -310,7 +317,8 @@ describe('Validators routes', () => {
                   timestamp: latestBlock.timestamp.toISOString(),
                   l1LockedHeight: latestBlock.l1_locked_height,
                   appVersion: latestBlock.app_version,
-                  blockVersion: latestBlock.block_version
+                  blockVersion: latestBlock.block_version,
+                  validator: latestBlock.validator
                 }
               : null
           }

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -23,13 +23,18 @@ describe('Validators routes', () => {
 
     await fixtures.cleanup(knex)
 
-    for (let i = 1; i < 31; i++) {
+    for (let i = 0; i < 25; i++) {
       const validator = await fixtures.validator(knex)
       validators.push(validator)
-      for (let j = 1; j <= 5; j++) {
-        const block = await fixtures.block(knex, { validator: validator.pro_tx_hash, height: (i - 1) * 4 + j })
-        blocks.push(block)
-      }
+    }
+
+    for (let i = 1; i <= 50; i++) {
+      const block = await fixtures.block(
+        knex,
+        // { validator: validators[i % 2].pro_tx_hash, height: i }
+        { validator: validators[i % 24].pro_tx_hash, height: i }
+      )
+      blocks.push(block)
     }
   })
 
@@ -51,16 +56,16 @@ describe('Validators routes', () => {
       const expectedValidator = {
         proTxHash: validator.pro_tx_hash,
         blocksCount: blocks.filter((block) => block.validator === validator.pro_tx_hash).length,
-        propsedBlock: {
-          header: {
-            hash: latestBlock.hash,
-            height: latestBlock.height,
-            timestamp: latestBlock.timestamp.toISOString(),
-            l1LockedHeight: latestBlock.l1_locked_height,
-            appVersion: latestBlock.app_version,
-            blockVersion: latestBlock.block_version
-          }
-        }
+        lastProposedBlockHeader: latestBlock
+          ? {
+              hash: latestBlock.hash,
+              height: latestBlock.height,
+              timestamp: latestBlock.timestamp.toISOString(),
+              l1LockedHeight: latestBlock.l1_locked_height,
+              appVersion: latestBlock.app_version,
+              blockVersion: latestBlock.block_version
+            }
+          : null
       }
 
       assert.deepEqual(expectedValidator, body)
@@ -92,16 +97,16 @@ describe('Validators routes', () => {
           return {
             proTxHash: row.pro_tx_hash,
             blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            propsedBlock: {
-              header: {
-                hash: latestBlock.hash,
-                height: latestBlock.height,
-                timestamp: latestBlock.timestamp.toISOString(),
-                l1LockedHeight: latestBlock.l1_locked_height,
-                appVersion: latestBlock.app_version,
-                blockVersion: latestBlock.block_version
-              }
-            }
+            lastProposedBlockHeader: latestBlock
+              ? {
+                  hash: latestBlock.hash,
+                  height: latestBlock.height,
+                  timestamp: latestBlock.timestamp.toISOString(),
+                  l1LockedHeight: latestBlock.l1_locked_height,
+                  appVersion: latestBlock.app_version,
+                  blockVersion: latestBlock.block_version
+                }
+              : null
           }
         })
 
@@ -127,16 +132,16 @@ describe('Validators routes', () => {
           return {
             proTxHash: row.pro_tx_hash,
             blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            propsedBlock: {
-              header: {
-                hash: latestBlock.hash,
-                height: latestBlock.height,
-                timestamp: latestBlock.timestamp.toISOString(),
-                l1LockedHeight: latestBlock.l1_locked_height,
-                appVersion: latestBlock.app_version,
-                blockVersion: latestBlock.block_version
-              }
-            }
+            lastProposedBlockHeader: latestBlock
+              ? {
+                  hash: latestBlock.hash,
+                  height: latestBlock.height,
+                  timestamp: latestBlock.timestamp.toISOString(),
+                  l1LockedHeight: latestBlock.l1_locked_height,
+                  appVersion: latestBlock.app_version,
+                  blockVersion: latestBlock.block_version
+                }
+              : null
           }
         })
 
@@ -161,16 +166,16 @@ describe('Validators routes', () => {
           return {
             proTxHash: row.pro_tx_hash,
             blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            propsedBlock: {
-              header: {
-                hash: latestBlock.hash,
-                height: latestBlock.height,
-                timestamp: latestBlock.timestamp.toISOString(),
-                l1LockedHeight: latestBlock.l1_locked_height,
-                appVersion: latestBlock.app_version,
-                blockVersion: latestBlock.block_version
-              }
-            }
+            lastProposedBlockHeader: latestBlock
+              ? {
+                  hash: latestBlock.hash,
+                  height: latestBlock.height,
+                  timestamp: latestBlock.timestamp.toISOString(),
+                  l1LockedHeight: latestBlock.l1_locked_height,
+                  appVersion: latestBlock.app_version,
+                  blockVersion: latestBlock.block_version
+                }
+              : null
           }
         })
 
@@ -195,16 +200,16 @@ describe('Validators routes', () => {
           return {
             proTxHash: row.pro_tx_hash,
             blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            propsedBlock: {
-              header: {
-                hash: latestBlock.hash,
-                height: latestBlock.height,
-                timestamp: latestBlock.timestamp.toISOString(),
-                l1LockedHeight: latestBlock.l1_locked_height,
-                appVersion: latestBlock.app_version,
-                blockVersion: latestBlock.block_version
-              }
-            }
+            lastProposedBlockHeader: latestBlock
+              ? {
+                  hash: latestBlock.hash,
+                  height: latestBlock.height,
+                  timestamp: latestBlock.timestamp.toISOString(),
+                  l1LockedHeight: latestBlock.l1_locked_height,
+                  appVersion: latestBlock.app_version,
+                  blockVersion: latestBlock.block_version
+                }
+              : null
           }
         })
 
@@ -229,16 +234,16 @@ describe('Validators routes', () => {
           return {
             proTxHash: row.pro_tx_hash,
             blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            propsedBlock: {
-              header: {
-                hash: latestBlock.hash,
-                height: latestBlock.height,
-                timestamp: latestBlock.timestamp.toISOString(),
-                l1LockedHeight: latestBlock.l1_locked_height,
-                appVersion: latestBlock.app_version,
-                blockVersion: latestBlock.block_version
-              }
-            }
+            lastProposedBlockHeader: latestBlock
+              ? {
+                  hash: latestBlock.hash,
+                  height: latestBlock.height,
+                  timestamp: latestBlock.timestamp.toISOString(),
+                  l1LockedHeight: latestBlock.l1_locked_height,
+                  appVersion: latestBlock.app_version,
+                  blockVersion: latestBlock.block_version
+                }
+              : null
           }
         })
 
@@ -246,34 +251,34 @@ describe('Validators routes', () => {
     })
 
     it('should allow to walk through pages with custom page size desc', async () => {
-      const { body } = await client.get('/validators?limit=7&page=4&order=desc')
+      const { body } = await client.get('/validators?limit=5&page=4&order=desc')
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       assert.equal(body.pagination.page, 4)
-      assert.equal(body.pagination.limit, 7)
+      assert.equal(body.pagination.limit, 5)
       assert.equal(body.pagination.total, validators.length)
-      assert.equal(body.resultSet.length, 7)
+      assert.equal(body.resultSet.length, 5)
 
       const expectedValidators = validators
         .sort((a, b) => b.id - a.id)
-        .slice(21, 28)
+        .slice(15, 20)
         .map(row => {
           const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
 
           return {
             proTxHash: row.pro_tx_hash,
             blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            propsedBlock: {
-              header: {
-                hash: latestBlock.hash,
-                height: latestBlock.height,
-                timestamp: latestBlock.timestamp.toISOString(),
-                l1LockedHeight: latestBlock.l1_locked_height,
-                appVersion: latestBlock.app_version,
-                blockVersion: latestBlock.block_version
-              }
-            }
+            lastProposedBlockHeader: latestBlock
+              ? {
+                  hash: latestBlock.hash,
+                  height: latestBlock.height,
+                  timestamp: latestBlock.timestamp.toISOString(),
+                  l1LockedHeight: latestBlock.l1_locked_height,
+                  appVersion: latestBlock.app_version,
+                  blockVersion: latestBlock.block_version
+                }
+              : null
           }
         })
 
@@ -281,34 +286,33 @@ describe('Validators routes', () => {
     })
 
     it('should return less items when when it is out of bounds', async () => {
-      const { body } = await client.get('/validators?limit=7&page=5&order=desc')
+      const { body } = await client.get('/validators?limit=10&page=3&order=desc')
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      assert.equal(body.pagination.page, 5)
-      assert.equal(body.pagination.limit, 7)
+      assert.equal(body.pagination.page, 3)
+      assert.equal(body.pagination.limit, 10)
       assert.equal(body.pagination.total, validators.length)
-      assert.equal(body.resultSet.length, 2)
+      assert.equal(body.resultSet.length, 5)
 
       const expectedValidators = validators
-        .sort((a, b) => b.id - a.id)
-        .slice(28, 30)
+        .slice(20, 25)
         .map(row => {
           const [latestBlock] = blocks.filter((block) => block.validator === row.pro_tx_hash).toReversed()
 
           return {
             proTxHash: row.pro_tx_hash,
             blocksCount: blocks.filter((block) => block.validator === row.pro_tx_hash).length,
-            propsedBlock: {
-              header: {
-                hash: latestBlock.hash,
-                height: latestBlock.height,
-                timestamp: latestBlock.timestamp.toISOString(),
-                l1LockedHeight: latestBlock.l1_locked_height,
-                appVersion: latestBlock.app_version,
-                blockVersion: latestBlock.block_version
-              }
-            }
+            lastProposedBlockHeader: latestBlock
+              ? {
+                  hash: latestBlock.hash,
+                  height: latestBlock.height,
+                  timestamp: latestBlock.timestamp.toISOString(),
+                  l1LockedHeight: latestBlock.l1_locked_height,
+                  appVersion: latestBlock.app_version,
+                  blockVersion: latestBlock.block_version
+                }
+              : null
           }
         })
 

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -83,7 +83,7 @@ describe('Validators routes', () => {
       assert.equal(body.pagination.limit, 10)
       assert.equal(body.pagination.total, validators.length)
       assert.equal(body.resultSet.length, 10)
-      
+
       const expectedValidators = validators
         .slice(0, 10)
         .map(row => {

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -46,7 +46,6 @@ describe('Validators routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-
       const lastBlocks = blocks.filter((block) => block.validator === body.proTxHash).sort((a, b) => b.height - a.height)
       const [lastBlock] = lastBlocks
 
@@ -54,7 +53,7 @@ describe('Validators routes', () => {
         proTxHash: validator.pro_tx_hash,
         latestHeight: lastBlock.height,
         latestTimestamp: lastBlock.timestamp.toISOString(),
-        blocksCount: lastBlocks.length,
+        blocksCount: lastBlocks.length
       }
 
       assert.deepEqual(expectedValidator, body)
@@ -87,7 +86,7 @@ describe('Validators routes', () => {
             proTxHash: row.pro_tx_hash,
             latestHeight: lastBlock.height,
             latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length,
+            blocksCount: lastBlocks.length
           })
         })
 
@@ -114,7 +113,7 @@ describe('Validators routes', () => {
             proTxHash: row.pro_tx_hash,
             latestHeight: lastBlock.height,
             latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length,
+            blocksCount: lastBlocks.length
           })
         })
 
@@ -140,7 +139,7 @@ describe('Validators routes', () => {
             proTxHash: row.pro_tx_hash,
             latestHeight: lastBlock.height,
             latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length,
+            blocksCount: lastBlocks.length
           })
         })
 
@@ -166,7 +165,7 @@ describe('Validators routes', () => {
             proTxHash: row.pro_tx_hash,
             latestHeight: lastBlock.height,
             latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length,
+            blocksCount: lastBlocks.length
           })
         })
 
@@ -192,7 +191,7 @@ describe('Validators routes', () => {
             proTxHash: row.pro_tx_hash,
             latestHeight: lastBlock.height,
             latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length,
+            blocksCount: lastBlocks.length
           })
         })
 
@@ -219,7 +218,7 @@ describe('Validators routes', () => {
             proTxHash: row.pro_tx_hash,
             latestHeight: lastBlock.height,
             latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length,
+            blocksCount: lastBlocks.length
           })
         })
 
@@ -246,7 +245,7 @@ describe('Validators routes', () => {
             proTxHash: row.pro_tx_hash,
             latestHeight: lastBlock.height,
             latestTimestamp: lastBlock.timestamp.toISOString(),
-            blocksCount: lastBlocks.length,
+            blocksCount: lastBlocks.length
           })
         })
       assert.deepEqual(expectedValidators, body.resultSet)

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -144,7 +144,8 @@ GET /blocks
 ```
 ---
 ### Validators
-Return all validators with pagination info
+Return all validators with pagination info.
+* `lastProposedBlockHeader` field is nullable
 ```
 GET /validators
 
@@ -160,6 +161,7 @@ GET /validators
         "l1LockedHeight": 1337,
         "appVersion": 1,
         "blockVersion": 13
+        "validator": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0"
       }
     }, ...
   ],
@@ -172,7 +174,8 @@ GET /validators
 ```
 ---
 ### Validator by ProTxHash
-Get validator by ProTxHash
+Get validator by ProTxHash.
+* `lastProposedBlockHeader` field is nullable
 ```
 GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
@@ -185,7 +188,8 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
     "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
     "l1LockedHeight": 1337,
     "appVersion": 1,
-    "blockVersion": 13
+    "blockVersion": 13,
+    "validator": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0"
   }
 }
 ```

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -152,12 +152,12 @@ GET /validators
   resultSet: [
     {
       "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
+      "blocksCount": 5,
       "propsedBlock": {
         "header": {
-          "latestHeight": 5,
-          "latestTimestamp": "2024-06-23T13:51:44.154Z",
-          "blocksCount": 5,
-          "blockHash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+          "height": 5,
+          "timestamp": "2024-06-23T13:51:44.154Z",
+          "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
           "l1LockedHeight": 1337,
           "appVersion": 1,
           "blockVersion": 13
@@ -180,12 +180,12 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
 {
   "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
+  "blocksCount": 5,
   "propsedBlock": {
     "header": {
-        "latestHeight": 5,
-        "latestTimestamp": "2024-06-23T13:51:44.154Z",
-        "blocksCount": 5,
-        "blockHash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+        "height": 5,
+        "timestamp": "2024-06-23T13:51:44.154Z",
+        "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
         "l1LockedHeight": 1337,
         "appVersion": 1,
         "blockVersion": 13

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -152,7 +152,7 @@ GET /validators
   resultSet: [
     {
       "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
-      "blocksCount": 5,
+      "proposedBlocksAmount": 5,
       "lastProposedBlockHeader": {
         "height": 5,
         "timestamp": "2024-06-23T13:51:44.154Z",
@@ -178,7 +178,7 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
 {
   "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
-  "blocksCount": 5,
+  "proposedBlocksAmount": 5,
   "lastProposedBlockHeader": {
     "height": 5,
     "timestamp": "2024-06-23T13:51:44.154Z",

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -153,15 +153,13 @@ GET /validators
     {
       "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
       "blocksCount": 5,
-      "propsedBlock": {
-        "header": {
-          "height": 5,
-          "timestamp": "2024-06-23T13:51:44.154Z",
-          "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
-          "l1LockedHeight": 1337,
-          "appVersion": 1,
-          "blockVersion": 13
-        }
+      "lastProposedBlockHeader": {
+        "height": 5,
+        "timestamp": "2024-06-23T13:51:44.154Z",
+        "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+        "l1LockedHeight": 1337,
+        "appVersion": 1,
+        "blockVersion": 13
       }
     }, ...
   ],
@@ -181,15 +179,13 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 {
   "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
   "blocksCount": 5,
-  "propsedBlock": {
-    "header": {
-        "height": 5,
-        "timestamp": "2024-06-23T13:51:44.154Z",
-        "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
-        "l1LockedHeight": 1337,
-        "appVersion": 1,
-        "blockVersion": 13
-    }
+  "lastProposedBlockHeader": {
+    "height": 5,
+    "timestamp": "2024-06-23T13:51:44.154Z",
+    "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+    "l1LockedHeight": 1337,
+    "appVersion": 1,
+    "blockVersion": 13
   }
 }
 ```

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -151,10 +151,18 @@ GET /validators
 {
   resultSet: [
     {
-      proTxHash: '35513037C3476ADDE0B23903A1A1E50660D076370F62F79F0E24212F29088044',
-      latestHeight: 5,
-      latestTimestamp: '2024-06-22T12:42:06.112Z',
-      blocksCount: 4
+      "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
+      "propsedBlock": {
+        "header": {
+          "latestHeight": 5,
+          "latestTimestamp": "2024-06-23T13:51:44.154Z",
+          "blocksCount": 5,
+          "blockHash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+          "l1LockedHeight": 1337,
+          "appVersion": 1,
+          "blockVersion": 13
+        }
+      }
     }, ...
   ],
   pagination: { 
@@ -168,13 +176,21 @@ GET /validators
 ### Validator by ProTxHash
 Get validator by ProTxHash
 ```
-GET /validator/35513037C3476ADDE0B23903A1A1E50660D076370F62F79F0E24212F29088044
+GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
 {
-  proTxHash: '5F1BBB3E5E546BC84731E08679C45A467DD38793B84B575601A56411DD279E34',
-  latestHeight: 5,
-  latestTimestamp: '2024-06-22T12:47:47.359Z',
-  blocksCount: 4
+  "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
+  "propsedBlock": {
+    "header": {
+        "latestHeight": 5,
+        "latestTimestamp": "2024-06-23T13:51:44.154Z",
+        "blocksCount": 5,
+        "blockHash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
+        "l1LockedHeight": 1337,
+        "appVersion": 1,
+        "blockVersion": 13
+    }
+  }
 }
 ```
 ---

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -143,6 +143,41 @@ GET /blocks
 }
 ```
 ---
+### Validators
+Return all validators with pagination info
+```
+GET /validators
+
+{
+  resultSet: [
+    {
+      proTxHash: '35513037C3476ADDE0B23903A1A1E50660D076370F62F79F0E24212F29088044',
+      latestHeight: 5,
+      latestTimestamp: '2024-06-22T12:42:06.112Z',
+      blocksCount: 4
+    }, ...
+  ],
+  pagination: { 
+    page: 1, 
+    limit: 10, 
+    total: 30 
+  }
+}
+```
+---
+### Validator by ProTxHash
+Get validator by ProTxHash
+```
+GET /validator/35513037C3476ADDE0B23903A1A1E50660D076370F62F79F0E24212F29088044
+
+{
+  proTxHash: '5F1BBB3E5E546BC84731E08679C45A467DD38793B84B575601A56411DD279E34',
+  latestHeight: 5,
+  latestTimestamp: '2024-06-22T12:47:47.359Z',
+  blocksCount: 4
+}
+```
+---
 ### Transaction by hash
 Get a transaction (state transition) by hash
 


### PR DESCRIPTION
# Issue
To finish validators page (https://github.com/pshenmic/platform-explorer/pull/152), we need to add few metadata fields in the response of the getValidators() query with such data:

Total proposed blocks count
Last proposed block height ( + timestamp)

# Things Done
Now in response to `getValidators` and `getValidatorByProTxHash` query we get data of this format:

```
{
  "proTxHash": "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0",
  "blocksCount": 5,
  "lastProposedBlockHeader": {
    "height": 5,
    "timestamp": "2024-06-23T13:51:44.154Z",
    "hash": "7253F441FF6AEAC847F9E03672B9386E35FC8CBCFC4A7CC67557FCA10E342904",
    "l1LockedHeight": 1337,
    "appVersion": 1,
    "blockVersion": 13
  }
}
```
To get the new fields it was necessary to realize one more database access, but already in the blocks table, then process the data and after that produce a response.
Tests have also been adjusted to work with the new data
`README.md` was updated with information about `getValidators` and `getValidatorByProTxHash`