### PR TITLE
Add new data contracts to the cards block

### DIFF
--- a/packages/frontend/src/app/dataContracts/Cards.js
+++ b/packages/frontend/src/app/dataContracts/Cards.js
@@ -8,6 +8,10 @@ export default function Cards () {
     data: {
       resultSet: [
         {
+          identifier: 'CzQbXNyvsjGWmJ9YMHkpVSceW16YmQEuoaosAkpm1JSN',
+          name: 'Platform Explorer'
+        },
+        {
           identifier: 'Bwr4WHCPz5rFVAD87RqTs3izo4zpzwsEdKPWUT1NS1C7',
           name: 'Dashpay'
         },
@@ -22,6 +26,10 @@ export default function Cards () {
         {
           identifier: 'HY1keaRK5bcDmujNCQq5pxNyvAiHHpoHQgLN5ppiu4kh',
           name: 'FeatureFlags'
+        },
+        {
+          identifier: '4fJLR2GYTPFdomuTVvNy3VRrvWgvkKPzqehEBpNf2nk6',
+          name: 'Withdrawals'
         }
       ]
     },

--- a/packages/frontend/src/components/cards/CardsGrid.js
+++ b/packages/frontend/src/components/cards/CardsGrid.js
@@ -1,8 +1,9 @@
 import { InfoCard } from './'
 import './CardsGrid.scss'
 
-function CardsGrid ({ children, className }) {
-  return <div className={`CardsGrid ${className || ''}`}>{children}</div>
+function CardsGrid ({ children, className, itemsCount = null }) {
+  const justifyClass = (itemsCount && itemsCount % 3 === 0) ? 'CardsGrid--DivideBy3' : ''
+  return <div className={`CardsGrid ${justifyClass} ${className || ''}`}>{children}</div>
 }
 
 function CardsGridHeader ({ children, className }) {

--- a/packages/frontend/src/components/cards/CardsGrid.scss
+++ b/packages/frontend/src/components/cards/CardsGrid.scss
@@ -20,19 +20,29 @@
     @media screen and (max-width: $breakpoint-lg) {
         &__Item {
             width: calc(25% - 10px);
-            margin: 10px 0;
+        }
+
+        &--DivideBy3 &__Item {
+            width: calc(100% / 3 - 10px);
         }
     }
 
     @media screen and (max-width: $breakpoint-md) {
         &__Item {
             width: calc(50% - 10px);
-            margin: 10px 0;
+        }
+
+        &--DivideBy3 &__Item {
+            width: calc(50% - 10px);
         }
     }
 
     @media screen and (max-width: $breakpoint-sm) {
         &__Item {
+            width: 100%;
+        }
+
+        &--DivideBy3 &__Item {
             width: 100%;
         }
     }

--- a/packages/frontend/src/components/dataContracts/Cards.js
+++ b/packages/frontend/src/components/dataContracts/Cards.js
@@ -26,10 +26,10 @@ function DataContractCard ({ dataContract, loading = false }) {
   )
 }
 
-function DataContractCards ({ title, items }) {
+function DataContractCards ({ title, items, className }) {
   return (
     !items.error
-      ? <CardsGrid>
+      ? <CardsGrid className={className} itemsCount={items?.data?.resultSet?.length || null}>
           {title &&
             <CardsGridHeader>
               <CardsGridTitle>{title}</CardsGridTitle>


### PR DESCRIPTION
# Issue
It is necessary to add new named data contracts to the top cards block on the Data Contracts page.

# Things done
- Added new data contracts to the cards block
- Updated CardsGrid component: added justify class