### PR TITLE
Endpoint to get statistics on proposed blocks for validators

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -247,6 +247,20 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 }
 ```
 ---
+### Validator stats by ProTxHash
+Return a series data for the amount of proposed blocks by validator chart with variable timespan (1h, 24h, 3d, 1w)
+```
+GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/stats?timespan=24h
+[
+    {
+        timestamp: "2024-06-23T13:51:44.154Z",
+        data: {
+            blocksCount: 2
+        }
+    },...
+]
+```
+---
 ### Transaction by hash
 Get a transaction (state transition) by hash
 

--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -55,6 +55,26 @@ class ValidatorsController {
         validator.lastProposedBlockHeader))
     })
   }
+
+  getValidatorStatsByProTxHash = async (request, response) => {
+    const { proTxHash } = request.params
+    const { timespan = '1h' } = request.query
+
+    const possibleValues = ['1h', '24h', '3d', '1w']
+
+    if (possibleValues.indexOf(timespan) === -1) {
+      return response.status(400)
+        .send({ message: `invalid timespan value ${timespan}. only one of '${possibleValues}' is valid` })
+    }
+
+    if (!proTxHash) {
+      return response.status(400).send({ message: 'invalid proTxHash' })
+    }
+
+    const stats = await this.validatorsDAO.getValidatorStatsByProTxHash(proTxHash, timespan)
+
+    response.send(stats)
+  }
 }
 
 module.exports = ValidatorsController

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -128,6 +128,11 @@ module.exports = ({
       path: '/validator/:proTxHash',
       method: 'GET',
       handler: validatorsController.getValidatorByProTxHash
+    },
+    {
+      path: '/validator/:proTxHash/stats',
+      method: 'GET',
+      handler: validatorsController.getValidatorStatsByProTxHash
     }
   ]
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -216,6 +216,20 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 }
 ```
 ---
+### Validator stats by ProTxHash
+Return a series data for the amount of proposed blocks by validator chart with variable timespan (1h, 24h, 3d, 1w)
+```
+GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/stats?timespan=24h
+[
+    {
+        timestamp: "2024-06-23T13:51:44.154Z",
+        data: {
+            blocksCount: 2
+        }
+    },...
+]
+```
+---
 ### Transaction by hash
 Get a transaction (state transition) by hash
 


### PR DESCRIPTION
# Issue
The api lacked an endpoint for getting block statistics for validators
# Things done
A method for obtaining validator statistics was implemented to obtain statistics for a specific time period (1h, 24h, 3d, 1w).
Integration tests for the new method were written, and `README.md` was updated
```
GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/stats?timespan=24h

[
    {
        timestamp: "2024-06-23T13:51:44.154Z",
        data: {
            blocksCount: 2
        }
    },...
]
```