### PR TITLE
Handle Tenderdash RPC race condition & always restart

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,4 +188,4 @@ jobs:
             docker run --rm --env-file api.env ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:indexer refinery migrate -e DATABASE_URL -p /app/migrations
             docker run -d -p 3005:3005 --restart always --env-file api.env --name platform-explorer-api ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:api
             sleep 3
-            docker run -d --env-file api.env --name platform-explorer-indexer ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:indexer cargo run
+            docker run -d --env-file api.env --restart always --name platform-explorer-indexer ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:indexer cargo run

--- a/packages/indexer/src/indexer/mod.rs
+++ b/packages/indexer/src/indexer/mod.rs
@@ -86,10 +86,14 @@ impl Indexer {
                             Err(err) => {
                                 match err {
                                     ProcessorError::DatabaseError => {
-                                        println!("Database error occurred while indexing block height {}", block_height);
+                                        println!("Database error occurred while indexing block height {} retrying ...", block_height);
                                     }
                                     ProcessorError::UnexpectedError => {
-                                        println!("Unexpected processor error happened at block height {}", block_height);
+                                        println!("Unexpected processor error happened at block height {}, retrying ...", block_height);
+                                    }
+                                    // https://github.com/pshenmic/platform-explorer/issues/170
+                                    ProcessorError::TenderdashTxResultNotExists => {
+                                        println!("Block TX Count length and Block Results Tx Count length did not match for height {}, retrying...", block_height);
                                     }
                                 }
                             }
@@ -107,6 +111,11 @@ impl Indexer {
         let validators = self.tenderdash_rpc.get_validators_by_block_height(block_height.clone()).await?;
 
         let tx_results = block_results_response.txs_results.unwrap_or(vec![]);
+
+        if block.block.data.txs.len() != tx_results.len() {
+            return Err(ProcessorError::TenderdashTxResultNotExists);
+        }
+
         let block_hash = block.block_id.hash;
 
         let transactions = block.block.data.txs.iter().enumerate().map(|(i, tx_string)| {

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -34,6 +34,7 @@ use crate::models::{TransactionResult, TransactionStatus};
 
 pub enum ProcessorError {
     DatabaseError,
+    TenderdashTxResultNotExists,
     UnexpectedError,
 }
 


### PR DESCRIPTION
# Issue

Platform Explorer had instability for a quite time related to the TD RPC https://github.com/pshenmic/platform-explorer/issues/170
Also, in case of unexpected errors indexer have been set up to stop, for a better debugging. I think it should be changed for production, where we most likely would like to auto-restart the process in case of sporadic errors.


# Things done
* Added a check if tx length in the responses from /block and /block_results matches and handles retry in that case
* Added restart=always option to the production PE indexer Docker container
