### PR TITLE
Fix proTxHash was not underscored from TD RPC + tests

### DIFF
--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -18,7 +18,7 @@ class ValidatorsController {
 
     const validators = await TenderdashRPC.getValidators()
 
-    const isActive = validators.some(validator => validator.proTxHash === proTxHash)
+    const isActive = validators.some(validator => validator.pro_tx_hash === proTxHash)
 
     response.send(new Validator(validator.proTxHash, isActive, validator.proposedBlocksAmount, validator.lastProposedBlockHeader))
   }
@@ -50,7 +50,7 @@ class ValidatorsController {
       ...validators,
       resultSet: validators.resultSet.map(validator =>
         new Validator(validator.proTxHash, activeValidators.some(activeValidator =>
-          activeValidator.proTxHash === validator.proTxHash),
+          activeValidator.pro_tx_hash === validator.proTxHash),
         validator.proposedBlocksAmount,
         validator.lastProposedBlockHeader))
     })

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -72,9 +72,9 @@ module.exports = class ValidatorsDAO {
         this.knex('validators')
           .modify(function (knex) {
             if (isActive !== undefined && isActive) {
-              knex.whereIn('pro_tx_hash', validators.map(validator => validator.proTxHash))
+              knex.whereIn('pro_tx_hash', validators.map(validator => validator.pro_tx_hash))
             } else if (isActive !== undefined && !isActive) {
-              knex.whereNotIn('pro_tx_hash', validators.map(validator => validator.proTxHash))
+              knex.whereNotIn('pro_tx_hash', validators.map(validator => validator.pro_tx_hash))
             }
           })
           .count('pro_tx_hash').as('total_count'),
@@ -107,9 +107,9 @@ module.exports = class ValidatorsDAO {
       )
       .modify(function (knex) {
         if (isActive !== undefined && isActive) {
-          knex.whereIn('pro_tx_hash', validators.map(validator => validator.proTxHash))
+          knex.whereIn('pro_tx_hash', validators.map(validator => validator.pro_tx_hash))
         } else if (isActive !== undefined && !isActive) {
-          knex.whereNotIn('pro_tx_hash', validators.map(validator => validator.proTxHash))
+          knex.whereNotIn('pro_tx_hash', validators.map(validator => validator.pro_tx_hash))
         }
       })
       .leftJoin('blocks', 'blocks.hash', 'proposed_block_hash')

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -48,7 +48,7 @@ describe('Validators routes', () => {
     mock.method(tenderdashRpc, 'getValidators',
       async () =>
         Promise.resolve(activeValidators.map(activeValidator =>
-          ({ proTxHash: activeValidator.pro_tx_hash }))))
+          ({ pro_tx_hash: activeValidator.pro_tx_hash }))))
   })
 
   after(async () => {


### PR DESCRIPTION
# Issue

![image](https://github.com/pshenmic/platform-explorer/assets/17009187/08a278ee-1506-4206-8bcc-ff20cc9763c6)

Incorrect field name was used in the code in the validators when it is coming from Tenderdash RPC. Integration test have been using incorrect mock and tests did not catch that.

# Things done
* Fixed ValidatorsDAO / ValidatorsController to use `pro_tx_hash` instead of `proTxHash`
* Fixed integration test