### PR TITLE
Update Validators list styles

### DIFF
--- a/packages/frontend/src/components/validators/ValidatorsList.js
+++ b/packages/frontend/src/components/validators/ValidatorsList.js
@@ -21,7 +21,7 @@ export default function ValidatorsList ({ validators, pageSize }) {
   const ValidatorRow = ({ validator, loading }) => {
     return (
       <Tr className={'ValidatorTableRow'}>
-        <Td>
+        <Td py={0} maxW={'calc(100vw - 500px)'} minW={'200px'} pr={0}>
           <LoadingLine loading={loading} w={'700px'} className={'ValidatorTableRow__IdentifierContainer'}>
             {!loading &&
               <Link href={`/validator/${validator.proTxHash}`} className={'ValidatorTableRow__IdentifierContainer'}>

--- a/packages/frontend/src/components/validators/ValidatorsList.scss
+++ b/packages/frontend/src/components/validators/ValidatorsList.scss
@@ -27,5 +27,8 @@
         font-family: $monospace-font;
         font-size: 16px;
         text-transform: uppercase;
+        max-width: 100%;
+        overflow: hidden;
+        text-overflow: ellipsis;
     }
 }

--- a/packages/frontend/src/styles/mixins.scss
+++ b/packages/frontend/src/styles/mixins.scss
@@ -20,6 +20,8 @@
 
     &__Avatar {
         margin-right: 12px;
+        height: 28px;
+        width: 28px;
     }
 
     &:hover {


### PR DESCRIPTION
# Issue
On mobile resolution, the identifier in Validators list takes up a lot of space and the table has a long scroll.

# Things done
- Identifiers are abbreviated with ellipsis on mobile resolution
- Fixed Avatars size on mobiles