### PR TITLE
Fees collected by the epoch and best validator

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -103,6 +103,8 @@ HTTP /status
 Returns info about epoch by specific index
 
 * tps - Transactions per second
+* totalCollectedFees - total number or fees spent per epoch
+* bestValidator - validator with most validated blocks
 
 
 ```
@@ -114,7 +116,9 @@ HTTP /epoch/1
         startTime: "2024-04-08T14:00:00.000Z",
         endTime: "2024-04-09T14:00:00.000Z"
     },
-    tps: 0.01666666666     
+    tps: 0.01666666666,
+    totalCollectedFees: 30,
+    bestValidator: "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0"
 }
 ```
 ---

--- a/packages/api/src/dao/EpochDAO.js
+++ b/packages/api/src/dao/EpochDAO.js
@@ -2,6 +2,7 @@ const TransactionsDAO = require('../dao/TransactionsDAO')
 const BlocksDAO = require('../dao/BlocksDAO')
 const Epoch = require('../models/Epoch')
 const Constants = require('../constants')
+const EpochData = require('../models/EpochData')
 
 module.exports = class EpochDAO {
   constructor (knex) {
@@ -19,16 +20,36 @@ module.exports = class EpochDAO {
 
     const subquery = this.knex('state_transitions')
       .leftJoin('blocks', 'state_transitions.block_hash', 'blocks.hash')
-      .whereRaw(`blocks.timestamp > '${epoch.startTime.toISOString()}' and blocks.timestamp <= '${epoch.endTime.toISOString()}'`)
+      .leftJoin('validators', 'blocks.validator', 'validators.pro_tx_hash')
+      .where('blocks.timestamp', '>', epoch.startTime.toISOString())
+      .andWhere('blocks.timestamp', '<=', epoch.endTime.toISOString())
+      .groupBy('validators.pro_tx_hash')
       .count('* as tx_count')
+      .sum('gas_used as collected_fees')
+      .select('validators.pro_tx_hash',
+        this.knex.raw('ROW_NUMBER() OVER (ORDER BY COUNT(blocks.hash) DESC) as row_num')
+      )
 
-    const [row] = await this.knex
-      .select(this.knex.raw(`SUM(tx_count) * 1.0 / ${Constants.EPOCH_CHANGE_TIME / 1000} as tps`))
+    const subqueryWithTotalFees = this.knex
+      .select(
+        'pro_tx_hash',
+        'tx_count',
+        'collected_fees',
+        'row_num',
+        this.knex.raw('SUM(collected_fees) OVER () as total_collected_fees')
+      )
       .from(subquery)
 
-    return {
-      epoch,
-      tps: Number(row.tps)
-    }
+    const [row] = await this.knex
+      .select(
+        this.knex.raw(`SUM(tx_count) OVER () * 1.0 / ${Constants.EPOCH_CHANGE_TIME / 1000} as tps`),
+        'pro_tx_hash as best_validator',
+        'total_collected_fees as total_collected_fees'
+      )
+      .groupBy('pro_tx_hash', 'row_num', 'collected_fees', 'total_collected_fees', 'tx_count')
+      .orderBy('row_num', 'asc')
+      .from(subqueryWithTotalFees)
+
+    return EpochData.fromObject({ epoch, ...row })
   }
 }

--- a/packages/api/src/models/EpochData.js
+++ b/packages/api/src/models/EpochData.js
@@ -1,0 +1,18 @@
+module.exports = class EpochData {
+  epoch
+  tps
+  totalCollectedFees
+  bestValidator
+
+  constructor (epoch, tps, totalCollectedFees, bestValidator) {
+    this.epoch = epoch ?? null
+    this.tps = tps ?? null
+    this.totalCollectedFees = totalCollectedFees ?? null
+    this.bestValidator = bestValidator ?? null
+  }
+
+  // eslint-disable-next-line camelcase
+  static fromObject ({ epoch, tps, total_collected_fees, best_validator }) {
+    return new EpochData(epoch, Number(tps), Number(total_collected_fees), best_validator)
+  }
+}

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -72,6 +72,8 @@ HTTP /status
 Returns info about epoch by specific index
 
 * tps - Transactions per second
+* totalCollectedFees - total number or fees spent per epoch
+* bestValidator - validator with most validated blocks
 
 
 ```
@@ -83,7 +85,9 @@ HTTP /epoch/1
         startTime: "2024-04-08T14:00:00.000Z",
         endTime: "2024-04-09T14:00:00.000Z"
     },
-    tps: 0.01666666666     
+    tps: 0.01666666666,
+    totalCollectedFees: 30,
+    bestValidator: "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0"
 }
 ```
 ---


### PR DESCRIPTION
# Issue
In the getEpochByIndex method, we should extend it with fees collected in this epoch and best validator
# Things done
Added new fiels in `getEpochInfo`. Epoch tests update. `Readme.md` update
now we can get `feesCollected` and `bestValidator `
```
{
    epoch: {
        index: 1,
        startTime: "2024-04-08T14:00:00.000Z",
        endTime: "2024-04-09T14:00:00.000Z"
    },
    tps: 0.01666666666,
    totalCollectedFees: 30,
    bestValidator: "F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0"
}
```