### PR TITLE
Search Identity by DPNS name

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -55,6 +55,7 @@ Reference:
 * [Document by Identifier](#document-by-identifier)
 * [Documents by Data Contract](#documents-by-data-contract)
 * [Identity by Identifier](#identity-by-identifier)
+* [Identity by DPNS](#identity-by-dpns)
 * [Identities](#identities)
 * [Data Contracts by Identity](#data-contracts-by-identity)
 * [Documents by Identity](#documents-by-identity)
@@ -519,6 +520,32 @@ Response codes:
 Return identity by given identifier
 ```
 GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
+
+{
+    identifier: "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+    owner: "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+    revision: 1,
+    balance: 1000000,
+    timestamp: "2024-03-18T10:13:54.150Z",
+    txHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+    totalTxs: 1,
+    totalTransfers: 0,
+    totalDocuments: 0,
+    totalDataContracts: 0,
+    isSystem: false
+}
+```
+Response codes:
+```
+200: OK
+404: Not found
+500: Internal Server Error
+```
+---
+### Identity by DPNS
+Return identity by given DPNS/alias
+```
+GET /dpns/identity?dpns=test-name.1.dash
 
 {
     identifier: "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -17,6 +17,18 @@ class IdentitiesController {
     response.send(identity)
   }
 
+  getIdentityByDPNS = async (request, response) => {
+    const { dpns } = request.query
+
+    const identity = await this.identitiesDAO.getIdentityByDPNS(dpns)
+
+    if (!identity) {
+      return response.status(404).send({ message: 'not found' })
+    }
+
+    response.send(identity)
+  }
+
   getIdentities = async (request, response) => {
     const { page = 1, limit = 10, order = 'asc', order_by: orderBy = 'block_height' } = request.query
 

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -65,6 +65,21 @@ module.exports = class IdentitiesDAO {
     return Identity.fromRow({ ...row })
   }
 
+  getIdentityByDPNS = async (dpns) => {
+    const [identifier] = await this.knex('identity_aliases')
+      .select('alias', 'identity_identifier')
+      .whereRaw(`UPPER(alias) LIKE UPPER('${dpns}')`)
+
+    if (!identifier) {
+      // throw new Error(`${dpns} not found`)
+      return null
+    }
+
+    const identity = await this.getIdentityByIdentifier(identifier.identity_identifier)
+
+    return identity
+  }
+
   getIdentities = async (page, limit, order, orderBy) => {
     const fromRank = (page - 1) * limit + 1
     const toRank = fromRank + limit - 1

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -163,6 +163,20 @@ module.exports = ({
       }
     },
     {
+      path: '/dpns/identity',
+      method: 'GET',
+      handler: identitiesController.getIdentityByDPNS,
+      schema: {
+        querystring: {
+          type: 'object',
+          required: ['dpns'],
+          properties: {
+            dpns: { type: 'string' }
+          }
+        }
+      }
+    },
+    {
       path: '/identity/:identifier/transactions',
       method: 'GET',
       handler: identitiesController.getTransactionsByIdentity,

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -74,6 +74,66 @@ describe('Identities routes', () => {
     })
   })
 
+  describe('getIdentityByDPNS()', async () => {
+    it('should return identity by dpns', async () => {
+      const block = await fixtures.block(knex)
+      const identity = await fixtures.identity(knex, { block_hash: block.hash })
+      await fixtures.identity_alias(knex, { dpns: 'test-name.1.dash', identity })
+
+      const { body } = await client.get('/dpns/identity?dpns=test-name.1.dash')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedIdentity = {
+        identifier: identity.identifier,
+        owner: identity.identifier,
+        revision: identity.revision,
+        balance: 0,
+        timestamp: block.timestamp.toISOString(),
+        txHash: identity.txHash,
+        totalTxs: 1,
+        totalTransfers: 0,
+        totalDocuments: 0,
+        totalDataContracts: 0,
+        isSystem: false
+      }
+
+      assert.deepEqual(body, expectedIdentity)
+    })
+
+    it('should return identity by dpns with any case', async () => {
+      const block = await fixtures.block(knex)
+      const identity = await fixtures.identity(knex, { block_hash: block.hash })
+      await fixtures.identity_alias(knex, { dpns: 'test-name.2.dash', identity })
+
+      const { body } = await client.get('/dpns/identity?dpns=TeSt-NaME.2.DAsH')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedIdentity = {
+        identifier: identity.identifier,
+        owner: identity.identifier,
+        revision: identity.revision,
+        balance: 0,
+        timestamp: block.timestamp.toISOString(),
+        txHash: identity.txHash,
+        totalTxs: 1,
+        totalTransfers: 0,
+        totalDocuments: 0,
+        totalDataContracts: 0,
+        isSystem: false
+      }
+
+      assert.deepEqual(body, expectedIdentity)
+    })
+
+    it('should return 404 when identity not found', async () => {
+      await client.get('/dpns/identity?dpns=bad-name')
+        .expect(404)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+    })
+  })
+
   describe('getIdentities()', async () => {
     it('should return default set of identities', async () => {
       const identities = []

--- a/packages/api/test/utils/fixtures.js
+++ b/packages/api/test/utils/fixtures.js
@@ -83,6 +83,21 @@ const fixtures = {
 
     return { ...row, txHash: state_transition_hash ?? transaction.hash, id: result[0].id, transaction }
   },
+
+  identity_alias: async (knex, { dpns, identity, block_hash } = {}) => {
+    if (!identity) {
+      identity = this.identity(knex, { block_hash })
+    }
+
+    const row = {
+      identity_identifier: identity.identifier,
+      alias: dpns
+    }
+
+    await knex('identity_aliases').insert(row).returning('id')
+
+    return { ...row }
+  },
   dataContract: async (knex, { identifier, name, schema, version, state_transition_hash, owner, is_system, documents = [] } = {}) => {
     if (!identifier) {
       identifier = generateIdentifier()
@@ -180,6 +195,7 @@ const fixtures = {
   },
   cleanup: async (knex) => {
     await knex.raw('DELETE FROM identities')
+    await knex.raw('DELETE FROM identity_aliases')
     await knex.raw('DELETE FROM documents')
     await knex.raw('DELETE FROM data_contracts')
     await knex.raw('DELETE FROM transfers')

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -22,6 +22,7 @@ Reference:
 * [Document by Identifier](#document-by-identifier)
 * [Documents by Data Contract](#documents-by-data-contract)
 * [Identity by Identifier](#identity-by-identifier)
+* [Identity by DPNS](#identity-by-dpns)
 * [Identities](#identities)
 * [Data Contracts by Identity](#data-contracts-by-identity)
 * [Documents by Identity](#documents-by-identity)
@@ -486,6 +487,32 @@ Response codes:
 Return identity by given identifier
 ```
 GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
+
+{
+    identifier: "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+    owner: "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+    revision: 1,
+    balance: 1000000,
+    timestamp: "2024-03-18T10:13:54.150Z",
+    txHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+    totalTxs: 1,
+    totalTransfers: 0,
+    totalDocuments: 0,
+    totalDataContracts: 0,
+    isSystem: false
+}
+```
+Response codes:
+```
+200: OK
+404: Not found
+500: Internal Server Error
+```
+---
+### Identity by DPNS
+Return identity by given DPNS/alias
+```
+GET /dpns/identity?dpns=test-name.1.dash
 
 {
     identifier: "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",


### PR DESCRIPTION
# Issue
User should be able to find identity by his dpns name or alias (eg. pshenmic.dash)

# Things done
An endpoint api has been implemented that allows you to get the Identity by dpns/alias.
The `README.md` file has been updated as well
Tests for the new endpoint were implemented

```
GET /dpns/identity?dpns=test-name.1.dash

{
    identifier: "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
    owner: "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
    revision: 1,
    balance: 1000000,
    timestamp: "2024-03-18T10:13:54.150Z",
    txHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
    totalTxs: 1,
    totalTransfers: 0,
    totalDocuments: 0,
    totalDataContracts: 0,
    isSystem: false
}
```