### PR TITLE
Handle legacy masternodes in the protx info call

### DIFF
--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -48,10 +48,18 @@ class ValidatorsController {
 
     const validatorsWithInfo = await Promise.all(
       validators.resultSet.map(async (validator) => {
+        // const validatorTx = 
         try {
-          return { ...validator, proTxInfo: await DashCoreRPC.getProTxInfo(validator.proTxHash) }
+          return {
+            ...validator,
+            proTxInfo: await DashCoreRPC.getProTxInfo(validator.proTxHash)
+          }
         } catch (error) {
-          return {...validator, proTxInfo: null}
+          const txn = await DashCoreRPC.getRawTransaction(validator.proTxHash)
+          return {
+            ...validator,
+            proTxInfo: await DashCoreRPC.getProTxInfo(validator.proTxHash, txn.blockhash)
+          }
         }
       }))
 

--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -5,7 +5,7 @@ const DashCoreRPC = require('../dashcoreRpc')
 const ProTxInfo = require('../models/ProTxInfo')
 
 class ValidatorsController {
-  constructor(knex) {
+  constructor (knex) {
     this.validatorsDAO = new ValidatorsDAO(knex)
   }
 
@@ -57,9 +57,9 @@ class ValidatorsController {
       resultSet: validatorsWithInfo.map(validator =>
         new Validator(validator.proTxHash, activeValidators.some(activeValidator =>
           activeValidator.pro_tx_hash === validator.proTxHash),
-          validator.proposedBlocksAmount,
-          validator.lastProposedBlockHeader,
-          ProTxInfo.fromObject(validator.proTxInfo)
+        validator.proposedBlocksAmount,
+        validator.lastProposedBlockHeader,
+        ProTxInfo.fromObject(validator.proTxInfo)
         )
       )
     })

--- a/packages/api/src/dashcoreRpc.js
+++ b/packages/api/src/dashcoreRpc.js
@@ -12,7 +12,7 @@ const config = {
 const rpc = new RpcClient(config)
 
 class DashCoreRPC {
-  static async getProTxInfo(proTxHash,blockHash) {
+  static async getProTxInfo (proTxHash, blockHash) {
     try {
       const { result } = await rpc.protx('info', proTxHash, blockHash)
       return result
@@ -22,7 +22,7 @@ class DashCoreRPC {
     }
   }
 
-  static async getRawTransaction(proTxHash) {
+  static async getRawTransaction (proTxHash) {
     try {
       const { result } = await rpc.getRawTransaction(proTxHash, 1)
       return result

--- a/packages/api/src/dashcoreRpc.js
+++ b/packages/api/src/dashcoreRpc.js
@@ -15,6 +15,7 @@ class DashCoreRPC {
   static async getRawTransaction (proTxHash) {
     try {
       const { result } = await rpc.getRawTransaction(proTxHash, 1)
+
       return result
     } catch (e) {
       console.error(e)
@@ -22,18 +23,19 @@ class DashCoreRPC {
     }
   }
 
-  static async getProTxInfo (proTxHash, blockHash) {
+  static async getProTxInfo (proTxHash, blockHash = NaN) {
     try {
-      const args = ['info', proTxHash]
-      if (blockHash) args.push(blockHash)
-      const { result } = await rpc.protx(...args)
+      const { result } = await rpc.protx('info', proTxHash, blockHash)
+
       return result
     } catch (e) {
       if (e.code === -8) {
         const { blockhash } = await this.getRawTransaction(proTxHash)
         const result = await this.getProTxInfo(proTxHash, blockhash)
+
         return result
       }
+
       console.error(e)
       throw new ServiceNotAvailableError()
     }

--- a/packages/api/src/dashcoreRpc.js
+++ b/packages/api/src/dashcoreRpc.js
@@ -23,7 +23,7 @@ class DashCoreRPC {
     }
   }
 
-  static async getProTxInfo (proTxHash, blockHash = NaN) {
+  static async getProTxInfo (proTxHash, blockHash = undefined) {
     try {
       const args = ['info', proTxHash]
       if (blockHash) args.push(blockHash)

--- a/packages/api/src/dashcoreRpc.js
+++ b/packages/api/src/dashcoreRpc.js
@@ -12,9 +12,19 @@ const config = {
 const rpc = new RpcClient(config)
 
 class DashCoreRPC {
-  static async getProTxInfo (proTxHash) {
+  static async getProTxInfo(proTxHash,blockHash) {
     try {
-      const { result } = await rpc.protx('info', proTxHash)
+      const { result } = await rpc.protx('info', proTxHash, blockHash)
+      return result
+    } catch (e) {
+      console.error(e)
+      throw new ServiceNotAvailableError()
+    }
+  }
+
+  static async getRawTransaction(proTxHash) {
+    try {
+      const { result } = await rpc.getRawTransaction(proTxHash, 1)
       return result
     } catch (e) {
       console.error(e)

--- a/packages/api/src/dashcoreRpc.js
+++ b/packages/api/src/dashcoreRpc.js
@@ -25,7 +25,10 @@ class DashCoreRPC {
 
   static async getProTxInfo (proTxHash, blockHash = NaN) {
     try {
-      const { result } = await rpc.protx('info', proTxHash, blockHash)
+      const args = ['info', proTxHash]
+      if (blockHash) args.push(blockHash)
+
+      const { result } = await rpc.protx(...args)
 
       return result
     } catch (e) {

--- a/packages/api/src/dashcoreRpc.js
+++ b/packages/api/src/dashcoreRpc.js
@@ -12,7 +12,7 @@ const config = {
 const rpc = new RpcClient(config)
 
 class DashCoreRPC {
-  static async getRawTransaction(proTxHash) {
+  static async getRawTransaction (proTxHash) {
     try {
       const { result } = await rpc.getRawTransaction(proTxHash, 1)
       return result
@@ -22,14 +22,14 @@ class DashCoreRPC {
     }
   }
 
-  static async getProTxInfo(proTxHash, blockHash) {
+  static async getProTxInfo (proTxHash, blockHash) {
     try {
-      const args = ['info', proTxHash, ]
-      if(blockHash) args.push(blockHash)
+      const args = ['info', proTxHash]
+      if (blockHash) args.push(blockHash)
       const { result } = await rpc.protx(...args)
       return result
     } catch (e) {
-      if (e.code == -8) {
+      if (e.code === -8) {
         const { blockhash } = await this.getRawTransaction(proTxHash)
         const result = await this.getProTxInfo(proTxHash, blockhash)
         return result


### PR DESCRIPTION
# Issue
There was a problem with getting proTxInfo for some specific validator that has been removed from the network. For such masternodes, you need to provide a block hash to get a correct data.

An example of such validator: `1404DDD2C5433554EBECB2CB2C3A8581C10D950D9B0E3374117DC10BC1BF3265A16A`

# Things done
An implementation was added to the `getProTxInfo` call the handles "protxinfo not found" error and isses an `getRawTransaction` method to get the hash of a block that we retry with to the getProTxInfo again.