### PR TITLE
The total number of identities on /status endpoint

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -80,6 +80,7 @@ HTTP /status
         startTime: "2024-04-08T14:00:00.000Z",
         endTime: "2024-04-09T14:00:00.000Z"
     },
+    identitiesCount: 12,
     transactionsCount: 3,
     transfersCount: 0,
     dataContractsCount: 1,

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -12,7 +12,7 @@ const API_VERSION = require('../../package.json').version
 const PLATFORM_VERSION = '1' + require('../../package.json').dependencies.dash.substring(1)
 
 class MainController {
-  constructor (knex) {
+  constructor(knex) {
     this.blocksDAO = new BlocksDAO(knex)
     this.dataContractsDAO = new DataContractsDAO(knex)
     this.documentsDAO = new DocumentsDAO(knex)
@@ -22,16 +22,15 @@ class MainController {
   }
 
   getStatus = async (request, response) => {
-    const [blocks, stats, tdStatus, genesisTime] = (await Promise.allSettled([
+    const [blocks, stats, identitiesCount, tdStatus, genesisTime] = (await Promise.allSettled([
       this.blocksDAO.getBlocks(1, 1, 'desc'),
       this.blocksDAO.getStats(),
+      this.identitiesDAO.getStatus(),
       TenderdashRPC.getStatus(),
-      Constants.genesisTime
+      Constants.genesisTime,
     ])).map((e) => e.value ?? null)
 
     const [currentBlock] = blocks?.resultSet ?? []
-
-    const identitiesCount = await this.identitiesDAO.getIdentitiesCount()
 
     const epoch = genesisTime && currentBlock
       ? Epoch.fromObject({

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -12,7 +12,7 @@ const API_VERSION = require('../../package.json').version
 const PLATFORM_VERSION = '1' + require('../../package.json').dependencies.dash.substring(1)
 
 class MainController {
-  constructor(knex) {
+  constructor (knex) {
     this.blocksDAO = new BlocksDAO(knex)
     this.dataContractsDAO = new DataContractsDAO(knex)
     this.documentsDAO = new DocumentsDAO(knex)
@@ -22,12 +22,11 @@ class MainController {
   }
 
   getStatus = async (request, response) => {
-    const [blocks, stats, identitiesCount, tdStatus, genesisTime] = (await Promise.allSettled([
+    const [blocks, stats, tdStatus, genesisTime] = (await Promise.allSettled([
       this.blocksDAO.getBlocks(1, 1, 'desc'),
       this.blocksDAO.getStats(),
-      this.identitiesDAO.getStatus(),
       TenderdashRPC.getStatus(),
-      Constants.genesisTime,
+      Constants.genesisTime
     ])).map((e) => e.value ?? null)
 
     const [currentBlock] = blocks?.resultSet ?? []
@@ -45,7 +44,7 @@ class MainController {
       transfersCount: stats?.transfersCount,
       dataContractsCount: stats?.dataContractsCount,
       documentsCount: stats?.documentsCount,
-      identitiesCount,
+      identitiesCount: stats?.identitiesCount,
       network: tdStatus?.network ?? null,
       api: {
         version: API_VERSION,

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -31,6 +31,8 @@ class MainController {
 
     const [currentBlock] = blocks?.resultSet ?? []
 
+    const identitiesCount = await this.identitiesDAO.getIdentitiesCount()
+
     const epoch = genesisTime && currentBlock
       ? Epoch.fromObject({
         timestamp: currentBlock.header.timestamp,
@@ -44,6 +46,7 @@ class MainController {
       transfersCount: stats?.transfersCount,
       dataContractsCount: stats?.dataContractsCount,
       documentsCount: stats?.documentsCount,
+      identitiesCount,
       network: tdStatus?.network ?? null,
       api: {
         version: API_VERSION,

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -12,6 +12,7 @@ module.exports = class BlockDAO {
       .select(this.knex('transfers').count('*').as('transfers_count'))
       .select(this.knex('data_contracts').count('*').as('data_contracts_count'))
       .select(this.knex('documents').count('*').as('documents_count'))
+      .select(this.knex('identities').count('*').as('identities_count'))
 
     const [row] = rows
 
@@ -19,14 +20,16 @@ module.exports = class BlockDAO {
       tx_count: txCount,
       transfers_count: transfersCount,
       data_contracts_count: dataContractsCount,
-      documents_count: documentsCount
+      documents_count: documentsCount,
+      identities_count: identitiesCount
     } = row
 
     return {
       transactionsCount: parseInt(txCount),
       transfersCount: parseInt(transfersCount),
       dataContractsCount: parseInt(dataContractsCount),
-      documentsCount: parseInt(documentsCount)
+      documentsCount: parseInt(documentsCount),
+      identitiesCount: parseInt(identitiesCount)
     }
   }
 

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -65,6 +65,13 @@ module.exports = class IdentitiesDAO {
     return Identity.fromRow({ ...row })
   }
 
+  getIdentitiesCount = async () => {
+    const [{ count }] = await this.knex('identities')
+      .count('*')
+
+    return Number(count ?? 0)
+  }
+
   getIdentityByDPNS = async (dpns) => {
     const identifier = this.knex('identity_aliases')
       .select('identity_identifier')

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -10,13 +10,6 @@ module.exports = class IdentitiesDAO {
     this.knex = knex
   }
 
-  getStatus = async () => {
-    const [{ count }] = await this.knex('identities')
-      .count('*')
-
-    return Number(count ?? 0)
-  }
-
   getIdentityByIdentifier = async (identifier) => {
     const subquery = this.knex('identities')
       .select('identities.id', 'identities.identifier as identifier', 'identities.owner as owner',

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -10,6 +10,13 @@ module.exports = class IdentitiesDAO {
     this.knex = knex
   }
 
+  getStatus = async () => {
+    const [{ count }] = await this.knex('identities')
+      .count('*')
+
+    return Number(count ?? 0)
+  }
+
   getIdentityByIdentifier = async (identifier) => {
     const subquery = this.knex('identities')
       .select('identities.id', 'identities.identifier as identifier', 'identities.owner as owner',
@@ -63,13 +70,6 @@ module.exports = class IdentitiesDAO {
     const [row] = rows
 
     return Identity.fromRow({ ...row })
-  }
-
-  getIdentitiesCount = async () => {
-    const [{ count }] = await this.knex('identities')
-      .count('*')
-
-    return Number(count ?? 0)
   }
 
   getIdentityByDPNS = async (dpns) => {

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -251,6 +251,7 @@ describe('Other routes', () => {
 
       const expectedStats = {
         epoch: null,
+        identitiesCount: 1,
         transactionsCount: 3,
         transfersCount: 0,
         dataContractsCount: 1,
@@ -304,6 +305,7 @@ describe('Other routes', () => {
 
       const expectedStats = {
         epoch: null,
+        identitiesCount: 1,
         transactionsCount: 3,
         transfersCount: 0,
         dataContractsCount: 1,
@@ -362,6 +364,7 @@ describe('Other routes', () => {
           startTime: '1970-01-01T18:00:00.000Z',
           endTime: '1970-01-01T19:00:00.000Z'
         },
+        identitiesCount: 1,
         transactionsCount: 3,
         transfersCount: 0,
         dataContractsCount: 1,

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -47,6 +47,7 @@ HTTP /status
         startTime: "2024-04-08T14:00:00.000Z",
         endTime: "2024-04-09T14:00:00.000Z"
     },
+    identitiesCount: 12,
     transactionsCount: 3,
     transfersCount: 0,
     dataContractsCount: 1,


### PR DESCRIPTION
# Issue
A request was received to add the `identitiesCount` field to the /status page

# Things done
the getStatus method in BlocksDAO has been updated that now also returns the number of Identities in the network. In addition, the `MainController` has been changed. The tests for `MainController` have been updated and `README.md` has been completed