### PR TITLE
CI Github Release permissions fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,9 +8,13 @@ on:
     types: 
       - completed
 
-jobs: 
+jobs:
   create_tag:
     runs-on: ubuntu-latest
+
+    permissions:
+      packages: write
+      contents: write
 
     if: github.event.workflow_run.conclusion == 'success'
     steps:


### PR DESCRIPTION
# Issue
Right now we are getting a 403 error when trying to create a release due to incorrect permissions
# Things done
Permissions in `release.yml` has been added