### PR TITLE
Do not create system identities

### DIFF
--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -364,8 +364,6 @@ impl PSQLProcessor {
         let identity = Identity::from(system_data_contract);
         let data_contract_identifier = data_contract.identifier.clone();
         let data_contract_owner = data_contract.owner.clone();
-
-        self.dao.create_identity(identity, None).await.unwrap();
         self.dao.create_data_contract(data_contract, None).await;
 
         match system_data_contract {


### PR DESCRIPTION
# Issue

Since Dash Platform v1, there is not system identities that comes with system data contracts. Instead, its just a zero bytes now. Thus, we should not track them in the database anymore

# Things done
Removed system identities initialization