### PR TITLE
Update validators list filter

### DIFF
--- a/packages/frontend/src/app/validators/Validators.js
+++ b/packages/frontend/src/app/validators/Validators.js
@@ -33,7 +33,7 @@ function Validators ({ defaultPage = 1, defaultPageSize, defaultIsActive }) {
   const fetchData = (page, count, active) => {
     setValidators({ data: {}, loading: true, error: false })
 
-    Api.getValidators(page, count, 'desc', active)
+    Api.getValidators(page, count, 'desc', active || null)
       .then(res => {
         if (res.pagination.total === -1) {
           setCurrentPage(0)
@@ -90,7 +90,7 @@ function Validators ({ defaultPage = 1, defaultPageSize, defaultIsActive }) {
                     title: 'Active'
                   },
                   {
-                    title: 'Inactive'
+                    title: 'All'
                   }
                 ]}
                 onChange={e => isActiveSwitchHandler(e === 'Active')}

--- a/packages/frontend/src/app/validators/Validators.js
+++ b/packages/frontend/src/app/validators/Validators.js
@@ -24,7 +24,7 @@ function Validators ({ defaultPage = 1, defaultPageSize, defaultIsActive }) {
   const [pageSize, setPageSize] = useState(defaultPageSize || paginateConfig.pageSize.default)
   const [currentPage, setCurrentPage] = useState(defaultPage ? defaultPage - 1 : 0)
   const [total, setTotal] = useState(1)
-  const [isActive, setIsActive] = useState(defaultIsActive !== undefined ? defaultIsActive === true : true)
+  const [isActive, setIsActive] = useState(defaultIsActive !== undefined ? defaultIsActive === true : false)
   const pageCount = Math.ceil(total / pageSize)
   const router = useRouter()
   const pathname = usePathname()
@@ -87,13 +87,13 @@ function Validators ({ defaultPage = 1, defaultPageSize, defaultIsActive }) {
               <Switcher
                 options={[
                   {
-                    title: 'Active'
+                    title: 'All'
                   },
                   {
-                    title: 'All'
+                    title: 'Current'
                   }
                 ]}
-                onChange={e => isActiveSwitchHandler(e === 'Active')}
+                onChange={e => isActiveSwitchHandler(e === 'Current')}
               />
             </Box>
 

--- a/packages/frontend/src/util/Api.js
+++ b/packages/frontend/src/util/Api.js
@@ -99,8 +99,8 @@ const getIdentities = (page = 1, limit = 30, order = 'asc', orderBy) => {
   return call(`identities?page=${page}&limit=${limit}&order=${order}${orderBy ? `&order_by=${orderBy}` : ''}`, 'GET')
 }
 
-const getValidators = (page = 1, limit = 30, order = 'asc', isActive = true, orderBy) => {
-  return call(`validators?page=${page}&limit=${limit}&order=${order}&isActive=${String(isActive)}${orderBy ? `&order_by=${orderBy}` : ''}`, 'GET')
+const getValidators = (page = 1, limit = 30, order = 'asc', isActive, orderBy) => {
+  return call(`validators?page=${page}&limit=${limit}&order=${order}${typeof isActive === 'boolean' ? `&isActive=${String(isActive)}` : ''}${orderBy ? `&order_by=${orderBy}` : ''}`, 'GET')
 }
 
 const getValidatorByProTxHash = (proTxHash) => {


### PR DESCRIPTION
# Issue
Active / Inactive validators list filtering is confusing people, we should make it All / Current instead so masternode owner won't worry that there is something with their nodes.
It will be more convenient if we make filtering in the list of validators as all / current.

# Things done
* Changed filtering from Active / Inactive to All / Current