### PR TITLE
Add validator's identities in the indexer

### DIFF
--- a/packages/indexer/Cargo.lock
+++ b/packages/indexer/Cargo.lock
@@ -1115,6 +1115,7 @@ dependencies = [
  "dotenv",
  "dpp",
  "futures",
+ "hex",
  "refinery",
  "reqwest",
  "serde",

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -24,3 +24,4 @@ chrono = { version = "0.4.34", features = ["serde", "rustc-serialize"] }
 tokio-postgres = { version="0.7.10", features=["with-chrono-0_4", "with-serde_json-1"] }
 time = { version="0.3.29", features=["serde"] }
 dashcore-rpc = { git = "https://github.com/dashpay/rust-dashcore-rpc", tag = "v0.15.2" }
+hex = "0.4.3"

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -311,7 +311,8 @@ impl PSQLProcessor {
 
         match existing {
             None => {
-                self.dao.create_validator(validator).await?;
+                self.dao.create_validator(validator.clone()).await?;
+                self.dao.create_identity(Identity::from(validator), None).await?;
                 Ok(())
             }
             Some(_) => Ok(())


### PR DESCRIPTION
# Issue

All validators have its own automatically generated identities in the system, but we do not track them yet. Indexer should automatically create an Identity in the database as soon as it finds the validator in the chain.

# Things done
* Added a identity creation when inserting a validator in the database
