### PR TITLE
Base64 identity balance fix

### DIFF
--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -9,8 +9,8 @@ class DAPI {
     this.dpp = dpp
   }
 
-  async getIdentityBalance (identifier) {
-    const { balance } = await this.dapi.platform.getIdentityBalance(Identifier.from(identifier))
+  async getIdentityBalance (identifier, encoding='base58') {
+    const { balance } = await this.dapi.platform.getIdentityBalance(Identifier.from(identifier, encoding))
     return balance
   }
 

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -40,7 +40,7 @@ class IdentitiesController {
     const identities = await this.identitiesDAO.getIdentities(Number(page), Number(limit), order, orderBy)
 
     const identitiesWithBalance = await Promise.all(identities.resultSet.map(async identity => {
-      const balance = await this.dapi.getIdentityBalance(identity.identifier)
+      const balance = await this.dapi.getIdentityBalance(identity.identifier,identity.txHash?'base58':'base64')
       return { ...identity, balance }
     }))
 


### PR DESCRIPTION
# Issue
Error when trying to get identity with base64 identitifier and Error on zero balance without proofs
# Things done
added convertation from base64 to base58

updated `GetIdentityBalanceResponse.js` in [dapi-client](https://github.com/owl352/dapi-client)