### PR TITLE
Case sensitivity in search

### DIFF
--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -77,7 +77,7 @@ class MainController {
       }
     }
 
-    if (/^[0-9A-F]{64,64}$/.test(query)) {
+    if (/^[0-9A-f]{64,64}$/.test(query)) {
       // search block by hash
       const block = await this.blocksDAO.getBlockByHash(query)
 


### PR DESCRIPTION
# Issue
At this moment we have non sensetive for case hash, but we dont have this at `/search` endpoint

# Things done
removed case sensetive in `/search`