### PR TITLE
Identities sort by balance test fix

### DIFF
--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -356,18 +356,29 @@ describe('Identities routes', () => {
           owner: identity.identifier
         })
         transfer = await fixtures.transfer(knex, {
-          amount: Math.floor(1000 * Math.random()),
+          amount: Math.floor(25 * (i+1)),
           recipient: identity.identifier,
           state_transition_hash: transferTx.hash
         })
+
         identity.balance = transfer.amount
+
         identities.push({ identity, block, transfer })
       }
+
+      mock.reset()
 
       mock.method(DAPI.prototype, 'getIdentityBalance', async (identifier) => {
         const { identity } = identities.find(({ identity }) => identity.identifier === identifier)
         return identity.balance
       })
+      mock.method(tenderdashRpc, 'getBlockByHeight', async () => ({
+        block: {
+          header: {
+            time: new Date(0).toISOString()
+          }
+        }
+      }))
 
       const { body } = await client.get('/identities?order_by=balance&order=desc')
         .expect(200)

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -356,7 +356,7 @@ describe('Identities routes', () => {
           owner: identity.identifier
         })
         transfer = await fixtures.transfer(knex, {
-          amount: Math.floor(25 * (i+1)),
+          amount: Math.floor(25 * (i + 1)),
           recipient: identity.identifier,
           state_transition_hash: transferTx.hash
         })


### PR DESCRIPTION
# Issue
At this moment, our test for identities with `sortBy=balance` throws error on deepEquals.
The reason for this - `Math.random()` for balance, sometimes balance on several identities can be the same and that's violates this test

# Things done
`1000 * Math.random()` replaced with `25 * (i+1)`
before DAPI mock added `mock.reset()`
tiny lint