### PR TITLE
Implement identities names on the backend

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -544,7 +544,8 @@ GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
     totalTransfers: 0,
     totalDocuments: 0,
     totalDataContracts: 0,
-    isSystem: false
+    isSystem: false,
+    alias: "test.dash"
 }
 ```
 Response codes:
@@ -606,7 +607,8 @@ GET /identities?page=1&limit=10&order=asc&order_by=block_height
         totalTransfers: 0,
         totalDocuments: 0,
         totalDataContracts: 0,
-        isSystem: false
+        isSystem: false,
+        alias: "test.dash"
     }, ...
     ]
 }

--- a/packages/api/src/models/Identity.js
+++ b/packages/api/src/models/Identity.js
@@ -9,8 +9,9 @@ module.exports = class Identity {
   totalDocuments
   totalDataContracts
   isSystem
+  alias
 
-  constructor (identifier, owner, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash, isSystem) {
+  constructor (identifier, owner, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash, isSystem, alias) {
     this.identifier = identifier ? identifier.trim() : null
     this.owner = owner ? owner.trim() : null
     this.revision = revision ?? null
@@ -22,10 +23,11 @@ module.exports = class Identity {
     this.totalTransfers = totalTransfers ?? null
     this.txHash = txHash ?? null
     this.isSystem = isSystem ?? null
+    this.alias = alias ?? null
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow ({ identifier, owner, revision, balance, timestamp, total_txs, total_data_contracts, total_documents, total_transfers, tx_hash, is_system }) {
-    return new Identity(identifier, owner, revision, Number(balance), timestamp, Number(total_txs), Number(total_data_contracts), Number(total_documents), Number(total_transfers), tx_hash, is_system)
+  static fromRow ({ identifier, owner, revision, balance, timestamp, total_txs, total_data_contracts, total_documents, total_transfers, tx_hash, is_system, alias }) {
+    return new Identity(identifier, owner, revision, Number(balance), timestamp, Number(total_txs), Number(total_data_contracts), Number(total_documents), Number(total_transfers), tx_hash, is_system, alias)
   }
 }

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -14,6 +14,7 @@ describe('Identities routes', () => {
   let knex
 
   let identity
+  let alias
   let block
   let dataContract
   let dataContractTransaction
@@ -55,6 +56,12 @@ describe('Identities routes', () => {
     it('should return identity by identifier', async () => {
       const block = await fixtures.block(knex)
       const identity = await fixtures.identity(knex, { block_hash: block.hash })
+      const { alias } = await fixtures.identity_alias(knex,
+        {
+          alias: 'test',
+          identity
+        }
+      )
 
       const { body } = await client.get(`/identity/${identity.identifier}`)
         .expect(200)
@@ -71,7 +78,8 @@ describe('Identities routes', () => {
         totalTransfers: 0,
         totalDocuments: 0,
         totalDataContracts: 0,
-        isSystem: false
+        isSystem: false,
+        alias
       }
 
       assert.deepEqual(body, expectedIdentity)
@@ -88,7 +96,7 @@ describe('Identities routes', () => {
     it('should return identity by dpns', async () => {
       const block = await fixtures.block(knex)
       const identity = await fixtures.identity(knex, { block_hash: block.hash })
-      await fixtures.identity_alias(knex, { alias: 'test-name.1.dash', identity })
+      const { alias } = await fixtures.identity_alias(knex, { alias: 'test-name.1.dash', identity })
 
       const { body } = await client.get('/dpns/identity?dpns=test-name.1.dash')
         .expect(200)
@@ -105,7 +113,8 @@ describe('Identities routes', () => {
         totalTransfers: 0,
         totalDocuments: 0,
         totalDataContracts: 0,
-        isSystem: false
+        isSystem: false,
+        alias
       }
 
       assert.deepEqual(body, expectedIdentity)
@@ -114,7 +123,7 @@ describe('Identities routes', () => {
     it('should return identity by dpns with any case', async () => {
       const block = await fixtures.block(knex)
       const identity = await fixtures.identity(knex, { block_hash: block.hash })
-      await fixtures.identity_alias(knex, { alias: 'test-name.2.dash', identity })
+      const { alias } = await fixtures.identity_alias(knex, { alias: 'test-name.2.dash', identity })
 
       const { body } = await client.get('/dpns/identity?dpns=TeSt-NaME.2.DAsH')
         .expect(200)
@@ -131,7 +140,8 @@ describe('Identities routes', () => {
         totalTransfers: 0,
         totalDocuments: 0,
         totalDataContracts: 0,
-        isSystem: false
+        isSystem: false,
+        alias
       }
 
       assert.deepEqual(body, expectedIdentity)
@@ -147,11 +157,14 @@ describe('Identities routes', () => {
   describe('getIdentities()', async () => {
     it('should return default set of identities', async () => {
       const identities = []
+      const aliases = []
 
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
         identity = await fixtures.identity(knex, { block_hash: block.hash })
+        alias = await fixtures.identity_alias(knex, { alias: `#test$${i}`, identity })
         identities.push({ identity, block })
+        aliases.push(alias)
       }
 
       const { body } = await client.get('/identities')
@@ -174,18 +187,22 @@ describe('Identities routes', () => {
         totalTransfers: 0,
         totalDocuments: 0,
         totalDataContracts: 0,
-        isSystem: false
+        isSystem: false,
+        alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
       }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
     })
     it('should return default set of identities desc', async () => {
       const identities = []
+      const aliases = []
 
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
         identity = await fixtures.identity(knex, { block_hash: block.hash })
+        alias = await fixtures.identity_alias(knex, { alias: `#test1$${i}`, identity })
         identities.push({ identity, block })
+        aliases.push(alias)
       }
 
       const { body } = await client.get('/identities?order=desc')
@@ -210,7 +227,8 @@ describe('Identities routes', () => {
           totalTransfers: 0,
           totalDocuments: 0,
           totalDataContracts: 0,
-          isSystem: false
+          isSystem: false,
+          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -218,11 +236,14 @@ describe('Identities routes', () => {
 
     it('should allow walk through pages', async () => {
       const identities = []
+      const aliases = []
 
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
         identity = await fixtures.identity(knex, { block_hash: block.hash })
+        alias = await fixtures.identity_alias(knex, { alias: `#test2$${i}`, identity })
         identities.push({ identity, block })
+        aliases.push(alias)
       }
 
       const { body } = await client.get('/identities?page=2')
@@ -247,7 +268,8 @@ describe('Identities routes', () => {
           totalTransfers: 0,
           totalDocuments: 0,
           totalDataContracts: 0,
-          isSystem: false
+          isSystem: false,
+          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -255,11 +277,14 @@ describe('Identities routes', () => {
 
     it('should allow walk through pages desc', async () => {
       const identities = []
+      const aliases = []
 
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
         identity = await fixtures.identity(knex, { block_hash: block.hash })
+        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity })
         identities.push({ identity, block })
+        aliases.push(alias)
       }
 
       const { body } = await client.get('/identities?page=2&limit=5&order=desc')
@@ -285,7 +310,9 @@ describe('Identities routes', () => {
           totalTransfers: 0,
           totalDocuments: 0,
           totalDataContracts: 0,
-          isSystem: false
+          isSystem: false,
+          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
+
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -293,6 +320,7 @@ describe('Identities routes', () => {
 
     it('should allow sort by tx count', async () => {
       const identities = []
+      const aliases = []
 
       for (let i = 0; i < 30; i++) {
         const transactions = []
@@ -313,6 +341,8 @@ describe('Identities routes', () => {
         identity.transactions = transactions
 
         identities.push({ identity, block })
+        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity })
+        aliases.push(alias)
       }
 
       const { body } = await client.get('/identities?order_by=tx_count&order=desc')
@@ -338,7 +368,8 @@ describe('Identities routes', () => {
           totalTransfers: 0,
           totalDocuments: 0,
           totalDataContracts: 0,
-          isSystem: false
+          isSystem: false,
+          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -346,6 +377,7 @@ describe('Identities routes', () => {
 
     it('should allow sort by balance', async () => {
       const identities = []
+      const aliases = []
 
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
@@ -364,6 +396,8 @@ describe('Identities routes', () => {
         identity.balance = transfer.amount
 
         identities.push({ identity, block, transfer })
+        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity })
+        aliases.push(alias)
       }
 
       mock.reset()
@@ -403,7 +437,9 @@ describe('Identities routes', () => {
           totalTransfers: 1,
           totalDocuments: 0,
           totalDataContracts: 0,
-          isSystem: false
+          isSystem: false,
+          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
+
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -218,7 +218,7 @@ describe('Other routes', () => {
       assert.deepEqual({ dataContract: expectedDataContract }, body)
     })
 
-    it('should search by identity', async () => {
+    it('should search by identity DPNS', async () => {
       mock.method(DAPI.prototype, 'getIdentityBalance', async () => 0)
 
       const { body } = await client.get(`/search?query=${identityAlias.alias}`)
@@ -236,13 +236,14 @@ describe('Other routes', () => {
         totalDocuments: 1,
         totalDataContracts: 1,
         isSystem: false,
-        owner: identity.identifier
+        owner: identity.identifier,
+        alias: 'dpns.dash'
       }
 
       assert.deepEqual({ identity: expectedIdentity }, body)
     })
 
-    it('should search identity by DPNS', async () => {
+    it('should search identity', async () => {
       const { body } = await client.get(`/search?query=${identity.identifier}`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
@@ -258,7 +259,8 @@ describe('Other routes', () => {
         totalDocuments: 1,
         totalDataContracts: 1,
         isSystem: false,
-        owner: identity.identifier
+        owner: identity.identifier,
+        alias: 'dpns.dash'
       }
 
       assert.deepEqual({ identity: expectedIdentity }, body)

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -29,7 +29,7 @@ Reference:
 * [Transactions By Identity](#transactions-by-identity)
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
-* [Rate](#rate)
+* [Rate](#rates)
 
 ### Status
 Returns basic stats and epoch info
@@ -511,7 +511,8 @@ GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
     totalTransfers: 0,
     totalDocuments: 0,
     totalDataContracts: 0,
-    isSystem: false
+    isSystem: false,
+    alias: "test.dash"
 }
 ```
 Response codes:
@@ -573,7 +574,8 @@ GET /identities?page=1&limit=10&order=asc&order_by=block_height
         totalTransfers: 0,
         totalDocuments: 0,
         totalDataContracts: 0,
-        isSystem: false
+        isSystem: false,
+        alias: "test.dash"
     }, ...
     ]
 }


### PR DESCRIPTION
# Issue
At this momment, we have aliases in indexer database, but those aliases don't show up anywhere in our responses.

# Things done
Added `alias` field to identity responses
Updated `Reamde.md`
Updated integration tests for identities