### PR TITLE
Identities duplicates fix

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -545,7 +545,7 @@ GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
     totalDocuments: 0,
     totalDataContracts: 0,
     isSystem: false,
-    alias: "test.dash"
+    aliases: ["test.dash"...]
 }
 ```
 Response codes:
@@ -571,7 +571,8 @@ GET /dpns/identity?dpns=test-name.1.dash
     totalTransfers: 0,
     totalDocuments: 0,
     totalDataContracts: 0,
-    isSystem: false
+    isSystem: false,
+    aliases: []
 }
 ```
 Response codes:
@@ -608,7 +609,7 @@ GET /identities?page=1&limit=10&order=asc&order_by=block_height
         totalDocuments: 0,
         totalDataContracts: 0,
         isSystem: false,
-        alias: "test.dash"
+        aliases: ["test.dash"]
     }, ...
     ]
 }

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -12,8 +12,9 @@ module.exports = class IdentitiesDAO {
 
   getIdentityByIdentifier = async (identifier) => {
     const aliasSubquery = this.knex('identity_aliases')
-      .select('identity_identifier', 'alias')
+      .select('identity_identifier', this.knex.raw('array_agg(alias) as aliases'))
       .where('identity_identifier', '=', identifier)
+      .groupBy('identity_identifier')
       .as('identity_alias')
 
     const subquery = this.knex('identities')
@@ -57,7 +58,7 @@ module.exports = class IdentitiesDAO {
       .select(this.knex(documentsSubQuery).count('*').where('rank', 1).as('total_documents'))
       .select(this.knex(dataContractsSubQuery).count('*').where('rank', 1).as('total_data_contracts'))
       .select(this.knex(transfersSubquery).count('*').as('total_transfers'))
-      .select(this.knex(aliasSubquery).select('alias').limit(1).as('alias'))
+      .select(this.knex(aliasSubquery).select('aliases').limit(1).as('aliases'))
       .from('with_alias')
       .limit(1)
 
@@ -100,6 +101,11 @@ module.exports = class IdentitiesDAO {
         acc + ` ${value.column} ${value.order}${index === arr.length - 1 ? '' : ','}`, 'order by')
     }
 
+    const aliasesSubquery = this.knex('identity_aliases')
+      .select('identity_identifier', this.knex.raw('array_agg(alias) as aliases'))
+      .groupBy('identity_identifier')
+      .as('aliases')
+
     const subquery = this.knex('identities')
       .select('identities.id as identity_id', 'identities.identifier as identifier', 'identities.owner as identity_owner',
         'identities.is_system as is_system', 'identities.state_transition_hash as tx_hash',
@@ -124,8 +130,8 @@ module.exports = class IdentitiesDAO {
       .whereRaw('data_contracts.owner = with_alias.identifier')
       .as('as_data_contracts')
 
-    const withouOrder = this.knex.with('with_alias', filteredIdentities)
-      .select('total_txs', 'identity_id', 'identifier', 'identity_owner', 'revision', 'tx_hash', 'blocks.timestamp as timestamp', 'row_number', 'is_system', 'identity_aliases.alias as alias', 'balance')
+    const rows = await this.knex.with('with_alias', filteredIdentities)
+      .select('total_txs', 'identity_id', 'identifier', 'identity_owner', 'revision', 'tx_hash', 'blocks.timestamp as timestamp', 'row_number', 'is_system', 'aliases.aliases as aliases', 'balance')
       .select(this.knex('with_alias').count('*').as('total_count'))
       .select(this.knex(this.knex(documentsSubQuery)
         .select('id', this.knex.raw('rank() over (partition by as_documents.identifier order by as_documents.id desc) rank')).as('ranked_documents'))
@@ -136,22 +142,10 @@ module.exports = class IdentitiesDAO {
       .select(this.knex('transfers').count('*').whereRaw('sender = identifier or recipient = identifier').as('total_transfers'))
       .leftJoin('state_transitions', 'state_transitions.hash', 'tx_hash')
       .leftJoin('blocks', 'state_transitions.block_hash', 'blocks.hash')
-      .leftJoin('identity_aliases', 'identity_aliases.identity_identifier', 'identifier')
-      .from('with_alias')
-      .distinctOn('identifier')
-
-    const rows = await this.knex.with('alias', withouOrder)
-      .select(
-        'total_txs', 'identity_id', 'identifier',
-        'identity_owner', 'revision', 'tx_hash',
-        'timestamp', 'row_number', 'is_system',
-        'alias', 'total_count', 'total_documents',
-        'total_data_contracts', 'total_transfers',
-        'balance'
-      )
+      .leftJoin(aliasesSubquery, 'identity_identifier', 'identifier')
       .whereBetween('row_number', [fromRank, toRank])
       .orderBy(orderByOptions)
-      .from('alias')
+      .from('with_alias')
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 

--- a/packages/api/src/models/Identity.js
+++ b/packages/api/src/models/Identity.js
@@ -9,9 +9,9 @@ module.exports = class Identity {
   totalDocuments
   totalDataContracts
   isSystem
-  alias
+  aliases
 
-  constructor (identifier, owner, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash, isSystem, alias) {
+  constructor (identifier, owner, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash, isSystem, aliases) {
     this.identifier = identifier ? identifier.trim() : null
     this.owner = owner ? owner.trim() : null
     this.revision = revision ?? null
@@ -23,11 +23,11 @@ module.exports = class Identity {
     this.totalTransfers = totalTransfers ?? null
     this.txHash = txHash ?? null
     this.isSystem = isSystem ?? null
-    this.alias = alias ?? null
+    this.aliases = aliases ?? []
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow ({ identifier, owner, revision, balance, timestamp, total_txs, total_data_contracts, total_documents, total_transfers, tx_hash, is_system, alias }) {
-    return new Identity(identifier, owner, revision, Number(balance), timestamp, Number(total_txs), Number(total_data_contracts), Number(total_documents), Number(total_transfers), tx_hash, is_system, alias)
+  static fromRow ({ identifier, owner, revision, balance, timestamp, total_txs, total_data_contracts, total_documents, total_transfers, tx_hash, is_system, aliases }) {
+    return new Identity(identifier, owner, revision, Number(balance), timestamp, Number(total_txs), Number(total_data_contracts), Number(total_documents), Number(total_transfers), tx_hash, is_system, aliases)
   }
 }

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -79,7 +79,7 @@ describe('Identities routes', () => {
         totalDocuments: 0,
         totalDataContracts: 0,
         isSystem: false,
-        alias
+        aliases: [alias]
       }
 
       assert.deepEqual(body, expectedIdentity)
@@ -114,7 +114,7 @@ describe('Identities routes', () => {
         totalDocuments: 0,
         totalDataContracts: 0,
         isSystem: false,
-        alias
+        aliases: [alias]
       }
 
       assert.deepEqual(body, expectedIdentity)
@@ -141,7 +141,7 @@ describe('Identities routes', () => {
         totalDocuments: 0,
         totalDataContracts: 0,
         isSystem: false,
-        alias
+        aliases: [alias]
       }
 
       assert.deepEqual(body, expectedIdentity)
@@ -188,7 +188,7 @@ describe('Identities routes', () => {
         totalDocuments: 0,
         totalDataContracts: 0,
         isSystem: false,
-        alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
+        aliases: [aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias]
       }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -228,7 +228,7 @@ describe('Identities routes', () => {
           totalDocuments: 0,
           totalDataContracts: 0,
           isSystem: false,
-          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
+          aliases: [aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias]
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -269,7 +269,7 @@ describe('Identities routes', () => {
           totalDocuments: 0,
           totalDataContracts: 0,
           isSystem: false,
-          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
+          aliases: [aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias]
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -311,7 +311,7 @@ describe('Identities routes', () => {
           totalDocuments: 0,
           totalDataContracts: 0,
           isSystem: false,
-          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
+          aliases: [aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias]
 
         }))
 
@@ -369,7 +369,7 @@ describe('Identities routes', () => {
           totalDocuments: 0,
           totalDataContracts: 0,
           isSystem: false,
-          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
+          aliases: [aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias]
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -438,7 +438,7 @@ describe('Identities routes', () => {
           totalDocuments: 0,
           totalDataContracts: 0,
           isSystem: false,
-          alias: aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
+          aliases: [aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias]
 
         }))
 

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -237,7 +237,7 @@ describe('Other routes', () => {
         totalDataContracts: 1,
         isSystem: false,
         owner: identity.identifier,
-        alias: 'dpns.dash'
+        aliases: ['dpns.dash']
       }
 
       assert.deepEqual({ identity: expectedIdentity }, body)
@@ -260,7 +260,7 @@ describe('Other routes', () => {
         totalDataContracts: 1,
         isSystem: false,
         owner: identity.identifier,
-        alias: 'dpns.dash'
+        aliases: ['dpns.dash']
       }
 
       assert.deepEqual({ identity: expectedIdentity }, body)

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -512,7 +512,7 @@ GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
     totalDocuments: 0,
     totalDataContracts: 0,
     isSystem: false,
-    alias: "test.dash"
+    aliases: ["test.dash"...]
 }
 ```
 Response codes:
@@ -538,7 +538,8 @@ GET /dpns/identity?dpns=test-name.1.dash
     totalTransfers: 0,
     totalDocuments: 0,
     totalDataContracts: 0,
-    isSystem: false
+    isSystem: false,
+    aliases: []
 }
 ```
 Response codes:
@@ -575,7 +576,7 @@ GET /identities?page=1&limit=10&order=asc&order_by=block_height
         totalDocuments: 0,
         totalDataContracts: 0,
         isSystem: false,
-        alias: "test.dash"
+        aliases: ["test.dash"]
     }, ...
     ]
 }


### PR DESCRIPTION
# Issue
After adding aliases to response for identities, we ran into a problem with duplicates.

# Things done
Grouped by `identity_identifier` in `identity_aliases`