### PR TITLE
Prefix version and remove unnecessary packages

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,10 +12,7 @@
     "lint": "standard ."
   },
   "dependencies": {
-    "@dashevo/dapi-grpc": "^1.4.0",
-    "@dashevo/dapi-client": "^1.4.0",
-    "@dashevo/dashd-rpc": "^19.0.0",
-    "@dashevo/wasm-dpp": "^1.4.0",
+    "@dashevo/dashd-rpc": "19.0.0",
     "@fastify/cors": "^8.3.0",
     "@scure/base": "^1.1.5",
     "bs58": "^6.0.0",


### PR DESCRIPTION
# Issue
dashevo packages was marked as ^ in the package.json that was incorrectly pulling correct version of the Dash sdk

Incorrect packages in `package.json` broke deserialize_consensus_error

# Things done
`package.json` has been updated