### PR TITLE
Move endpoints out of protx in the validators

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -281,6 +281,7 @@ GET /validators
       withdrawalsCount: null,
       lastWithdrawal: null,
       lastWithdrawalTime: null,
+      endpoints: null
     }, ...
   ],
   pagination: { 
@@ -334,23 +335,6 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
       platformHTTPPort: 1443,
       payoutAddress: "yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A",
       pubKeyOperator: "b928fa4e127214ccb2b5de1660b5e371d2f3c9845077bc3900fc6aabe82ddd2e61530be3765cea15752e30fc761ab730",
-      endpoints: {
-        coreP2PPortStatus: {
-          host: '52.33.28.41',
-          port: 19999,
-          status: 'ERROR'
-        },
-        platformP2PPortStatus: {
-          host: '52.33.28.41',
-          port: 36656,
-          status: 'ERROR'
-        },
-        platformGrpcPortStatus: {
-          host: '52.33.28.41',
-          port: 1443,
-          status: 'ERROR'
-        }
-      }
     }
   },
   identity: "8tsWRSwsTM5AXv4ViCF9gu39kzjbtfFDM6rCyL2RcFzd",
@@ -367,7 +351,24 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
   epochReward: 0,
   withdrawalsCount: 1,
   lastWithdrawal: "01FE1F00379C66C6E3BFD81A088E57E17613EC36E4FF812458535A8ABCB84047",
-  lastWithdrawalTime: "2024-10-12T03:15:19.257Z"
+  lastWithdrawalTime: "2024-10-12T03:15:19.257Z",
+  endpoints: {
+    coreP2PPortStatus: {
+      host: '52.33.28.41',
+      port: 19999,
+      status: 'ERROR'
+    },
+    platformP2PPortStatus: {
+      host: '52.33.28.41',
+      port: 36656,
+      status: 'ERROR'
+    },
+    platformGrpcPortStatus: {
+      host: '52.33.28.41',
+      port: 1443,
+      status: 'ERROR'
+    }
+  }
 }
 ```
 ---

--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -66,16 +66,11 @@ class ValidatorsController {
         {
           ...validator,
           isActive,
-          proTxInfo: ProTxInfo.fromObject({
-            ...proTxInfo,
-            state: {
-              ...proTxInfo.state,
-              endpoints
-            }
-          }),
+          proTxInfo: ProTxInfo.fromObject(proTxInfo),
           identifier,
           identityBalance,
-          epochInfo
+          epochInfo,
+          endpoints
         }
       )
     )

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -15,6 +15,7 @@ module.exports = class Validator {
   withdrawalsCount
   lastWithdrawal
   lastWithdrawalTime
+  endpoints
 
   constructor (
     proTxHash,
@@ -29,7 +30,8 @@ module.exports = class Validator {
     lastWithdrawalTime,
     identifier,
     identityBalance,
-    epochInfo
+    epochInfo,
+    endpoints
   ) {
     this.proTxHash = proTxHash ?? null
     this.isActive = isActive ?? null
@@ -44,6 +46,7 @@ module.exports = class Validator {
     this.withdrawalsCount = withdrawalsCount ?? null
     this.lastWithdrawal = lastWithdrawal ?? null
     this.lastWithdrawalTime = lastWithdrawalTime ?? null
+    this.endpoints = endpoints ?? null
   }
 
   static fromRow ({
@@ -99,7 +102,8 @@ module.exports = class Validator {
     lastWithdrawalTime,
     identifier,
     identityBalance,
-    epochInfo
+    epochInfo,
+    endpoints
   }) {
     return new Validator(
       proTxHash,
@@ -114,7 +118,8 @@ module.exports = class Validator {
       lastWithdrawalTime,
       identifier,
       identityBalance,
-      epochInfo
+      epochInfo,
+      endpoints
     )
   }
 }

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -30,6 +30,7 @@ describe('Validators routes', () => {
   let timestamp
 
   let dashCoreRpcResponse
+  let endpoints
 
   let intervals
 
@@ -46,6 +47,24 @@ describe('Validators routes', () => {
     identities = []
     transactions = []
     timestamp = new Date()
+
+    endpoints = {
+      coreP2PPortStatus: {
+        host: '255.255.255.255',
+        port: 255,
+        status: 'ERR_OUT_OF_RANGE'
+      },
+      platformP2PPortStatus: {
+        host: '255.255.255.255',
+        port: 255,
+        status: 'ERR_OUT_OF_RANGE'
+      },
+      platformGrpcPortStatus: {
+        host: '255.255.255.255',
+        port: 255,
+        status: 'ERR_OUT_OF_RANGE'
+      }
+    }
 
     intervals = {
       '1h': 300000,
@@ -77,24 +96,7 @@ describe('Validators routes', () => {
         platformP2PPort: 255,
         platformHTTPPort: 255,
         payoutAddress: 'yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A',
-        pubKeyOperator: 'af9cd8567923fea3f6e6bbf5e1b3a76bf772f6a3c72b41be15c257af50533b32cc3923cebdeda9fce7a6bc9659123d53',
-        endpoints: {
-          coreP2PPortStatus: {
-            host: '255.255.255.255',
-            port: 255,
-            status: 'ERR_OUT_OF_RANGE'
-          },
-          platformP2PPortStatus: {
-            host: '255.255.255.255',
-            port: 255,
-            status: 'ERR_OUT_OF_RANGE'
-          },
-          platformGrpcPortStatus: {
-            host: '255.255.255.255',
-            port: 255,
-            status: 'ERR_OUT_OF_RANGE'
-          }
-        }
+        pubKeyOperator: 'af9cd8567923fea3f6e6bbf5e1b3a76bf772f6a3c72b41be15c257af50533b32cc3923cebdeda9fce7a6bc9659123d53'
       },
       confirmations: 214276,
       metaInfo: {
@@ -224,7 +226,8 @@ describe('Validators routes', () => {
         epochInfo: { ...fullEpochInfo },
         withdrawalsCount: 5,
         lastWithdrawal: transactions[transactions.length - 1].hash,
-        lastWithdrawalTime: timestamp.toISOString()
+        lastWithdrawalTime: timestamp.toISOString(),
+        endpoints
       }
 
       assert.deepEqual(body, expectedValidator)
@@ -273,7 +276,8 @@ describe('Validators routes', () => {
         epochInfo: { ...fullEpochInfo },
         withdrawalsCount: 5,
         lastWithdrawal: transactions[transactions.length - 2].hash,
-        lastWithdrawalTime: timestamp.toISOString()
+        lastWithdrawalTime: timestamp.toISOString(),
+        endpoints
       }
 
       assert.deepEqual(body, expectedValidator)
@@ -336,7 +340,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -389,7 +394,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -445,7 +451,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -500,7 +507,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -559,7 +567,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -614,7 +623,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -671,7 +681,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -726,7 +737,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -798,7 +810,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -851,7 +864,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -906,7 +920,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -961,7 +976,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1016,7 +1032,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1071,7 +1088,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1127,7 +1145,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1182,7 +1201,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1242,7 +1262,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1283,7 +1304,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1327,7 +1349,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1370,7 +1393,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1413,7 +1437,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1456,7 +1481,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1512,7 +1538,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 
@@ -1567,7 +1594,8 @@ describe('Validators routes', () => {
               epochInfo: { ...fullEpochInfo },
               withdrawalsCount: null,
               lastWithdrawal: null,
-              lastWithdrawalTime: null
+              lastWithdrawalTime: null,
+              endpoints: null
             }
           })
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -248,6 +248,7 @@ GET /validators
       withdrawalsCount: null,
       lastWithdrawal: null,
       lastWithdrawalTime: null,
+      endpoints: null
     }, ...
   ],
   pagination: { 
@@ -301,23 +302,6 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
       platformHTTPPort: 1443,
       payoutAddress: "yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A",
       pubKeyOperator: "b928fa4e127214ccb2b5de1660b5e371d2f3c9845077bc3900fc6aabe82ddd2e61530be3765cea15752e30fc761ab730",
-      endpoints: {
-        coreP2PPortStatus: {
-          host: '52.33.28.41',
-          port: 19999,
-          status: 'ERROR'
-        },
-        platformP2PPortStatus: {
-          host: '52.33.28.41',
-          port: 36656,
-          status: 'ERROR'
-        },
-        platformGrpcPortStatus: {
-          host: '52.33.28.41',
-          port: 1443,
-          status: 'ERROR'
-        }
-      }
     }
   },
   identity: "8tsWRSwsTM5AXv4ViCF9gu39kzjbtfFDM6rCyL2RcFzd",
@@ -334,7 +318,24 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
   epochReward: 0,
   withdrawalsCount: 1,
   lastWithdrawal: "01FE1F00379C66C6E3BFD81A088E57E17613EC36E4FF812458535A8ABCB84047",
-  lastWithdrawalTime: "2024-10-12T03:15:19.257Z"
+  lastWithdrawalTime: "2024-10-12T03:15:19.257Z",
+  endpoints: {
+    coreP2PPortStatus: {
+      host: '52.33.28.41',
+      port: 19999,
+      status: 'ERROR'
+    },
+    platformP2PPortStatus: {
+      host: '52.33.28.41',
+      port: 36656,
+      status: 'ERROR'
+    },
+    platformGrpcPortStatus: {
+      host: '52.33.28.41',
+      port: 1443,
+      status: 'ERROR'
+    }
+  }
 }
 ```
 ---
@@ -741,7 +742,7 @@ Response codes:
 Return all transfers made by the given identity
 * `limit` cannot be more then 100
 ```
-GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/transfers?page=1&limit=10&order=asc
+GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/transfers?page=1&limit=10&order=asc&type=1
 
 {
     pagination: {


### PR DESCRIPTION
# Issue
Currently we store the `endpoints` property in `protx.state`, however this is incorrect and we should store this field in the root of the `Validator` object

# Things done
`endpoints` moved to root of `Validator` class