### PR TITLE
Validators structure fix

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -356,17 +356,20 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
     coreP2PPortStatus: {
       host: '52.33.28.41',
       port: 19999,
-      status: 'ERROR'
+      status: 'ERROR',
+      message: null
     },
     platformP2PPortStatus: {
       host: '52.33.28.41',
       port: 36656,
-      status: 'ERROR'
+      status: 'ERROR',
+      message: null
     },
     platformGrpcPortStatus: {
       host: '52.33.28.41',
       port: 1443,
-      status: 'ERROR'
+      status: 'ERROR',
+      message: null
     }
   }
 }

--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -41,23 +41,27 @@ class ValidatorsController {
       checkTcpConnect(servicePort, host),
       checkTcpConnect(proTxInfo?.state.platformP2PPort, host),
       checkTcpConnect(proTxInfo?.state.platformHTTPPort, host)
-    ])).map((e) => e.value ?? (e.reason?.code ? e.reason?.code : e.message))
+    ])).map(
+      (e) => ({
+        status: e.value ?? e.reason?.code,
+        message: e.reason?.message ?? null
+      }))
 
     const endpoints = {
       coreP2PPortStatus: {
         host,
         port: Number(servicePort),
-        status: coreStatus
+        ...coreStatus
       },
       platformP2PPortStatus: {
         host,
         port: Number(proTxInfo?.state.platformP2PPort),
-        status: platformStatus
+        ...platformStatus
       },
       platformGrpcPortStatus: {
         host,
         port: Number(proTxInfo?.state.platformHTTPPort ?? 0),
-        status: grpcStatus
+        ...grpcStatus
       }
     }
 

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -114,7 +114,7 @@ const checkTcpConnect = (port, host) => {
       connection.once('error', async (e) => {
         await connection.destroy()
         console.error(e)
-        reject(e.message)
+        reject(e)
       })
 
       connection.once('connect', async () => {

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -52,17 +52,20 @@ describe('Validators routes', () => {
       coreP2PPortStatus: {
         host: '255.255.255.255',
         port: 255,
-        status: 'ERR_OUT_OF_RANGE'
+        status: 'ERR_OUT_OF_RANGE',
+        message: 'The value of "msecs" is out of range. It must be a non-negative finite number. Received NaN'
       },
       platformP2PPortStatus: {
         host: '255.255.255.255',
         port: 255,
-        status: 'ERR_OUT_OF_RANGE'
+        status: 'ERR_OUT_OF_RANGE',
+        message: 'The value of "msecs" is out of range. It must be a non-negative finite number. Received NaN'
       },
       platformGrpcPortStatus: {
         host: '255.255.255.255',
         port: 255,
-        status: 'ERR_OUT_OF_RANGE'
+        status: 'ERR_OUT_OF_RANGE',
+        message: 'The value of "msecs" is out of range. It must be a non-negative finite number. Received NaN'
       }
     }
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -323,17 +323,20 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
     coreP2PPortStatus: {
       host: '52.33.28.41',
       port: 19999,
-      status: 'ERROR'
+      status: 'ERROR',
+      message: null
     },
     platformP2PPortStatus: {
       host: '52.33.28.41',
       port: 36656,
-      status: 'ERROR'
+      status: 'ERROR',
+      message: null
     },
     platformGrpcPortStatus: {
       host: '52.33.28.41',
       port: 1443,
-      status: 'ERROR'
+      status: 'ERROR',
+      message: null
     }
   }
 }


### PR DESCRIPTION
# Issue
At this momment, we sending message in `status` field, now it stored in `message` field

# Things done
Edited rejects for new structure
Implemented new structure in controller
Updated readme

response example: 
```json 
{
  "proTxHash": "3971DAB9691EFAC06E4CE7A5483131373E84726458924FE48B7D541791693BE1",
  "isActive": false,
  "proposedBlocksAmount": 22,
  "lastProposedBlockHeader": {
    "hash": "386D9CEF27AB19E685312C5AF8D4B258815D9BFE74D80627BBEE784A44A368BD",
    "height": 31547,
    "timestamp": "2024-10-08T19:20:03.079Z",
    "blockVersion": 14,
    "appVersion": 3,
    "l1LockedHeight": 1117614,
    "validator": "3971DAB9691EFAC06E4CE7A5483131373E84726458924FE48B7D541791693BE1"
  },
  "proTxInfo": {
    "type": "Evo",
    "collateralHash": "6df9226a0d08e38045297e147a8d5d17e0ccf4e45bdcdcda517ae10c0e6d6c92",
    "collateralIndex": 0,
    "collateralAddress": "yhGUeeepQhYvXwE2spAqLWaUspToUfRj9D",
    "operatorReward": 0,
    "confirmations": 6,
    "state": {
      "version": 2,
      "service": "92.63.176.202:19999",
      "registeredHeight": 1116555,
      "lastPaidHeight": 0,
      "consecutivePayments": 0,
      "PoSePenalty": 0,
      "PoSeRevivedHeight": -1,
      "PoSeBanHeight": -1,
      "revocationReason": 0,
      "ownerAddress": "ycbpHHjyZzFrUG8MpzyACzuZpnrGPpztNL",
      "votingAddress": "ySzPE6KWnhQcChevbQXms6PctwKPGRos45",
      "platformNodeID": "61c274080f47a95be5372ef8c69bb60ab1d4ca82",
      "platformP2PPort": 36656,
      "platformHTTPPort": 1443,
      "payoutAddress": "yMe5b6wWmYSN6dwFGVkAKKsQQGJanaQq2E",
      "pubKeyOperator": "b92d4ef819fe283a307e6bcd500d8cd35e9a7b779dbca59bd3bc77b3bb3611c370258aa6dec13d0781e0b53c911bde08"
    }
  },
  "identity": "4sEw4qF2WEhotHr3TcUEUUMg3eN6XhFzaPSw5GyRGmPW",
  "identityBalance": 2042594489241,
  "epochInfo": {
    "number": 2267,
    "firstBlockHeight": 38404,
    "firstCoreBlockHeight": 1125317,
    "startTime": 1729514444438,
    "feeMultiplier": 1,
    "endTime": 1729518044438
  },
  "totalReward": 0,
  "epochReward": 0,
  "withdrawalsCount": 0,
  "lastWithdrawal": null,
  "lastWithdrawalTime": null,
  "endpoints": {
    "coreP2PPortStatus": {
      "host": "92.63.176.202",
      "port": 19999,
      "status": "ECONNREFUSED",
      "message": "connect ECONNREFUSED 92.63.176.202:19999"
    },
    "platformP2PPortStatus": {
      "host": "92.63.176.202",
      "port": 36656,
      "status": "ERR_CONNECTION_REFUSED",
      "message": null
    },
    "platformGrpcPortStatus": {
      "host": "92.63.176.202",
      "port": 1443,
      "status": "ERR_CONNECTION_REFUSED",
      "message": null
    }
  }
}
```