### PR TITLE
Fix for search query

### DIFF
--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -72,6 +72,11 @@ class MainController {
   search = async (request, response) => {
     const { query } = request.query
 
+    const epoch = Epoch.fromObject({
+      startTime: 0,
+      endTime: 0
+    })
+
     if (/^[0-9]+$/.test(query)) {
       // search block by height
       const block = await this.blocksDAO.getBlockByHeight(query)
@@ -97,7 +102,7 @@ class MainController {
       }
 
       // search validators
-      const validator = await this.validatorsDAO.getValidatorByProTxHash(query)
+      const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
 
       if (validator) {
         return response.send({ validator })

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -74,7 +74,7 @@ module.exports = class IdentitiesDAO {
   getIdentityByDPNS = async (dpns) => {
     const identifier = this.knex('identity_aliases')
       .select('identity_identifier')
-      .whereRaw(`LOWER(alias) LIKE LOWER('${dpns}')`)
+      .whereRaw(`LOWER(alias) LIKE LOWER('${dpns}${dpns.includes('.') ? '' : '.%'}')`)
       .limit(1)
 
     const identity = await this.getIdentityByIdentifier(identifier)


### PR DESCRIPTION
# Issue
At this momment search for validators not working and if query contains wrong tx hash, we also returnin validators search error.
Also we can search identities only by identifier and full alias with domain

# Things done
Fixed validators query by adding new variable for epoch
Added domain interpolation for search by dpns