### PR TITLE
Implement identities aliases in Top Identities cards

### DIFF
--- a/packages/frontend/src/components/data/Alias.js
+++ b/packages/frontend/src/components/data/Alias.js
@@ -1,10 +1,10 @@
 import './Alias.scss'
 
-export default function Alias ({ children, className }) {
+export default function Alias ({ children, ellipsis = true, className }) {
   const dashIndex = children.lastIndexOf('.dash')
 
   return (
-    <div className={`Alias ${className || ''}`}>
+    <div className={`Alias ${ellipsis && 'Alias--Ellipsis'}  ${className || ''}`}>
       <span className={'Alias__Name'}>
         {dashIndex !== -1
           ? children.slice(0, dashIndex)

--- a/packages/frontend/src/components/data/Alias.scss
+++ b/packages/frontend/src/components/data/Alias.scss
@@ -3,6 +3,7 @@
 
 .Alias {
   font-family: $font-mono;
+  font-size: 0.75rem;
   color: #fff;
 
   &__Domain {

--- a/packages/frontend/src/components/data/Alias.scss
+++ b/packages/frontend/src/components/data/Alias.scss
@@ -6,6 +6,12 @@
   font-size: 0.75rem;
   color: #fff;
 
+  &--Ellipsis {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
   &__Domain {
     opacity: .5;
   }

--- a/packages/frontend/src/components/identities/Cards.js
+++ b/packages/frontend/src/components/identities/Cards.js
@@ -8,6 +8,7 @@ import { ErrorMessageBlock } from '../Errors'
 import ImageGenerator from '../imageGenerator'
 import { RateTooltip } from '../ui/Tooltips'
 import './IdentityCard.scss'
+import { Identifier, Alias } from '../data'
 
 function IdentityCard ({ identity, rate, loading = false }) {
   return (
@@ -20,7 +21,10 @@ function IdentityCard ({ identity, rate, loading = false }) {
                       <div className={'IdentityCard__Img'}>
                         <ImageGenerator username={identity.identifier} lightness={50} saturation={50} width={42} height={42} />
                       </div>
-                      <div className={'IdentityCard__Alias'}>{identity.alias || identity.identifier}</div>
+                      <div className={'IdentityCard__Alias'}>{identity?.aliases?.length
+                        ? <Alias>{identity?.aliases[0]}</Alias>
+                        : <Identifier styles={['highlight-both']}>{identity.identifier}</Identifier>}
+                      </div>
                   </div>
 
                   <div className={'IdentityCard__Balance'}>


### PR DESCRIPTION
# Issue
We already implement displaying Identity aliases in lists and on the Identity page. And we also need to display it in the Top Identity list.

# Things done
Identity aliases implemented in Top Identities cards.