### PR TITLE
Rollback to the previous dapi client initialization method

### DIFF
--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -45,10 +45,7 @@ let dapi
 
 module.exports = {
   start: async () => {
-    client = new Dash.Client({
-      dapiAddresses: (process.env.DAPI_URL ?? '127.0.0.1:1443:self-signed').split(','),
-      network: process.env.NETWORK ?? 'testnet'
-    })
+    client = new Dash.Client()
 
     await loadWasmDpp()
 

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -17,7 +17,7 @@ const { getKnex } = require('./utils')
 const BlocksDAO = require('./dao/BlocksDAO')
 const DAPI = require('./DAPI')
 const RateController = require('./controllers/RateController')
-const DAPIClient = require("@dashevo/dapi-client");
+const DAPIClient = require('@dashevo/dapi-client')
 const { default: loadWasmDpp } = require('dash').PlatformProtocol
 
 function errorHandler (err, req, reply) {

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -17,6 +17,7 @@ const { getKnex } = require('./utils')
 const BlocksDAO = require('./dao/BlocksDAO')
 const DAPI = require('./DAPI')
 const RateController = require('./controllers/RateController')
+const DAPIClient = require("@dashevo/dapi-client");
 const { default: loadWasmDpp } = require('dash').PlatformProtocol
 
 function errorHandler (err, req, reply) {
@@ -53,7 +54,10 @@ module.exports = {
 
     await client.platform.initialize()
 
-    const dapiClient = client.getDAPIClient()
+    const dapiClient = new DAPIClient({
+      dapiAddresses: (process.env.DAPI_URL ?? '127.0.0.1:1443:self-signed').split(','),
+      network: process.env.NETWORK ?? 'testnet'
+    })
 
     const { dpp } = client.platform
 


### PR DESCRIPTION
# Issue
`this.dapi.platform.getContestedResourceVoteState is not a function` after #306 

# Things done 
reverted to old dapi instance creating 