### PR TITLE
Fix transactions list on home page

### DIFF
--- a/packages/frontend/src/app/home/Home.js
+++ b/packages/frontend/src/app/home/Home.js
@@ -153,6 +153,7 @@ function Home () {
         >
           <Flex
             maxW={blockMaxWidth}
+            w={'100%'}
             order={[4, 4, 0]}
             mb={0}
             className={'InfoBlock'}


### PR DESCRIPTION
# Issue
On the main page in mobile resolution the indents of the transaction list are incorrect
<img width="520" alt="image" src="https://github.com/user-attachments/assets/578e960a-35cf-429a-8073-2356fc954168">

# Things done
Fixed