### PR TITLE
New logic for search in API

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -999,6 +999,78 @@ Response codes:
 200: OK
 500: Internal Server Error
 ```
+---
+### Search
+This endpoint allows search any types of data
+
+* `query` required and must contains data for search
+* Response may contain array for Identity and Data Contract when searching by part of field
+
+#### Can be found:
+* Block
+  * Full `height`
+  * Full `hash`
+* Transaction
+  * Full `hash`
+* Validator
+  * Full `proTxHash`
+  * Full `Identifier` of Masternode Identity
+* Identity
+  * Full `Identifier`
+  * Part `alias`
+* Data Contract
+  * Full `Identifier`
+  * Part `name`
+* Document
+  * Full `Identifier`
+
+```
+GET /search?query=xyz
+
+{
+  "identities": [
+    {
+      "identifier": "36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm",
+      "alias": "xyz.dash",
+      "status": {
+        "alias": "xyz.dash",
+        "status": "ok",
+        "contested": true
+      }
+    },
+    {
+      "identifier": "5bUPV8KGgL42ZBS9fsmmKU3wweQbVeHHsiVrG3YMHyG5",
+      "alias": "xyz.dash",
+      "status": {
+        "alias": "xyz.dash",
+        "status": "locked",
+        "contested": true
+      }
+    }
+  ]
+}
+```
+
+```
+GET /search?query=36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm
+
+{
+  "identity": {
+    "identifier": "36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm",
+    "alias": "xyz.dash",
+    "status": {
+      "alias": "xyz.dash",
+      "status": "ok",
+      "contested": true
+    }
+  }
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+```
 ### Transactions history
 Return a series data for the amount of transactions chart
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -67,6 +67,7 @@ Reference:
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
 * [Rate](#rate)
+* [Search](#search)
 * [Decode Raw Transaction](#decode-raw-transaction)
 
 ### Status

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -774,10 +774,17 @@ Return identity by given DPNS/alias
 ```
 GET /dpns/identity?dpns=canuseethat2.dash
 
-{
-  "identity_identifier": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
-  "alias": "canuseethat2.dash"
-}
+[
+  {
+    "identity_identifier": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
+    "alias": "canuseethat2.dash",
+    "status": {
+      "alias": "canuseethat2.dash",
+      "contested": false,
+      "status": "ok"
+    }
+  }
+]
 ```
 Response codes:
 ```

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -547,7 +547,8 @@ GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEE
       aliases: [
         {
           alias: "alias.dash",
-          status: "locked"
+          status: "locked",
+          contested: true
         }
       ]
     }
@@ -599,7 +600,8 @@ GET /transactions?=1&limit=10&order=asc&owner=6q9RFbeea73tE31LGMBLFZhtBUX3wZL3Tc
           aliases: [
             {
               alias: "alias.dash",
-              status: "locked"
+              status: "locked",
+              contested: true
             }
           ]
         }
@@ -754,7 +756,8 @@ GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
     aliases: [
       {
         alias: "alias.dash",
-        status: "locked"
+        status: "locked",
+        contested: true
       }
     ]
 }
@@ -813,7 +816,8 @@ GET /identities?page=1&limit=10&order=asc&order_by=block_height
           aliases: [
             {
               alias: "alias.dash",
-              status: "locked"
+              status: "locked",
+              contested: true
             }
           ]
       }, ...

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -8,7 +8,6 @@ module.exports = {
   TCP_CONNECT_TIMEOUT: Number(process.env.TCP_CONNECT_TIMEOUT),
   DPNS_CONTRACT: 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec',
   NETWORK: process.env.NETWORK ?? 'testnet',
-  searchLimit: 25,
   get genesisTime () {
     if (!genesisTime || isNaN(genesisTime)) {
       return TenderdashRPC.getBlockByHeight(1).then((blockInfo) => {

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -8,6 +8,7 @@ module.exports = {
   TCP_CONNECT_TIMEOUT: Number(process.env.TCP_CONNECT_TIMEOUT),
   DPNS_CONTRACT: 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec',
   NETWORK: process.env.NETWORK ?? 'testnet',
+  searchLimit: 25,
   get genesisTime () {
     if (!genesisTime || isNaN(genesisTime)) {
       return TenderdashRPC.getBlockByHeight(1).then((blockInfo) => {

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -26,7 +26,7 @@ class IdentitiesController {
   getIdentityByDPNSName = async (request, response) => {
     const { dpns } = request.query
 
-    const identity = await this.identitiesDAO.getIdentityByDPNSName(dpns)
+    const identity = await this.identitiesDAO.getIdentitiesByDPNSName(dpns)
 
     if (!identity) {
       return response.status(404).send({ message: 'not found' })

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -6,13 +6,13 @@ const IdentitiesDAO = require('../dao/IdentitiesDAO')
 const ValidatorsDAO = require('../dao/ValidatorsDAO')
 const TenderdashRPC = require('../tenderdashRpc')
 const Epoch = require('../models/Epoch')
-const { base58 } = require('@scure/base')
+const {base58} = require('@scure/base')
 
 const API_VERSION = require('../../package.json').version
 const PLATFORM_VERSION = '1' + require('../../package.json').dependencies.dash.substring(1)
 
 class MainController {
-  constructor (knex, dapi) {
+  constructor(knex, dapi) {
     this.blocksDAO = new BlocksDAO(knex, dapi)
     this.dataContractsDAO = new DataContractsDAO(knex)
     this.documentsDAO = new DocumentsDAO(knex)
@@ -71,9 +71,9 @@ class MainController {
   }
 
   search = async (request, response) => {
-    const { query } = request.query
+    const {query} = request.query
 
-    let output = {}
+    let result = {}
 
     const epoch = Epoch.fromObject({
       startTime: 0,
@@ -85,7 +85,7 @@ class MainController {
       const block = await this.blocksDAO.getBlockByHeight(query)
 
       if (block) {
-        output = { ...output, block }
+        result = {...result, block}
       }
     }
 
@@ -94,21 +94,21 @@ class MainController {
       const block = await this.blocksDAO.getBlockByHash(query)
 
       if (block) {
-        output = { ...output, block }
+        result = {...result, block}
       }
 
       // search transactions
       const transaction = await this.transactionsDAO.getTransactionByHash(query)
 
       if (transaction) {
-        output = { ...output, transaction }
+        result = {...result, transaction}
       }
 
       // search validators by hash
       const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
 
       if (validator) {
-        output = { ...output, validator }
+        result = {...result, validator}
       }
     }
 
@@ -118,7 +118,7 @@ class MainController {
       const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
 
       if (identity) {
-        output = { ...output, identity }
+        result = {...result, identity}
       }
 
       // search validator by MasterNode identity
@@ -127,21 +127,21 @@ class MainController {
       const validator = await this.validatorsDAO.getValidatorByProTxHash(proTxHash, null, epoch)
 
       if (validator) {
-        output = { ...output, validator }
+        result = {...result, validator}
       }
 
       // search data contract by id
       const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(query)
 
       if (dataContract) {
-        output = { ...output, dataContract }
+        result = {...result, dataContract}
       }
 
       // search documents
       const document = await this.documentsDAO.getDocumentByIdentifier(query)
 
       if (document) {
-        output = { ...output, document }
+        result = {...result, document}
       }
     }
 
@@ -149,21 +149,21 @@ class MainController {
     const identities = await this.identitiesDAO.getIdentitiesByDPNSName(query)
 
     if (identities) {
-      output = { ...output, identities }
+      result = {...result, identities}
     }
 
     // by data-contract name
     const dataContracts = await this.dataContractsDAO.getDataContractByName(query)
 
     if (dataContracts) {
-      output = { ...output, dataContracts }
+      result = {...result, dataContracts}
     }
 
-    if (output !== {}) {
-      response.send(output)
+    if (Object.keys(result).length === 0) {
+      response.status(404).send({message: 'not found'})
     }
 
-    response.status(404).send({ message: 'not found' })
+    response.send(result)
   }
 }
 

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -7,6 +7,7 @@ const ValidatorsDAO = require('../dao/ValidatorsDAO')
 const TenderdashRPC = require('../tenderdashRpc')
 const Epoch = require('../models/Epoch')
 const {searchLimit} = require("../constants");
+const {base58} = require("@scure/base");
 
 const API_VERSION = require('../../package.json').version
 const PLATFORM_VERSION = '1' + require('../../package.json').dependencies.dash.substring(1)
@@ -71,90 +72,103 @@ class MainController {
   }
 
   search = async (request, response) => {
-    const {query} = request.query
+    const { query } = request.query
 
-    if (/^[0-9A-z]+$/.test(query)) {
-      // any
-      if (/^\d+$/.test(query)) {
-        //only height
-        const block = await this.blocksDAO.getBlockByHeight(query)
+    let output = {}
 
-        if (block) {
-          return response.send({block})
-        }
+    const epoch = Epoch.fromObject({
+      startTime: 0,
+      endTime: 0
+    })
+
+    if (/^[0-9]+$/.test(query)) {
+      // search block by height
+      const block = await this.blocksDAO.getBlockByHeight(query)
+
+      if(block){
+        output = {...output, block}
       }
-
-      let output = undefined
-
-      const blocksByHash = await this.blocksDAO.getBlockByHashPart(query, searchLimit)
-
-      if (blocksByHash) {
-        output = {blocks: blocksByHash}
-      }
-
-      const transactionsByHash = await this.transactionsDAO.getTransactionsByHashPart(query, searchLimit)
-
-      if (transactionsByHash) {
-        output = {...output, transactions: transactionsByHash}
-      }
-
-
-      if (output) {
-        return response.send(output)
-      }
-
-    } else {
-      // only aliases
     }
 
-    // const epoch = Epoch.fromObject({
-    //   startTime: 0,
-    //   endTime: 0
-    // })
-    //
+    if (/^[0-9A-f]{64,64}$/.test(query)) {
+      // search block by hash
+      const block = await this.blocksDAO.getBlockByHash(query)
 
-        //   // search validators
-    //   const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
-    //
-    //   if (validator) {
-    //     return response.send({ validator })
-    //   }
-    // }
-    //
-    // // check for any Identifiers (identities, data contracts, documents)
-    // if (/^[0-9A-z]{43,44}$/.test(query)) {
-    //   // search identites
-    //   const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
-    //
-    //   if (identity) {
-    //     return response.send({ identity })
-    //   }
-    //
-    //   // search data contracts
-    //   const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(query)
-    //
-    //   if (dataContract) {
-    //     return response.send({ dataContract })
-    //   }
-    //
-    //   // search documents
-    //   const document = await this.documentsDAO.getDocumentByIdentifier(query)
-    //
-    //   if (document) {
-    //     return response.send({ document })
-    //   }
-    // }
-    //
-    // // by dpns name
-    // if (/^[^\s.]+(\.[^\s.]+)*$/.test(query)) {
-    //   const identity = await this.identitiesDAO.getIdentityByDPNSName(query)
-    //
-    //   if (identity) {
-    //     return response.send({ identity })
-    //   }
-    // }
+      if (block) {
+        output = {...output, block}
+      }
 
-    response.status(404).send({message: 'not found'})
+      // search transactions
+      const transaction = await this.transactionsDAO.getTransactionByHash(query)
+
+      if (transaction) {
+        output = {...output, transaction}
+      }
+
+      // search validators by hash
+      const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
+
+      if (validator) {
+        output = {...output, validator}
+      }
+    }
+
+    // check for any Identifiers (identities, data contracts, documents)
+    if (/^[0-9A-z]{43,44}$/.test(query)) {
+      // search identites
+      const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
+
+      if (identity) {
+        output = {...output, identity}
+      }
+
+      // search validator by MasterNode identity
+      const proTxHash = Buffer.from(base58.decode(query)).toString('hex')
+
+      const validator = await this.validatorsDAO.getValidatorByProTxHash(proTxHash, null, epoch)
+
+      if (validator) {
+        output = {...output, validator}
+      }
+
+      // search data contract by id
+      const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(query)
+
+      if (dataContract) {
+        output = {...output, dataContract}
+      }
+
+      // search documents
+      const document = await this.documentsDAO.getDocumentByIdentifier(query)
+
+      if (document) {
+        output = {...output, document}
+      }
+    }
+
+    // by dpns name
+    if (/^[^\s.]+(\.[^\s.]+)*$/.test(query)) {
+      const identities = await this.identitiesDAO.getIdentitiesByDPNSName(query)
+
+      if (identities) {
+        output = {...output, identities}
+      }
+    }
+
+    // by data-contract name
+    if(/^[A-z]/.test(query)) {
+      const dataContracts = await this.dataContractsDAO.getDataContractByName(query)
+
+      if (dataContracts) {
+        output = {...output, dataContracts}
+      }
+    }
+
+    if(output!=={}){
+      response.send(output)
+    }
+
+    response.status(404).send({ message: 'not found' })
   }
 }
 

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -146,21 +146,17 @@ class MainController {
     }
 
     // by dpns name
-    if (/^[^\s.]+(\.[^\s.]+)*$/.test(query)) {
-      const identities = await this.identitiesDAO.getIdentitiesByDPNSName(query)
+    const identities = await this.identitiesDAO.getIdentitiesByDPNSName(query)
 
-      if (identities) {
-        output = { ...output, identities }
-      }
+    if (identities) {
+      output = { ...output, identities }
     }
 
     // by data-contract name
-    if (/^[A-z]/.test(query)) {
-      const dataContracts = await this.dataContractsDAO.getDataContractByName(query)
+    const dataContracts = await this.dataContractsDAO.getDataContractByName(query)
 
-      if (dataContracts) {
-        output = { ...output, dataContracts }
-      }
+    if (dataContracts) {
+      output = { ...output, dataContracts }
     }
 
     if (output !== {}) {

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -6,14 +6,13 @@ const IdentitiesDAO = require('../dao/IdentitiesDAO')
 const ValidatorsDAO = require('../dao/ValidatorsDAO')
 const TenderdashRPC = require('../tenderdashRpc')
 const Epoch = require('../models/Epoch')
-const {searchLimit} = require("../constants");
-const {base58} = require("@scure/base");
+const { base58 } = require('@scure/base')
 
 const API_VERSION = require('../../package.json').version
 const PLATFORM_VERSION = '1' + require('../../package.json').dependencies.dash.substring(1)
 
 class MainController {
-  constructor(knex, dapi) {
+  constructor (knex, dapi) {
     this.blocksDAO = new BlocksDAO(knex, dapi)
     this.dataContractsDAO = new DataContractsDAO(knex)
     this.documentsDAO = new DocumentsDAO(knex)
@@ -85,8 +84,8 @@ class MainController {
       // search block by height
       const block = await this.blocksDAO.getBlockByHeight(query)
 
-      if(block){
-        output = {...output, block}
+      if (block) {
+        output = { ...output, block }
       }
     }
 
@@ -95,21 +94,21 @@ class MainController {
       const block = await this.blocksDAO.getBlockByHash(query)
 
       if (block) {
-        output = {...output, block}
+        output = { ...output, block }
       }
 
       // search transactions
       const transaction = await this.transactionsDAO.getTransactionByHash(query)
 
       if (transaction) {
-        output = {...output, transaction}
+        output = { ...output, transaction }
       }
 
       // search validators by hash
       const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
 
       if (validator) {
-        output = {...output, validator}
+        output = { ...output, validator }
       }
     }
 
@@ -119,7 +118,7 @@ class MainController {
       const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
 
       if (identity) {
-        output = {...output, identity}
+        output = { ...output, identity }
       }
 
       // search validator by MasterNode identity
@@ -128,21 +127,21 @@ class MainController {
       const validator = await this.validatorsDAO.getValidatorByProTxHash(proTxHash, null, epoch)
 
       if (validator) {
-        output = {...output, validator}
+        output = { ...output, validator }
       }
 
       // search data contract by id
       const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(query)
 
       if (dataContract) {
-        output = {...output, dataContract}
+        output = { ...output, dataContract }
       }
 
       // search documents
       const document = await this.documentsDAO.getDocumentByIdentifier(query)
 
       if (document) {
-        output = {...output, document}
+        output = { ...output, document }
       }
     }
 
@@ -151,20 +150,20 @@ class MainController {
       const identities = await this.identitiesDAO.getIdentitiesByDPNSName(query)
 
       if (identities) {
-        output = {...output, identities}
+        output = { ...output, identities }
       }
     }
 
     // by data-contract name
-    if(/^[A-z]/.test(query)) {
+    if (/^[A-z]/.test(query)) {
       const dataContracts = await this.dataContractsDAO.getDataContractByName(query)
 
       if (dataContracts) {
-        output = {...output, dataContracts}
+        output = { ...output, dataContracts }
       }
     }
 
-    if(output!=={}){
+    if (output !== {}) {
       response.send(output)
     }
 

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -6,12 +6,13 @@ const IdentitiesDAO = require('../dao/IdentitiesDAO')
 const ValidatorsDAO = require('../dao/ValidatorsDAO')
 const TenderdashRPC = require('../tenderdashRpc')
 const Epoch = require('../models/Epoch')
+const {searchLimit} = require("../constants");
 
 const API_VERSION = require('../../package.json').version
 const PLATFORM_VERSION = '1' + require('../../package.json').dependencies.dash.substring(1)
 
 class MainController {
-  constructor (knex, dapi) {
+  constructor(knex, dapi) {
     this.blocksDAO = new BlocksDAO(knex, dapi)
     this.dataContractsDAO = new DataContractsDAO(knex)
     this.documentsDAO = new DocumentsDAO(knex)
@@ -70,79 +71,90 @@ class MainController {
   }
 
   search = async (request, response) => {
-    const { query } = request.query
+    const {query} = request.query
 
-    const epoch = Epoch.fromObject({
-      startTime: 0,
-      endTime: 0
-    })
+    if (/^[0-9A-z]+$/.test(query)) {
+      // any
+      if (/^\d+$/.test(query)) {
+        //only height
+        const block = await this.blocksDAO.getBlockByHeight(query)
 
-    if (/^[0-9]+$/.test(query)) {
-      // search block by height
-      const block = await this.blocksDAO.getBlockByHeight(query)
-
-      if (block) {
-        return response.send({ block })
+        if (block) {
+          return response.send({block})
+        }
       }
+
+      let output = undefined
+
+      const blocksByHash = await this.blocksDAO.getBlockByHashPart(query, searchLimit)
+
+      if (blocksByHash) {
+        output = {blocks: blocksByHash}
+      }
+
+      const transactionsByHash = await this.transactionsDAO.getTransactionsByHashPart(query, searchLimit)
+
+      if (transactionsByHash) {
+        output = {...output, transactions: transactionsByHash}
+      }
+
+
+      if (output) {
+        return response.send(output)
+      }
+
+    } else {
+      // only aliases
     }
 
-    if (/^[0-9A-f]{64,64}$/.test(query)) {
-      // search block by hash
-      const block = await this.blocksDAO.getBlockByHash(query)
+    // const epoch = Epoch.fromObject({
+    //   startTime: 0,
+    //   endTime: 0
+    // })
+    //
 
-      if (block) {
-        return response.send({ block })
-      }
+        //   // search validators
+    //   const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
+    //
+    //   if (validator) {
+    //     return response.send({ validator })
+    //   }
+    // }
+    //
+    // // check for any Identifiers (identities, data contracts, documents)
+    // if (/^[0-9A-z]{43,44}$/.test(query)) {
+    //   // search identites
+    //   const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
+    //
+    //   if (identity) {
+    //     return response.send({ identity })
+    //   }
+    //
+    //   // search data contracts
+    //   const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(query)
+    //
+    //   if (dataContract) {
+    //     return response.send({ dataContract })
+    //   }
+    //
+    //   // search documents
+    //   const document = await this.documentsDAO.getDocumentByIdentifier(query)
+    //
+    //   if (document) {
+    //     return response.send({ document })
+    //   }
+    // }
+    //
+    // // by dpns name
+    // if (/^[^\s.]+(\.[^\s.]+)*$/.test(query)) {
+    //   const identity = await this.identitiesDAO.getIdentityByDPNSName(query)
+    //
+    //   if (identity) {
+    //     return response.send({ identity })
+    //   }
+    // }
 
-      // search transactions
-      const transaction = await this.transactionsDAO.getTransactionByHash(query)
-
-      if (transaction) {
-        return response.send({ transaction })
-      }
-
-      // search validators
-      const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
-
-      if (validator) {
-        return response.send({ validator })
-      }
-    }
-
-    // check for any Identifiers (identities, data contracts, documents)
-    if (/^[0-9A-z]{43,44}$/.test(query)) {
-      // search identites
-      const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
-
-      if (identity) {
-        return response.send({ identity })
-      }
-
-      // search data contracts
-      const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(query)
-
-      if (dataContract) {
-        return response.send({ dataContract })
-      }
-
-      // search documents
-      const document = await this.documentsDAO.getDocumentByIdentifier(query)
-
-      if (document) {
-        return response.send({ document })
-      }
-    }
-
-    // by dpns name
-    if (/^[^\s.]+(\.[^\s.]+)*$/.test(query)) {
-      const identity = await this.identitiesDAO.getIdentityByDPNSName(query)
-
-      if (identity) {
-        return response.send({ identity })
-      }
-    }
-
-    response.status(404).send({ message: 'not found' })
+    response.status(404).send({message: 'not found'})
   }
 }
 

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -6,13 +6,13 @@ const IdentitiesDAO = require('../dao/IdentitiesDAO')
 const ValidatorsDAO = require('../dao/ValidatorsDAO')
 const TenderdashRPC = require('../tenderdashRpc')
 const Epoch = require('../models/Epoch')
-const {base58} = require('@scure/base')
+const { base58 } = require('@scure/base')
 
 const API_VERSION = require('../../package.json').version
 const PLATFORM_VERSION = '1' + require('../../package.json').dependencies.dash.substring(1)
 
 class MainController {
-  constructor(knex, dapi) {
+  constructor (knex, dapi) {
     this.blocksDAO = new BlocksDAO(knex, dapi)
     this.dataContractsDAO = new DataContractsDAO(knex)
     this.documentsDAO = new DocumentsDAO(knex)
@@ -71,7 +71,7 @@ class MainController {
   }
 
   search = async (request, response) => {
-    const {query} = request.query
+    const { query } = request.query
 
     let result = {}
 
@@ -85,7 +85,7 @@ class MainController {
       const block = await this.blocksDAO.getBlockByHeight(query)
 
       if (block) {
-        result = {...result, block}
+        result = { ...result, block }
       }
     }
 
@@ -94,21 +94,21 @@ class MainController {
       const block = await this.blocksDAO.getBlockByHash(query)
 
       if (block) {
-        result = {...result, block}
+        result = { ...result, block }
       }
 
       // search transactions
       const transaction = await this.transactionsDAO.getTransactionByHash(query)
 
       if (transaction) {
-        result = {...result, transaction}
+        result = { ...result, transaction }
       }
 
       // search validators by hash
       const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
 
       if (validator) {
-        result = {...result, validator}
+        result = { ...result, validator }
       }
     }
 
@@ -118,7 +118,7 @@ class MainController {
       const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
 
       if (identity) {
-        result = {...result, identity}
+        result = { ...result, identity }
       }
 
       // search validator by MasterNode identity
@@ -127,21 +127,21 @@ class MainController {
       const validator = await this.validatorsDAO.getValidatorByProTxHash(proTxHash, null, epoch)
 
       if (validator) {
-        result = {...result, validator}
+        result = { ...result, validator }
       }
 
       // search data contract by id
       const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(query)
 
       if (dataContract) {
-        result = {...result, dataContract}
+        result = { ...result, dataContract }
       }
 
       // search documents
       const document = await this.documentsDAO.getDocumentByIdentifier(query)
 
       if (document) {
-        result = {...result, document}
+        result = { ...result, document }
       }
     }
 
@@ -149,18 +149,18 @@ class MainController {
     const identities = await this.identitiesDAO.getIdentitiesByDPNSName(query)
 
     if (identities) {
-      result = {...result, identities}
+      result = { ...result, identities }
     }
 
     // by data-contract name
     const dataContracts = await this.dataContractsDAO.getDataContractByName(query)
 
     if (dataContracts) {
-      result = {...result, dataContracts}
+      result = { ...result, dataContracts }
     }
 
     if (Object.keys(result).length === 0) {
-      response.status(404).send({message: 'not found'})
+      response.status(404).send({ message: 'not found' })
     }
 
     response.send(result)

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -1,11 +1,10 @@
 const Block = require('../models/Block')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-const {getAliasInfo, getAliasStateByVote} = require('../utils')
-const {base58} = require('@scure/base')
+const { getAliasInfo, getAliasStateByVote } = require('../utils')
 const Transaction = require('../models/Transaction')
 
 module.exports = class BlockDAO {
-  constructor(knex, dapi) {
+  constructor (knex, dapi) {
     this.knex = knex
     this.dapi = dapi
   }
@@ -73,11 +72,11 @@ module.exports = class BlockDAO {
           return getAliasStateByVote(aliasInfo, alias, row.owner)
         }))
 
-        return Transaction.fromRow({...row, aliases})
+        return Transaction.fromRow({ ...row, aliases })
       }))
       : []
 
-    return Block.fromRow({header: block, txs})
+    return Block.fromRow({ header: block, txs })
   }
 
   getBlocksByValidator = async (validator, page, limit, order) => {
@@ -110,14 +109,14 @@ module.exports = class BlockDAO {
 
     const blocksMap = rows.reduce((blocks, row) => {
       const block = blocks[row.hash]
-      const {st_hash: txHash} = row
+      const { st_hash: txHash } = row
       const txs = block?.txs || []
 
       if (txHash) {
         txs.push(txHash)
       }
 
-      return {...blocks, [row.hash]: {...row, txs}}
+      return { ...blocks, [row.hash]: { ...row, txs } }
     }, {})
 
     const resultSet = Object.keys(blocksMap).map(blockHash => Block.fromRow({
@@ -142,7 +141,7 @@ module.exports = class BlockDAO {
 
     const txs = results.reduce((acc, value) => value.st_hash ? [...acc, value.st_hash] : acc, [])
 
-    return Block.fromRow({header: block, txs})
+    return Block.fromRow({ header: block, txs })
   }
 
   getBlocks = async (page, limit, order) => {
@@ -169,14 +168,14 @@ module.exports = class BlockDAO {
     // map-reduce Blocks with Transactions
     const blocksMap = rows.reduce((blocks, row) => {
       const block = blocks[row.hash]
-      const {st_hash: txHash} = row
+      const { st_hash: txHash } = row
       const txs = block?.txs || []
 
       if (txHash) {
         txs.push(txHash)
       }
 
-      return {...blocks, [row.hash]: {...row, txs}}
+      return { ...blocks, [row.hash]: { ...row, txs } }
     }, {})
 
     const resultSet = Object.keys(blocksMap).map(blockHash => Block.fromRow({

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -80,12 +80,6 @@ module.exports = class BlockDAO {
     return Block.fromRow({header: block, txs})
   }
 
-  getBlockByHashPart = async (blockHash, limit) =>
-    this.knex('blocks')
-      .select('hash',)
-      .whereILike('hash', `${blockHash}%`)
-      .limit(limit)
-
   getBlocksByValidator = async (validator, page, limit, order) => {
     const fromRank = ((page - 1) * limit) + 1
     const toRank = fromRank + limit - 1

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -101,6 +101,6 @@ module.exports = class DataContractsDAO {
       return null
     }
 
-    return rows.map(row=>DataContract.fromRow(row))
+    return rows.map(row => DataContract.fromRow(row))
   }
 }

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -84,4 +84,23 @@ module.exports = class DataContractsDAO {
 
     return DataContract.fromRow(row)
   }
+
+  getDataContractByName = async (name) => {
+    const rows = await this.knex('data_contracts')
+      .select(
+        'data_contracts.identifier as identifier', 'data_contracts.name as name',
+        'data_contracts.owner as owner', 'data_contracts.is_system as is_system',
+        'data_contracts.version as version', 'data_contracts.schema as schema',
+        'data_contracts.state_transition_hash as tx_hash', 'blocks.timestamp as timestamp'
+      )
+      .whereILike('data_contracts.name', `${name}%`)
+      .leftJoin('state_transitions', 'state_transitions.hash', 'data_contracts.state_transition_hash')
+      .leftJoin('blocks', 'state_transitions.block_hash', 'blocks.hash')
+
+    if (rows.length === 0) {
+      return null
+    }
+
+    return rows.map(row=>DataContract.fromRow(row))
+  }
 }

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -93,6 +93,13 @@ module.exports = class DataContractsDAO {
         'data_contracts.version as version', 'data_contracts.schema as schema',
         'data_contracts.state_transition_hash as tx_hash', 'blocks.timestamp as timestamp'
       )
+      .select(
+        this.knex('documents')
+          .count('*')
+          .leftJoin('data_contracts', 'data_contracts.id', 'documents.data_contract_id')
+          .whereILike('data_contracts.name', `${name}%`)
+          .as('documents_count')
+      )
       .whereILike('data_contracts.name', `${name}%`)
       .leftJoin('state_transitions', 'state_transitions.hash', 'data_contracts.state_transition_hash')
       .leftJoin('blocks', 'state_transitions.block_hash', 'blocks.hash')

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -4,12 +4,11 @@ const Transaction = require('../models/Transaction')
 const Document = require('../models/Document')
 const DataContract = require('../models/DataContract')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-const {IDENTITY_CREDIT_WITHDRAWAL} = require('../enums/StateTransitionEnum')
-const {getAliasInfo, getAliasStateByVote} = require('../utils')
-const {base58} = require('@scure/base')
+const { IDENTITY_CREDIT_WITHDRAWAL } = require('../enums/StateTransitionEnum')
+const { getAliasInfo, getAliasStateByVote } = require('../utils')
 
 module.exports = class IdentitiesDAO {
-  constructor(knex, dapi) {
+  constructor (knex, dapi) {
     this.knex = knex
     this.dapi = dapi
   }
@@ -115,14 +114,14 @@ module.exports = class IdentitiesDAO {
     const fromRank = (page - 1) * limit + 1
     const toRank = fromRank + limit - 1
 
-    const orderByOptions = [{column: 'identity_id', order}]
+    const orderByOptions = [{ column: 'identity_id', order }]
 
     if (orderBy === 'tx_count') {
-      orderByOptions.unshift({column: 'total_txs', order})
+      orderByOptions.unshift({ column: 'total_txs', order })
     }
 
     if (orderBy === 'balance') {
-      orderByOptions.unshift({column: 'balance', order})
+      orderByOptions.unshift({ column: 'balance', order })
     }
 
     const getRankString = () => {
@@ -184,7 +183,7 @@ module.exports = class IdentitiesDAO {
       const aliases = await Promise.all((row.aliases ?? []).map(async alias => {
         const aliasInfo = await getAliasInfo(alias, this.dapi)
 
-        return getAliasStateByVote(aliasInfo, alias, row.identifier.trim());
+        return getAliasStateByVote(aliasInfo, alias, row.identifier.trim())
       }))
 
       return Identity.fromRow({

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -10,12 +10,6 @@ module.exports = class TransactionsDAO {
     this.dapi = dapi
   }
 
-  getTransactionsByHashPart = async (hash, limit) =>
-    this.knex('state_transitions')
-      .select('hash')
-      .whereILike('hash', `${hash}%`)
-      .limit(limit)
-
   getTransactionByHash = async (hash) => {
     const aliasesSubquery = this.knex('identity_aliases')
       .select('identity_identifier', this.knex.raw('array_agg(alias) as aliases'))

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -1,8 +1,7 @@
 const Transaction = require('../models/Transaction')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 const SeriesData = require('../models/SeriesData')
-const { getAliasInfo, getAliasStateByVote} = require('../utils')
-const { base58 } = require('@scure/base')
+const { getAliasInfo, getAliasStateByVote } = require('../utils')
 
 module.exports = class TransactionsDAO {
   constructor (knex, dapi) {

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -417,6 +417,36 @@ const buildIndexBuffer = (name) => {
   )
 }
 
+const getAliasStateByVote = (aliasInfo, alias, identifier) => {
+  let status = null
+
+  if(aliasInfo.contestedState === null){
+    return {
+      alias,
+      status: 'ok',
+      contested: false,
+    }
+  }
+
+  const isLocked = base58.encode(
+    Buffer.from(aliasInfo.contestedState?.finishedVoteInfo?.wonByIdentityId ?? '', 'base64')
+  ) !== identifier
+
+  if (isLocked) {
+    status = 'locked'
+  }else if (!isLocked && aliasInfo.contestedState?.finishedVoteInfo?.wonByIdentityId === undefined){
+    status = 'pending'
+  }else{
+    status = 'ok'
+  }
+
+  return {
+    alias,
+    status,
+    contested: true,
+  }
+}
+
 const getAliasInfo = async (alias, dapi) => {
   const [label, domain] = alias.split('.')
 
@@ -451,5 +481,6 @@ module.exports = {
   checkTcpConnect,
   calculateInterval,
   iso8601duration,
-  getAliasInfo
+  getAliasInfo,
+  getAliasStateByVote
 }

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -3,12 +3,12 @@ const StateTransitionEnum = require('./enums/StateTransitionEnum')
 const PoolingEnum = require('./enums/PoolingEnum')
 const DocumentActionEnum = require('./enums/DocumentActionEnum')
 const net = require('net')
-const {TCP_CONNECT_TIMEOUT, DPNS_CONTRACT, NETWORK} = require('./constants')
-const {base58} = require('@scure/base')
+const { TCP_CONNECT_TIMEOUT, DPNS_CONTRACT, NETWORK } = require('./constants')
+const { base58 } = require('@scure/base')
 const convertToHomographSafeChars = require('dash/build/utils/convertToHomographSafeChars').default
 const Intervals = require('./enums/IntervalsEnum')
 const dashcorelib = require('@dashevo/dashcore-lib')
-const {InstantAssetLockProof, ChainAssetLockProof} = require('@dashevo/wasm-dpp')
+const { InstantAssetLockProof, ChainAssetLockProof } = require('@dashevo/wasm-dpp')
 const SecurityLevelEnum = require('./enums/SecurityLevelEnum')
 const KeyPurposeEnum = require('./enums/KeyPurposeEnum')
 const KeyTypeEnum = require('./enums/KeyTypeEnum')
@@ -22,7 +22,7 @@ const getKnex = () => {
       user: process.env.POSTGRES_USER,
       database: process.env.POSTGRES_DB,
       password: process.env.POSTGRES_PASS,
-      ssl: process.env.POSTGRES_SSL ? {rejectUnauthorized: false} : false
+      ssl: process.env.POSTGRES_SSL ? { rejectUnauthorized: false } : false
     }
   })
 }
@@ -424,7 +424,7 @@ const getAliasStateByVote = (aliasInfo, alias, identifier) => {
     return {
       alias,
       status: 'ok',
-      contested: false,
+      contested: false
     }
   }
 
@@ -443,7 +443,7 @@ const getAliasStateByVote = (aliasInfo, alias, identifier) => {
   return {
     alias,
     status,
-    contested: true,
+    contested: true
   }
 }
 
@@ -468,10 +468,10 @@ const getAliasInfo = async (alias, dapi) => {
       ]
     )
 
-    return {alias, contestedState}
+    return { alias, contestedState }
   }
 
-  return {alias, contestedState: null}
+  return { alias, contestedState: null }
 }
 
 module.exports = {

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -3,12 +3,12 @@ const StateTransitionEnum = require('./enums/StateTransitionEnum')
 const PoolingEnum = require('./enums/PoolingEnum')
 const DocumentActionEnum = require('./enums/DocumentActionEnum')
 const net = require('net')
-const { TCP_CONNECT_TIMEOUT, DPNS_CONTRACT, NETWORK } = require('./constants')
-const { base58 } = require('@scure/base')
+const {TCP_CONNECT_TIMEOUT, DPNS_CONTRACT, NETWORK} = require('./constants')
+const {base58} = require('@scure/base')
 const convertToHomographSafeChars = require('dash/build/utils/convertToHomographSafeChars').default
 const Intervals = require('./enums/IntervalsEnum')
 const dashcorelib = require('@dashevo/dashcore-lib')
-const { InstantAssetLockProof, ChainAssetLockProof } = require('@dashevo/wasm-dpp')
+const {InstantAssetLockProof, ChainAssetLockProof} = require('@dashevo/wasm-dpp')
 const SecurityLevelEnum = require('./enums/SecurityLevelEnum')
 const KeyPurposeEnum = require('./enums/KeyPurposeEnum')
 const KeyTypeEnum = require('./enums/KeyTypeEnum')
@@ -22,7 +22,7 @@ const getKnex = () => {
       user: process.env.POSTGRES_USER,
       database: process.env.POSTGRES_DB,
       password: process.env.POSTGRES_PASS,
-      ssl: process.env.POSTGRES_SSL ? { rejectUnauthorized: false } : false
+      ssl: process.env.POSTGRES_SSL ? {rejectUnauthorized: false} : false
     }
   })
 }
@@ -420,7 +420,7 @@ const buildIndexBuffer = (name) => {
 const getAliasStateByVote = (aliasInfo, alias, identifier) => {
   let status = null
 
-  if(aliasInfo.contestedState === null){
+  if (aliasInfo.contestedState === null) {
     return {
       alias,
       status: 'ok',
@@ -434,9 +434,9 @@ const getAliasStateByVote = (aliasInfo, alias, identifier) => {
 
   if (isLocked) {
     status = 'locked'
-  }else if (!isLocked && aliasInfo.contestedState?.finishedVoteInfo?.wonByIdentityId === undefined){
+  } else if (aliasInfo.contestedState?.finishedVoteInfo?.wonByIdentityId === undefined) {
     status = 'pending'
-  }else{
+  } else {
     status = 'ok'
   }
 
@@ -468,10 +468,10 @@ const getAliasInfo = async (alias, dapi) => {
       ]
     )
 
-    return { alias, contestedState }
+    return {alias, contestedState}
   }
 
-  return { alias, contestedState: null }
+  return {alias, contestedState: null}
 }
 
 module.exports = {

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -221,6 +221,7 @@ describe('Identities routes', () => {
         isSystem: false,
         aliases: [{
           alias,
+          contested: false,
           status: 'ok'
         }]
       }
@@ -307,10 +308,15 @@ describe('Identities routes', () => {
 
       const expectedIdentity = {
         identifier: identity.identifier,
-        alias
+        alias,
+        status: {
+          alias,
+          contested: false,
+          status: 'ok'
+        }
       }
 
-      assert.deepEqual(body, expectedIdentity)
+      assert.deepEqual(body, [expectedIdentity])
     })
 
     it('should return identity by dpns with any case', async () => {
@@ -324,10 +330,15 @@ describe('Identities routes', () => {
 
       const expectedIdentity = {
         identifier: identity.identifier,
-        alias
+        alias,
+        status: {
+          alias,
+          contested: false,
+          status: 'ok'
+        }
       }
 
-      assert.deepEqual(body, expectedIdentity)
+      assert.deepEqual(body, [expectedIdentity])
     })
 
     it('should return 404 when identity not found', async () => {
@@ -373,7 +384,7 @@ describe('Identities routes', () => {
         isSystem: false,
         aliases: [
           aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
-        ].map(alias => ({ alias, status: 'ok' }))
+        ].map(alias => ({ alias, status: 'ok', contested: false }))
       }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -415,7 +426,7 @@ describe('Identities routes', () => {
           isSystem: false,
           aliases: [
             aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
-          ].map(alias => ({ alias, status: 'ok' }))
+          ].map(alias => ({ alias, status: 'ok', contested: false }))
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -458,7 +469,7 @@ describe('Identities routes', () => {
           isSystem: false,
           aliases: [
             aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
-          ].map(alias => ({ alias, status: 'ok' }))
+          ].map(alias => ({ alias, status: 'ok', contested: false }))
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -502,7 +513,7 @@ describe('Identities routes', () => {
           isSystem: false,
           aliases: [
             aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
-          ].map(alias => ({ alias, status: 'ok' }))
+          ].map(alias => ({ alias, status: 'ok', contested: false }))
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -561,7 +572,7 @@ describe('Identities routes', () => {
           isSystem: false,
           aliases: [
             aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
-          ].map(alias => ({ alias, status: 'ok' }))
+          ].map(alias => ({ alias, status: 'ok', contested: false }))
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)
@@ -632,7 +643,7 @@ describe('Identities routes', () => {
           isSystem: false,
           aliases: [
             aliases.find((_alias) => _alias.identity_identifier === _identity.identity.identifier).alias
-          ].map(alias => ({ alias, status: 'ok' }))
+          ].map(alias => ({ alias, status: 'ok', contested: false }))
         }))
 
       assert.deepEqual(body.resultSet, expectedIdentities)

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -90,7 +90,8 @@ describe('Other routes', () => {
     })
     dataContract = await fixtures.dataContract(knex, {
       state_transition_hash: dataContractTransaction.hash,
-      owner: identity.identifier
+      owner: identity.identifier,
+      name: 'test'
     })
 
     documentTransaction = await fixtures.transaction(knex, {
@@ -293,6 +294,26 @@ describe('Other routes', () => {
       }
 
       assert.deepEqual({ dataContract: expectedDataContract }, body)
+    })
+
+    it('should search by data contract name', async () => {
+      const { body } = await client.get('/search?query=test')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedDataContract = {
+        identifier: dataContract.identifier,
+        name: dataContract.name,
+        owner: identity.identifier.trim(),
+        schema: JSON.stringify(dataContract.schema),
+        version: 0,
+        txHash: dataContractTransaction.hash,
+        timestamp: block.timestamp.toISOString(),
+        isSystem: false,
+        documentsCount: 1
+      }
+
+      assert.deepEqual({ dataContracts: [expectedDataContract] }, body)
     })
 
     it('should search by identity DPNS', async () => {

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -174,6 +174,7 @@ describe('Other routes', () => {
               identifier: identityTransaction.owner,
               aliases: [{
                 alias: 'dpns.dash',
+                contested: false,
                 status: 'ok'
               }]
             }
@@ -193,7 +194,8 @@ describe('Other routes', () => {
               identifier: dataContractTransaction.owner,
               aliases: [{
                 alias: 'dpns.dash',
-                status: 'ok'
+                status: 'ok',
+                contested: false
               }]
             }
           },
@@ -212,7 +214,8 @@ describe('Other routes', () => {
               identifier: documentTransaction.owner,
               aliases: [{
                 alias: 'dpns.dash',
-                status: 'ok'
+                status: 'ok',
+                contested: false
               }]
             }
           }
@@ -242,6 +245,7 @@ describe('Other routes', () => {
           identifier: dataContractTransaction.owner,
           aliases: [{
             alias: identityAlias.alias,
+            contested: false,
             status: 'ok'
           }]
         }
@@ -298,12 +302,17 @@ describe('Other routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      const expectedIdentity = {
+      const expectedIdentity = [{
         identifier: identity.identifier,
-        alias: identityAlias.alias
-      }
+        alias: identityAlias.alias,
+        status: {
+          alias: identityAlias.alias,
+          contested: false,
+          status: 'ok'
+        }
+      }]
 
-      assert.deepEqual({ identity: expectedIdentity }, body)
+      assert.deepEqual({ identities: expectedIdentity }, body)
     })
 
     it('should search identity', async () => {
@@ -325,6 +334,7 @@ describe('Other routes', () => {
         owner: identity.identifier,
         aliases: [{
           alias: 'dpns.dash',
+          contested: false,
           status: 'ok'
         }]
       }

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -119,6 +119,7 @@ describe('Transaction routes', () => {
           identifier: transaction.transaction.owner,
           aliases: [{
             alias: identityAlias.alias,
+            contested: false,
             status: 'ok'
           }]
         }
@@ -127,7 +128,7 @@ describe('Transaction routes', () => {
       assert.deepEqual(expectedTransaction, body)
     })
 
-    it('should error transaction', async () => {
+    it('should return error transaction', async () => {
       const [, transaction] = transactions
       const { body } = await client.get(`/transaction/${transaction.transaction.hash}`)
         .expect(200)
@@ -148,6 +149,7 @@ describe('Transaction routes', () => {
           identifier: transaction.transaction.owner,
           aliases: [{
             alias: identityAlias.alias,
+            contested: false,
             status: 'ok'
           }]
         }
@@ -191,6 +193,7 @@ describe('Transaction routes', () => {
             identifier: transaction.transaction.owner,
             aliases: [{
               alias: identityAlias.alias,
+              contested: false,
               status: 'ok'
             }]
           }
@@ -227,6 +230,7 @@ describe('Transaction routes', () => {
             identifier: transaction.transaction.owner,
             aliases: [{
               alias: identityAlias.alias,
+              contested: false,
               status: 'ok'
             }]
           }
@@ -266,6 +270,7 @@ describe('Transaction routes', () => {
             identifier: transaction.transaction.owner,
             aliases: [{
               alias: identityAlias.alias,
+              contested: false,
               status: 'ok'
             }]
           }
@@ -305,6 +310,7 @@ describe('Transaction routes', () => {
             identifier: transaction.transaction.owner,
             aliases: [{
               alias: identityAlias.alias,
+              contested: false,
               status: 'ok'
             }]
           }
@@ -342,6 +348,7 @@ describe('Transaction routes', () => {
             identifier: transaction.transaction.owner,
             aliases: [{
               alias: identityAlias.alias,
+              contested: false,
               status: 'ok'
             }]
           }
@@ -379,6 +386,7 @@ describe('Transaction routes', () => {
             identifier: transaction.transaction.owner,
             aliases: [{
               alias: identityAlias.alias,
+              contested: false,
               status: 'ok'
             }]
           }
@@ -425,6 +433,7 @@ describe('Transaction routes', () => {
             identifier: transaction.transaction.owner,
             aliases: [{
               alias: identityAlias.alias,
+              contested: false,
               status: 'ok'
             }]
           }
@@ -461,6 +470,7 @@ describe('Transaction routes', () => {
             identifier: transaction.transaction.owner,
             aliases: [{
               alias: identityAlias.alias,
+              contested: false,
               status: 'ok'
             }]
           }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -966,6 +966,78 @@ Response codes:
 200: OK
 500: Internal Server Error
 ```
+---
+### Search
+This endpoint allows search any types of data
+
+* `query` required and must contains data for search
+* Response may contain array for Identity and Data Contract when searching by part of field
+
+#### Can be found:
+* Block
+  * Full `height`
+  * Full `hash`
+* Transaction
+  * Full `hash`
+* Validator
+  * Full `proTxHash`
+  * Full `Identifier` of Masternode Identity
+* Identity
+  * Full `Identifier`
+  * Part `alias`
+* Data Contract
+  * Full `Identifier`
+  * Part `name`
+* Document
+  * Full `Identifier`
+
+```
+GET /search?query=xyz
+
+{
+  "identities": [
+    {
+      "identifier": "36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm",
+      "alias": "xyz.dash",
+      "status": {
+        "alias": "xyz.dash",
+        "status": "ok",
+        "contested": true
+      }
+    },
+    {
+      "identifier": "5bUPV8KGgL42ZBS9fsmmKU3wweQbVeHHsiVrG3YMHyG5",
+      "alias": "xyz.dash",
+      "status": {
+        "alias": "xyz.dash",
+        "status": "locked",
+        "contested": true
+      }
+    }
+  ]
+}
+```
+
+```
+GET /search?query=36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm
+
+{
+  "identity": {
+    "identifier": "36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm",
+    "alias": "xyz.dash",
+    "status": {
+      "alias": "xyz.dash",
+      "status": "ok",
+      "contested": true
+    }
+  }
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+```
 ### Transactions history
 Return a series data for the amount of transactions chart
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -34,6 +34,7 @@ Reference:
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
 * [Rate](#rate)
+* [Search](#search)
 * [Decode Raw Transaction](#decode-raw-transaction)
 
 ### Status

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -741,10 +741,17 @@ Return identity by given DPNS/alias
 ```
 GET /dpns/identity?dpns=canuseethat2.dash
 
-{
-  "identity_identifier": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
-  "alias": "canuseethat2.dash"
-}
+[
+  {
+    "identity_identifier": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
+    "alias": "canuseethat2.dash",
+    "status": {
+      "alias": "canuseethat2.dash",
+      "contested": false,
+      "status": "ok"
+    }
+  }
+]
 ```
 Response codes:
 ```

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -514,7 +514,8 @@ GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEE
       aliases: [
         {
           alias: "alias.dash",
-          status: "locked"
+          status: "locked",
+          contested: true
         }
       ]
     }
@@ -566,7 +567,8 @@ GET /transactions?=1&limit=10&order=asc&owner=6q9RFbeea73tE31LGMBLFZhtBUX3wZL3Tc
           aliases: [
             {
               alias: "alias.dash",
-              status: "locked"
+              status: "locked",
+              contested: true
             }
           ]
         }
@@ -721,7 +723,8 @@ GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
     aliases: [
       {
         alias: "alias.dash",
-        status: "locked"
+        status: "locked",
+        contested: true
       }
     ]
 }
@@ -780,7 +783,8 @@ GET /identities?page=1&limit=10&order=asc&order_by=block_height
           aliases: [
             {
               alias: "alias.dash",
-              status: "locked"
+              status: "locked",
+              contested: true
             }
           ]
       }, ...


### PR DESCRIPTION
# Issue
In response to numerous inquiries and complaints, we have decided to implement new search from #324 

# Things done
- Added new implementations for search in MainController. 
- Now we can get response with multiple fields in response, like when we can create alias which contrains Identificator and in response we get both. Also we getting data about all identities which included ballot for the alias
- Also added new part of `README.md`, which contains docs about `search` endpoint.
- Some parts of `README.md` was updated to actual data
- Some test was updated
- Also we returning status about contested alias (`ok`, `locked`, `pending`)
