### PR TITLE
New fields for identities

### DIFF
--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -1,6 +1,8 @@
 const Withdrawal = require('./models/Withdrawal')
 const { Identifier } = require('dash').PlatformProtocol
 
+const { IdentityPublicKey } = require('@dashevo/wasm-dpp/dist/wasm/wasm_dpp')
+
 class DAPI {
   dapi
   dpp
@@ -75,6 +77,25 @@ class DAPI {
       count
     )
     return contestedResourceContenders
+  }
+
+  async getIdentityKeys (identifier, keysIds, limit) {
+    const { identityKeys } = await this.dapi.platform.getIdentityKeys(Identifier.from(identifier), keysIds, limit)
+
+    return identityKeys.map(key => {
+      const serialized = IdentityPublicKey.fromBuffer(Buffer.from(key))
+
+      return {
+        keyId: serialized.getId(),
+        type: serialized.getType(),
+        data: Buffer.from(serialized.getData()).toString('hex'),
+        purpose: serialized.getPurpose(),
+        securityLevel: serialized.getSecurityLevel(),
+        isReadOnly: serialized.isReadOnly(),
+        isMaster: serialized.isMaster(),
+        hash: Buffer.from(serialized.hash()).toString('hex')
+      }
+    })
   }
 }
 

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -4,7 +4,7 @@ const Transaction = require('../models/Transaction')
 const Document = require('../models/Document')
 const DataContract = require('../models/DataContract')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-const { IDENTITY_CREDIT_WITHDRAWAL } = require('../enums/StateTransitionEnum')
+const { IDENTITY_CREDIT_WITHDRAWAL, IDENTITY_TOP_UP } = require('../enums/StateTransitionEnum')
 const { getAliasInfo } = require('../utils')
 const { base58 } = require('@scure/base')
 
@@ -53,18 +53,48 @@ module.exports = class IdentitiesDAO {
       .orWhere('recipient', identifier)
       .as('transfer_alias')
 
-    const rows = await this.knex.with('with_alias', lastRevisionIdentities)
+    const mainQuery = this.knex.with('with_alias', lastRevisionIdentities)
       .select('identifier', 'with_alias.owner as owner', 'revision', 'transfer_id', 'sender',
         'tx_hash', 'is_system', 'blocks.timestamp as timestamp', 'recipient', 'amount')
       .leftJoin('state_transitions', 'state_transitions.hash', 'tx_hash')
       .leftJoin('blocks', 'state_transitions.block_hash', 'blocks.hash')
       .select(this.knex('state_transitions').count('*').where('owner', identifier).as('total_txs'))
+      .select(this.knex('state_transitions').sum('gas_used').where('owner', identifier).as('total_gas_spent'))
       .select(this.knex(documentsSubQuery).count('*').where('rank', 1).as('total_documents'))
       .select(this.knex(dataContractsSubQuery).count('*').where('rank', 1).as('total_data_contracts'))
       .select(this.knex(transfersSubquery).count('*').as('total_transfers'))
       .select(this.knex(aliasSubquery).select('aliases').limit(1).as('aliases'))
       .from('with_alias')
       .limit(1)
+
+    const rows = await this.knex.with('with_alias', mainQuery)
+      .select(
+        'identifier', 'owner', 'revision',
+        'transfer_id', 'sender', 'tx_hash',
+        'is_system', 'timestamp', 'recipient',
+        'amount', 'total_txs', 'total_gas_spent',
+        'total_documents', 'total_data_contracts',
+        'total_transfers', 'aliases',
+        this.knex.raw('ROUND(total_gas_spent/total_txs) as average_gas_spent')
+      )
+      .select(this.knex('state_transitions')
+        .sum('gas_used')
+        .where('owner', identifier)
+        .andWhere('type', IDENTITY_TOP_UP)
+        .as('top_ups_gas_spent'))
+      .select(this.knex('state_transitions')
+        .sum('gas_used')
+        .where('owner', identifier)
+        .andWhere('type', IDENTITY_CREDIT_WITHDRAWAL)
+        .as('withdrawals_gas_spent'))
+      .select(this.knex('state_transitions')
+        .select('hash')
+        .where('owner', identifier)
+        .andWhere('type', IDENTITY_CREDIT_WITHDRAWAL)
+        .orderBy('id', 'desc')
+        .limit(1)
+        .as('last_withdrawal_hash'))
+      .from('with_alias')
 
     if (!rows.length) {
       return null
@@ -91,10 +121,13 @@ module.exports = class IdentitiesDAO {
       }
     }))
 
+    const publicKeys = await this.dapi.getIdentityKeys(row.identifier)
+
     return {
       ...identity,
       aliases,
-      balance: await this.dapi.getIdentityBalance(identity.identifier.trim())
+      balance: await this.dapi.getIdentityBalance(identity.identifier.trim()),
+      publicKeys: publicKeys ?? []
     }
   }
 

--- a/packages/api/src/models/Identity.js
+++ b/packages/api/src/models/Identity.js
@@ -10,8 +10,21 @@ module.exports = class Identity {
   totalDataContracts
   isSystem
   aliases
+  totalGasSpent
+  averageGasSpent
+  topUpsGasSpent
+  withdrawalsGasSpent
+  lastWithdrawalHash
 
-  constructor (identifier, owner, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash, isSystem, aliases) {
+  constructor (
+    identifier, owner, revision,
+    balance, timestamp, totalTxs,
+    totalDataContracts, totalDocuments,
+    totalTransfers, txHash, isSystem,
+    aliases, totalGasSpent, averageGasSpent,
+    topUpsGasSpent, withdrawalsGasSpent,
+    lastWithdrawalHash
+  ) {
     this.identifier = identifier ? identifier.trim() : null
     this.owner = owner ? owner.trim() : null
     this.revision = revision ?? null
@@ -24,14 +37,71 @@ module.exports = class Identity {
     this.txHash = txHash ?? null
     this.isSystem = isSystem ?? null
     this.aliases = aliases ?? []
+    this.totalGasSpent = totalGasSpent ?? null
+    this.averageGasSpent = averageGasSpent ?? null
+    this.topUpsGasSpent = topUpsGasSpent ?? null
+    this.withdrawalsGasSpent = withdrawalsGasSpent ?? null
+    this.lastWithdrawalHash = lastWithdrawalHash ?? null
   }
 
-  // eslint-disable-next-line camelcase
-  static fromRow ({ identifier, owner, revision, balance, timestamp, total_txs, total_data_contracts, total_documents, total_transfers, tx_hash, is_system, aliases }) {
-    return new Identity(identifier?.trim(), owner, revision, Number(balance), timestamp, Number(total_txs), Number(total_data_contracts), Number(total_documents), Number(total_transfers), tx_hash, is_system, aliases)
+  static fromObject ({
+    identifier, owner, revision,
+    balance, timestamp, totalTxs,
+    totalDataContracts, totalDocuments,
+    totalTransfers, txHash, isSystem,
+    aliases, totalGasSpent, averageGasSpent,
+    topUpsGasSpent, withdrawalsGasSpent,
+    lastWithdrawalHash
+  }) {
+    return new Identity(
+      identifier,
+      owner,
+      revision,
+      balance,
+      timestamp,
+      totalTxs,
+      totalDataContracts,
+      totalDocuments,
+      totalTransfers,
+      txHash,
+      isSystem,
+      aliases,
+      totalGasSpent,
+      averageGasSpent,
+      topUpsGasSpent,
+      withdrawalsGasSpent,
+      lastWithdrawalHash
+    )
   }
 
-  static fromObject ({ identifier, owner, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash, isSystem, aliases }) {
-    return new Identity(identifier, owner, revision, balance, timestamp, totalTxs, totalDataContracts, totalDocuments, totalTransfers, txHash, isSystem, aliases)
+  /* eslint-disable camelcase */
+  static fromRow ({
+    identifier, owner, revision,
+    balance, timestamp, total_txs,
+    total_data_contracts, total_documents,
+    total_transfers, tx_hash, is_system,
+    aliases, total_gas_spent, average_gas_spent,
+    top_ups_gas_spent, withdrawals_gas_spent,
+    last_withdrawal_hash
+  }) {
+    return new Identity(
+      identifier?.trim(),
+      owner,
+      revision,
+      Number(balance),
+      timestamp,
+      Number(total_txs),
+      Number(total_data_contracts),
+      Number(total_documents),
+      Number(total_transfers),
+      tx_hash,
+      is_system,
+      aliases,
+      Number(total_gas_spent),
+      Number(average_gas_spent),
+      Number(top_ups_gas_spent),
+      Number(withdrawals_gas_spent),
+      last_withdrawal_hash
+    )
   }
 }


### PR DESCRIPTION
# Issue
For new identities page, we need additional data in response from API
# Things done
Was added new method in `DAPI.js`, which allows to get identities public keys from dapi.
For this method, was updated my repo with `dapi-client`, because `getIdentityKeys` didn't  support value `all_keys` for `response_type`.
Was updated request query to indexer DB.
Updated the `Identity` model accordingly
~~Updated `README.md`
Updated integration tests for new data~~