### PR TITLE
Transactions gas history series

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -66,6 +66,7 @@ Reference:
 * [Transactions By Identity](#transactions-by-identity)
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
+* [Transactions gas history](#transactions-gas-history)
 * [Rate](#rate)
 * [Decode Raw Transaction](#decode-raw-transaction)
 
@@ -1023,6 +1024,40 @@ GET /transactions/history?start=2024-01-01T00:00:00&end=2025-01-01T00:00:00
           txs: 13,
           blockHeight: 7,
           blockHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+        }
+    }, ...
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check start/end values
+500: Internal Server Error
+```
+### Transactions Gas history
+Return a series data for the used gas of transactions chart
+
+* `start` lower interval threshold in ISO string ( _optional_ )
+* `end` upper interval threshold in ISO string ( _optional_ )
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /transactions/gas/history?start=2024-01-01T00:00:00&end=2025-01-01T00:00:00
+[
+    {
+        timestamp: "2024-04-22T08:45:20.911Z",
+        "data": {
+          "gas": 772831320,
+          "blockHeight": 64060,
+          "blockHash": "4A1F6B5238032DDAC55009A28797D909DB4288D5B5EC14B86DEC6EA8F25EC71A"
+        }
+    },
+    {
+        timestamp: "2024-04-22T08:50:20.911Z",
+        "data": {
+          "gas": 14108752440,
+          "blockHeight": 64333,
+          "blockHash": "507659D9BE2FF76A031F4219061F3D2D39475A7FA4B24F25AEFDB34CD4DF2A57"
         }
     }, ...
 ]

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -287,6 +287,14 @@ module.exports = ({
       }
     },
     {
+      path: '/transactions/gas/history',
+      method: 'GET',
+      handler: transactionsController.getGasHistory,
+      schema: {
+        querystring: { $ref: 'timeInterval#' }
+      }
+    },
+    {
       path: '/validators',
       method: 'GET',
       handler: validatorsController.getValidators,

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -700,7 +700,7 @@ describe('Transaction routes', () => {
           new Date(transaction.block.timestamp).getTime() >= nextPeriod
         )
 
-        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+        const gas = txs.reduce((a, b) => a + b.transaction.gas_used, 0)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
@@ -716,7 +716,7 @@ describe('Transaction routes', () => {
     })
 
     it('should return default series set timespan 2H', async () => {
-      const { body } = await client.get(`/transactions/history?start=${new Date(new Date().getTime() - 3600000).toISOString()}&end=${new Date(new Date().getTime() + 3600000).toISOString()}`)
+      const { body } = await client.get(`/transactions/gas/history?start=${new Date(new Date().getTime() - 3600000).toISOString()}&end=${new Date(new Date().getTime() + 3600000).toISOString()}`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
@@ -736,12 +736,12 @@ describe('Transaction routes', () => {
           new Date(transaction.block.timestamp).getTime() >= nextPeriod
         )
 
-        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+        const gas = txs.reduce((a, b) => a + b.transaction.gas_used, 0)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas,
+            gas: txs[0]?.block?.height? gas: null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -752,7 +752,7 @@ describe('Transaction routes', () => {
     })
 
     it('should return default series set timespan 24h', async () => {
-      const { body } = await client.get(`/transactions/history?start=${new Date(new Date().getTime() - 43200000).toISOString()}&end=${new Date(new Date().getTime() + 43200000).toISOString()}`)
+      const { body } = await client.get(`/transactions/gas/history?start=${new Date(new Date().getTime() - 43200000).toISOString()}&end=${new Date(new Date().getTime() + 43200000).toISOString()}`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
@@ -772,12 +772,12 @@ describe('Transaction routes', () => {
           new Date(transaction.block.timestamp).getTime() >= nextPeriod
         )
 
-        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+        const gas = txs.reduce((a, b) => a + b.transaction.gas_used, 0)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas,
+            gas: txs[0]?.block?.height? gas: null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -788,7 +788,7 @@ describe('Transaction routes', () => {
     })
 
     it('should return default series set timespan 3d', async () => {
-      const { body } = await client.get(`/transactions/history?start=${new Date(new Date().getTime() - 129600000).toISOString()}&end=${new Date(new Date().getTime() + 129600000).toISOString()}`)
+      const { body } = await client.get(`/transactions/gas/history?start=${new Date(new Date().getTime() - 129600000).toISOString()}&end=${new Date(new Date().getTime() + 129600000).toISOString()}`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
@@ -808,12 +808,12 @@ describe('Transaction routes', () => {
           new Date(transaction.block.timestamp).getTime() >= nextPeriod
         )
 
-        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+        const gas = txs.reduce((a, b) => a + b.transaction.gas_used, 0)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas,
+            gas: txs[0]?.block?.height? gas: null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -824,7 +824,7 @@ describe('Transaction routes', () => {
     })
 
     it('should return default series set timespan 1w', async () => {
-      const { body } = await client.get(`/transactions/history?start=${new Date(new Date().getTime() - 302400000).toISOString()}&end=${new Date(new Date().getTime() + 302400000).toISOString()}`)
+      const { body } = await client.get(`/transactions/gas/history?start=${new Date(new Date().getTime() - 302400000).toISOString()}&end=${new Date(new Date().getTime() + 302400000).toISOString()}`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
@@ -844,12 +844,12 @@ describe('Transaction routes', () => {
           new Date(transaction.block.timestamp).getTime() >= nextPeriod
         )
 
-        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+        const gas = txs.reduce((a, b) => a + b.transaction.gas_used, 0)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas,
+            gas: txs[0]?.block?.height? gas: null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -862,7 +862,7 @@ describe('Transaction routes', () => {
       const start = new Date(new Date().getTime())
       const end = new Date(start.getTime() + 10800000)
 
-      const { body } = await client.get(`/transactions/history?start=${start.toISOString()}&end=${end.toISOString()}&intervalsCount=3`)
+      const { body } = await client.get(`/transactions/gas/history?start=${start.toISOString()}&end=${end.toISOString()}&intervalsCount=3`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
@@ -882,12 +882,12 @@ describe('Transaction routes', () => {
           new Date(transaction.block.timestamp).getTime() >= nextPeriod
         )
 
-        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+        const gas = txs.reduce((a, b) => a + b.transaction.gas_used, 0)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas,
+            gas: txs[0]?.block?.height? gas: null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -741,7 +741,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height? gas: null,
+            gas: txs[0]?.block?.height ? gas : null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -777,7 +777,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height? gas: null,
+            gas: txs[0]?.block?.height ? gas : null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -813,7 +813,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height? gas: null,
+            gas: txs[0]?.block?.height ? gas : null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -849,7 +849,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height? gas: null,
+            gas: txs[0]?.block?.height ? gas : null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -887,7 +887,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height? gas: null,
+            gas: txs[0]?.block?.height ? gas : null,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -677,4 +677,224 @@ describe('Transaction routes', () => {
       assert.deepEqual(expectedSeriesData.reverse(), body)
     })
   })
+
+  describe('getGasHistorySeries()', async () => {
+    it('should return default series set', async () => {
+      const { body } = await client.get('/transactions/gas/history')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 12)
+
+      const [firstPeriod] = body.toReversed()
+      const firstTimestamp = new Date(firstPeriod.timestamp)
+
+      const expectedSeriesData = []
+
+      for (let i = 0; i < body.length; i++) {
+        const nextPeriod = firstTimestamp - 300000 * i
+        const prevPeriod = firstTimestamp - 300000 * (i - 1)
+
+        const txs = transactions.filter(transaction =>
+          new Date(transaction.block.timestamp).getTime() <= prevPeriod &&
+          new Date(transaction.block.timestamp).getTime() >= nextPeriod
+        )
+
+        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+
+        expectedSeriesData.push({
+          timestamp: new Date(nextPeriod).toISOString(),
+          data: {
+            gas,
+            blockHeight: txs[0]?.block?.height ?? null,
+            blockHash: txs[0]?.block?.hash ?? null
+          }
+        })
+      }
+
+      assert.deepEqual(expectedSeriesData.reverse(), body)
+    })
+
+    it('should return default series set timespan 2H', async () => {
+      const { body } = await client.get(`/transactions/history?start=${new Date(new Date().getTime() - 3600000).toISOString()}&end=${new Date(new Date().getTime() + 3600000).toISOString()}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 4)
+
+      const [firstPeriod] = body.toReversed()
+      const firstTimestamp = new Date(firstPeriod.timestamp)
+
+      const expectedSeriesData = []
+
+      for (let i = 0; i < body.length; i++) {
+        const nextPeriod = firstTimestamp - 1800000 * i
+        const prevPeriod = firstTimestamp - 1800000 * (i - 1)
+
+        const txs = transactions.filter(transaction =>
+          new Date(transaction.block.timestamp).getTime() <= prevPeriod &&
+          new Date(transaction.block.timestamp).getTime() >= nextPeriod
+        )
+
+        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+
+        expectedSeriesData.push({
+          timestamp: new Date(nextPeriod).toISOString(),
+          data: {
+            gas,
+            blockHeight: txs[0]?.block?.height ?? null,
+            blockHash: txs[0]?.block?.hash ?? null
+          }
+        })
+      }
+
+      assert.deepEqual(expectedSeriesData.reverse(), body)
+    })
+
+    it('should return default series set timespan 24h', async () => {
+      const { body } = await client.get(`/transactions/history?start=${new Date(new Date().getTime() - 43200000).toISOString()}&end=${new Date(new Date().getTime() + 43200000).toISOString()}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 4)
+
+      const [firstPeriod] = body.toReversed()
+      const firstTimestamp = new Date(firstPeriod.timestamp)
+
+      const expectedSeriesData = []
+
+      for (let i = 0; i < body.length; i++) {
+        const nextPeriod = firstTimestamp - 21600000 * i
+        const prevPeriod = firstTimestamp - 21600000 * (i - 1)
+
+        const txs = transactions.filter(transaction =>
+          new Date(transaction.block.timestamp).getTime() <= prevPeriod &&
+          new Date(transaction.block.timestamp).getTime() >= nextPeriod
+        )
+
+        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+
+        expectedSeriesData.push({
+          timestamp: new Date(nextPeriod).toISOString(),
+          data: {
+            gas,
+            blockHeight: txs[0]?.block?.height ?? null,
+            blockHash: txs[0]?.block?.hash ?? null
+          }
+        })
+      }
+
+      assert.deepEqual(expectedSeriesData.reverse(), body)
+    })
+
+    it('should return default series set timespan 3d', async () => {
+      const { body } = await client.get(`/transactions/history?start=${new Date(new Date().getTime() - 129600000).toISOString()}&end=${new Date(new Date().getTime() + 129600000).toISOString()}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 5)
+
+      const [firstPeriod] = body.toReversed()
+      const firstTimestamp = new Date(firstPeriod.timestamp)
+
+      const expectedSeriesData = []
+
+      for (let i = 0; i < body.length; i++) {
+        const nextPeriod = firstTimestamp - 50400000 * i
+        const prevPeriod = firstTimestamp - 50400000 * (i - 1)
+
+        const txs = transactions.filter(transaction =>
+          new Date(transaction.block.timestamp).getTime() <= prevPeriod &&
+          new Date(transaction.block.timestamp).getTime() >= nextPeriod
+        )
+
+        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+
+        expectedSeriesData.push({
+          timestamp: new Date(nextPeriod).toISOString(),
+          data: {
+            gas,
+            blockHeight: txs[0]?.block?.height ?? null,
+            blockHash: txs[0]?.block?.hash ?? null
+          }
+        })
+      }
+
+      assert.deepEqual(expectedSeriesData.reverse(), body)
+    })
+
+    it('should return default series set timespan 1w', async () => {
+      const { body } = await client.get(`/transactions/history?start=${new Date(new Date().getTime() - 302400000).toISOString()}&end=${new Date(new Date().getTime() + 302400000).toISOString()}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 7)
+
+      const [firstPeriod] = body.toReversed()
+      const firstTimestamp = new Date(firstPeriod.timestamp)
+
+      const expectedSeriesData = []
+
+      for (let i = 0; i < body.length; i++) {
+        const nextPeriod = firstTimestamp - 86400000 * i
+        const prevPeriod = firstTimestamp - 86400000 * (i - 1)
+
+        const txs = transactions.filter(transaction =>
+          new Date(transaction.block.timestamp).getTime() <= prevPeriod &&
+          new Date(transaction.block.timestamp).getTime() >= nextPeriod
+        )
+
+        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+
+        expectedSeriesData.push({
+          timestamp: new Date(nextPeriod).toISOString(),
+          data: {
+            gas,
+            blockHeight: txs[0]?.block?.height ?? null,
+            blockHash: txs[0]?.block?.hash ?? null
+          }
+        })
+      }
+
+      assert.deepEqual(expectedSeriesData.reverse(), body)
+    })
+    it('should return series of 6 intervals timespan 3d', async () => {
+      const start = new Date(new Date().getTime())
+      const end = new Date(start.getTime() + 10800000)
+
+      const { body } = await client.get(`/transactions/history?start=${start.toISOString()}&end=${end.toISOString()}&intervalsCount=3`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 3)
+
+      const [firstPeriod] = body.toReversed()
+      const firstTimestamp = new Date(firstPeriod.timestamp)
+
+      const expectedSeriesData = []
+
+      for (let i = 0; i < body.length; i++) {
+        const nextPeriod = firstTimestamp - Math.ceil((end - start) / 1000 / 3) * 1000 * i
+        const prevPeriod = firstTimestamp - 3600000 * (i - 1)
+
+        const txs = transactions.filter(transaction =>
+          new Date(transaction.block.timestamp).getTime() <= prevPeriod &&
+          new Date(transaction.block.timestamp).getTime() >= nextPeriod
+        )
+
+        const gas = txs.reduce((a, b) => a.gas_used + b.gas_used, 0)
+
+        expectedSeriesData.push({
+          timestamp: new Date(nextPeriod).toISOString(),
+          data: {
+            gas,
+            blockHeight: txs[0]?.block?.height ?? null,
+            blockHash: txs[0]?.block?.hash ?? null
+          }
+        })
+      }
+
+      assert.deepEqual(expectedSeriesData.reverse(), body)
+    })
+  })
 })

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -33,6 +33,7 @@ Reference:
 * [Transactions By Identity](#transactions-by-identity)
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
+* [Transactions gas history](#transactions-gas-history)
 * [Rate](#rate)
 * [Decode Raw Transaction](#decode-raw-transaction)
 
@@ -990,6 +991,40 @@ GET /transactions/history?start=2024-01-01T00:00:00&end=2025-01-01T00:00:00
           txs: 13,
           blockHeight: 7,
           blockHash: "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF"
+        }
+    }, ...
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check start/end values
+500: Internal Server Error
+```
+### Transactions Gas history
+Return a series data for the used gas of transactions chart
+
+* `start` lower interval threshold in ISO string ( _optional_ )
+* `end` upper interval threshold in ISO string ( _optional_ )
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /transactions/gas/history?start=2024-01-01T00:00:00&end=2025-01-01T00:00:00
+[
+    {
+        timestamp: "2024-04-22T08:45:20.911Z",
+        "data": {
+          "gas": 772831320,
+          "blockHeight": 64060,
+          "blockHash": "4A1F6B5238032DDAC55009A28797D909DB4288D5B5EC14B86DEC6EA8F25EC71A"
+        }
+    },
+    {
+        timestamp: "2024-04-22T08:50:20.911Z",
+        "data": {
+          "gas": 14108752440,
+          "blockHeight": 64333,
+          "blockHash": "507659D9BE2FF76A031F4219061F3D2D39475A7FA4B24F25AEFDB34CD4DF2A57"
         }
     }, ...
 ]


### PR DESCRIPTION
# Issue
For gas chart on home page we need data-series from API about gas, which was spent
# Things done
Added new enpoint `/transactions/gas/history`, which allows to get data-series, like in other places (`transactions/history` and etc)
This endpoint binded to new method in Transactions Controller, which calling data form indexer via TransactionsDAO.
Also updated README.md and added new integration tests