### PR TITLE
Add transaction hash in the identity names

### DIFF
--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -212,7 +212,8 @@ describe('Identities routes', () => {
       const { alias } = await fixtures.identity_alias(knex,
         {
           alias: 'test.dash',
-          identity
+          identity,
+          state_transition_hash: transaction.hash
         }
       )
 
@@ -320,7 +321,7 @@ describe('Identities routes', () => {
     it('should return identity by dpns', async () => {
       const block = await fixtures.block(knex)
       const identity = await fixtures.identity(knex, { block_hash: block.hash })
-      const { alias } = await fixtures.identity_alias(knex, { alias: 'test-name.1.dash', identity })
+      const { alias } = await fixtures.identity_alias(knex, { alias: 'test-name.1.dash', identity, state_transition_hash: identity.transaction.hash })
 
       const { body } = await client.get('/dpns/identity?dpns=test-name.1.dash')
         .expect(200)
@@ -342,7 +343,7 @@ describe('Identities routes', () => {
     it('should return identity by dpns with any case', async () => {
       const block = await fixtures.block(knex)
       const identity = await fixtures.identity(knex, { block_hash: block.hash })
-      const { alias } = await fixtures.identity_alias(knex, { alias: 'test-name.2.dash', identity })
+      const { alias } = await fixtures.identity_alias(knex, { alias: 'test-name.2.dash', identity, state_transition_hash: identity.transaction.hash })
 
       const { body } = await client.get('/dpns/identity?dpns=TeSt-NaME.2.DAsH')
         .expect(200)
@@ -376,7 +377,7 @@ describe('Identities routes', () => {
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
         identity = await fixtures.identity(knex, { block_hash: block.hash })
-        alias = await fixtures.identity_alias(knex, { alias: `#test$${i}`, identity })
+        alias = await fixtures.identity_alias(knex, { alias: `#test$${i}`, identity, state_transition_hash: identity.transaction.hash })
         identities.push({ identity, block })
         aliases.push(alias)
       }
@@ -423,7 +424,7 @@ describe('Identities routes', () => {
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
         identity = await fixtures.identity(knex, { block_hash: block.hash })
-        alias = await fixtures.identity_alias(knex, { alias: `#test1$${i}`, identity })
+        alias = await fixtures.identity_alias(knex, { alias: `#test1$${i}`, identity, state_transition_hash: identity.transaction.hash })
         identities.push({ identity, block })
         aliases.push(alias)
       }
@@ -473,7 +474,7 @@ describe('Identities routes', () => {
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
         identity = await fixtures.identity(knex, { block_hash: block.hash })
-        alias = await fixtures.identity_alias(knex, { alias: `#test2$${i}`, identity })
+        alias = await fixtures.identity_alias(knex, { alias: `#test2$${i}`, identity, state_transition_hash: identity.transaction.hash })
         identities.push({ identity, block })
         aliases.push(alias)
       }
@@ -523,7 +524,7 @@ describe('Identities routes', () => {
       for (let i = 0; i < 30; i++) {
         block = await fixtures.block(knex, { height: i + 1 })
         identity = await fixtures.identity(knex, { block_hash: block.hash })
-        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity })
+        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity, state_transition_hash: identity.transaction.hash })
         identities.push({ identity, block })
         aliases.push(alias)
       }
@@ -590,7 +591,7 @@ describe('Identities routes', () => {
         identity.transactions = transactions
 
         identities.push({ identity, block })
-        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity })
+        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity, state_transition_hash: identity.transaction.hash })
         aliases.push(alias)
       }
 
@@ -654,7 +655,7 @@ describe('Identities routes', () => {
         identity.balance = transfer.amount
 
         identities.push({ identity, block, transfer })
-        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity })
+        alias = await fixtures.identity_alias(knex, { alias: `#test3$${i}`, identity, state_transition_hash: identity.transaction.hash })
         aliases.push(alias)
       }
 

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -84,7 +84,8 @@ describe('Other routes', () => {
 
     identityAlias = await fixtures.identity_alias(knex, {
       alias: 'dpns.dash',
-      identity
+      identity,
+      state_transition_hash: identityTransaction.hash,
     })
 
     dataContractTransaction = await fixtures.transaction(knex, {

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -85,7 +85,7 @@ describe('Other routes', () => {
     identityAlias = await fixtures.identity_alias(knex, {
       alias: 'dpns.dash',
       identity,
-      state_transition_hash: identityTransaction.hash,
+      state_transition_hash: identityTransaction.hash
     })
 
     dataContractTransaction = await fixtures.transaction(knex, {

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -42,7 +42,7 @@ describe('Transaction routes', () => {
     })
     identity = await fixtures.identity(knex, { block_hash: block.hash })
 
-    identityAlias = await fixtures.identity_alias(knex, { alias: 'test.dash', identity })
+    identityAlias = await fixtures.identity_alias(knex, { alias: 'test.dash', identity, state_transition_hash: identity.transaction.hash })
 
     transactions = [{ transaction: identity.transaction, block }]
 

--- a/packages/api/test/utils/fixtures.js
+++ b/packages/api/test/utils/fixtures.js
@@ -84,14 +84,15 @@ const fixtures = {
     return { ...row, txHash: state_transition_hash ?? transaction.hash, id: result[0].id, transaction }
   },
 
-  identity_alias: async (knex, { alias, identity, block_hash } = {}) => {
+  identity_alias: async (knex, { alias, identity, block_hash, state_transition_hash } = {}) => {
     if (!identity) {
       identity = this.identity(knex, { block_hash })
     }
 
     const row = {
       identity_identifier: identity.identifier,
-      alias
+      alias,
+      state_transition_hash
     }
 
     await knex('identity_aliases').insert(row).returning('id')

--- a/packages/indexer/migrations/V43__add_identity_alias_st_hash.sql
+++ b/packages/indexer/migrations/V43__add_identity_alias_st_hash.sql
@@ -1,0 +1,2 @@
+ALTER TABLE identity_aliases
+ADD COLUMN "state_transition_hash" CHAR(64) NOT NULL;

--- a/packages/indexer/src/processor/psql/dao/mod.rs
+++ b/packages/indexer/src/processor/psql/dao/mod.rs
@@ -179,19 +179,20 @@ impl PostgresDAO {
         Ok(())
     }
 
-    pub async fn create_identity_alias(&self, identity: Identity, alias: String) -> Result<(), PoolError> {
+    pub async fn create_identity_alias(&self, identity: Identity, alias: String, st_hash: String) -> Result<(), PoolError> {
         let client = self.connection_pool.get().await.unwrap();
 
-        let query = "INSERT INTO identity_aliases(identity_identifier,alias) VALUES ($1, $2);";
+        let query = "INSERT INTO identity_aliases(identity_identifier,alias,state_transition_hash) VALUES ($1, $2, $3);";
 
         let stmt = client.prepare_cached(query).await.unwrap();
 
         client.query(&stmt, &[
             &identity.identifier.to_string(Base58),
             &alias,
+            &st_hash,
         ]).await.unwrap();
 
-        println!("Created Identity Alias {} -> {}", identity.identifier.to_string(Base58), alias);
+        println!("Created Identity Alias {} -> {} ({})", identity.identifier.to_string(Base58), alias, &st_hash);
 
         Ok(())
     }

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -145,7 +145,7 @@ impl PSQLProcessor {
                 let identity = self.dao.get_identity_by_identifier(identity_identifier.clone()).await.unwrap().expect(&format!("Could not find identity with identifier {}", identity_identifier));
                 let alias = format!("{}.{}", label, normalized_parent_domain_name);
 
-                self.dao.create_identity_alias(identity, alias).await.unwrap();
+                self.dao.create_identity_alias(identity, alias, st_hash.clone()).await.unwrap();
             }
 
             if document_type == "dataContracts" && document_transition.data_contract_id() == self.platform_explorer_identifier {


### PR DESCRIPTION
# Issue

Identity aliases in the indexer is missing reference to transaction hash, and it makes it complicated to show timestamp of the identity names on the backend through DAPI.


# Things done

* Added new column state_transition_hash for identity_aliases
* Added transaction hash of the DPNS name creation in the identity aliases records