### PR TITLE
Add document transition type and document type name

### DIFF
--- a/packages/indexer/migrations/V43__add_document_transition_type.sql
+++ b/packages/indexer/migrations/V43__add_document_transition_type.sql
@@ -1,0 +1,2 @@
+ALTER TABLE documents
+ADD COLUMN "transition_type" BIGINT NOT NULL;

--- a/packages/indexer/migrations/V44__add_document_type_name.sql
+++ b/packages/indexer/migrations/V44__add_document_type_name.sql
@@ -1,0 +1,2 @@
+ALTER TABLE documents
+ADD COLUMN "document_type_name" TEXT NOT NULL;

--- a/packages/indexer/src/entities/identity.rs
+++ b/packages/indexer/src/entities/identity.rs
@@ -45,7 +45,13 @@ impl From<IdentityCreateTransition> for Identity {
                                       Auth::UserPass(core_rpc_user, core_rpc_password)).unwrap();
 
                 let block_hash = rpc.get_block_hash(block_height).unwrap();
-                let transaction = rpc.get_raw_transaction(&Txid::from_hex(&tx_hash).unwrap(), Some(&block_hash)).unwrap();
+                let transaction = match rpc.get_raw_transaction(&Txid::from_hex(&tx_hash).unwrap(), Some(&block_hash)) {
+                    Ok(tx) => tx,
+                    Err(err) => {
+                        println!("Could not find transaction {} in blockhash {}", &tx_hash, &block_hash);
+                        panic!("Err");
+                    }
+                };
 
                 transaction
             }

--- a/packages/indexer/src/processor/psql/dao/mod.rs
+++ b/packages/indexer/src/processor/psql/dao/mod.rs
@@ -106,7 +106,7 @@ impl PostgresDAO {
         let id = document.identifier;
         let revision = document.revision;
         let revision_i32 = revision as i32;
-
+        let transition_type = document.transition_type as i64;
         let data = document.data;
         let is_system = document.is_system;
 
@@ -130,13 +130,15 @@ impl PostgresDAO {
                                             document.data_contract_identifier.to_string(Base58)));
         let data_contract_id = data_contract.id.unwrap() as i32;
 
-        let query = "INSERT INTO documents(identifier,owner,revision,data,deleted,\
-        state_transition_hash,data_contract_id,is_system) VALUES ($1, $2, $3, $4, $5, $6, $7, $8);";
+        let query = "INSERT INTO documents(identifier,document_type_name,transition_type,owner,revision,data,deleted,\
+        state_transition_hash,data_contract_id,is_system) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10);";
 
         let stmt = client.prepare_cached(query).await.unwrap();
 
         client.query(&stmt, &[
             &id.to_string(Base58),
+            &document.document_type_name,
+            &transition_type,
             &owner.to_string(Base58),
             &revision_i32,
             &data,
@@ -260,7 +262,8 @@ impl PostgresDAO {
     pub async fn get_document_by_identifier(&self, identifier: Identifier) -> Result<Option<Document>, PoolError> {
         let client = self.connection_pool.get().await?;
 
-        let stmt = client.prepare_cached("SELECT documents.id, documents.identifier,\
+        let stmt = client.prepare_cached("SELECT documents.id, documents.identifier, \
+        documents.document_type_name, documents.transition_type, \
         data_contracts.identifier,documents.owner,documents.price,\
         documents.deleted,documents.revision,documents.is_system \
         FROM documents \

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -18,6 +18,7 @@ use dpp::state_transition::documents_batch_transition::{DocumentsBatchTransition
 use sha256::digest;
 use dpp::state_transition::data_contract_update_transition::DataContractUpdateTransition;
 use dpp::state_transition::documents_batch_transition::document_transition::{DocumentTransition, DocumentTransitionV0Methods};
+use dpp::state_transition::documents_batch_transition::document_transition::action_type::DocumentTransitionActionType;
 use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
 use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTransferTransition;
 use dpp::state_transition::identity_credit_withdrawal_transition::IdentityCreditWithdrawalTransition;
@@ -420,12 +421,14 @@ impl PSQLProcessor {
                         215, 242, 197, 63, 70, 169, 23, 171, 110, 91, 57, 162, 215, 188, 38, 11, 100, 146, 137, 69, 55,
                         68, 209, 224, 212, 242, 106, 141, 142, 255, 55, 207,
                     ]).unwrap(),
+                    document_type_name: String::from("domain"),
                     data_contract_identifier,
                     data: Some(serde_json::to_value(dash_tld_document_values).unwrap()),
                     deleted: false,
                     revision: 0,
                     is_system: true,
                     price: None,
+                    transition_type: DocumentTransitionActionType::Create,
                 };
 
                 self.dao.create_document(dash_tld_document, None).await.unwrap();


### PR DESCRIPTION
# Issue
Indexer is missing document transition type and document type name in the SQL. Adding it will allow more precise transaction filtering in the backend (and thus frontend).

Adding document type name will show the type of the document user is submitting
Adding document transition type allow filtering by type on the backend (and thus frontend)

# Things done
* Added transition_type and document_type_name in the documents table