### PR TITLE
Transaction decode nonce error fix

### DIFF
--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -264,7 +264,7 @@ const decodeStateTransition = async (client, base64) => {
       break
     }
     case StateTransitionEnum.IDENTITY_CREDIT_TRANSFER: {
-      decoded.identityContractNonce = Number(stateTransition.getIdentityContractNonce())
+      decoded.nonce = Number(stateTransition.getNonce())
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
       decoded.senderId = stateTransition.getIdentityId().toString()
       decoded.recipientId = stateTransition.getRecipientId().toString()
@@ -284,7 +284,6 @@ const decodeStateTransition = async (client, base64) => {
         : null
 
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
-      decoded.identityContractNonce = Number(stateTransition.getIdentityContractNonce())
       decoded.identityNonce = parseInt(stateTransition.getNonce())
       decoded.senderId = stateTransition.getIdentityId().toString()
       decoded.amount = parseInt(stateTransition.getAmount())

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -277,7 +277,7 @@ describe('Utils', () => {
 
       assert.deepEqual(decoded, {
         type: 7,
-        identityContractNonce: 3,
+        nonce: 3,
         userFeeIncrease: 2,
         senderId: '4CpFVPyU95ZxNeDnRWfkpjUa9J72i3nZ4YPsTnpdUudu',
         recipientId: 'GxdRSLivPDeACYU8Z6JSNvtrRPX7QG715JoumnctbwWN',
@@ -295,7 +295,6 @@ describe('Utils', () => {
         type: 6,
         outputAddress: 'yZF5JqEgS9xT1xSkhhUQACdLLDbqSixL8i',
         userFeeIncrease: 2,
-        identityContractNonce: 1,
         senderId: 'FvqzjDyub72Hk51pcmJvd1JUACuor7vA3aJawiVG7Z17',
         amount: 1000000,
         identityNonce: 1,


### PR DESCRIPTION
# Issue
After new update of wasm-dpp, we getting error, when decoding transfer and withdrawal transactions
# Things done
Removed identityContractNonce, added nonce to decoding util
Updated Tests