### PR TITLE
Improve network status check

### DIFF
--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -31,7 +31,7 @@ function NetworkStatus ({ className }) {
     Api.getStatus()
       .then(res => fetchHandlerSuccess(setStatus, res))
       .catch(err => fetchHandlerError(setStatus, err))
-      .finally(() => setTimeout(fetchData, 60000))
+      .finally(() => setTimeout(fetchData, 15000))
   }, [])
 
   useEffect(fetchData, [fetchData])

--- a/packages/frontend/src/components/networkStatus/index.js
+++ b/packages/frontend/src/components/networkStatus/index.js
@@ -10,8 +10,22 @@ import { EpochTooltip } from '../ui/Tooltips'
 import Link from 'next/link'
 import './NetworkStatus.scss'
 
+function checkApiStatus (status) {
+  if (!status?.data?.tenderdash?.block?.timestamp || !status?.data?.api?.block?.timestamp) return false
+
+  const tenderdashTimestamp = new Date(status?.data?.tenderdash?.block?.timestamp).getTime()
+  const apiTimestamp = new Date(status?.data?.api?.block?.timestamp).getTime()
+
+  return !Number.isNaN(apiTimestamp) && !Number.isNaN(tenderdashTimestamp) &&
+    Math.abs(apiTimestamp - tenderdashTimestamp) <= 10 * 60 * 1000
+}
+
 function NetworkStatus ({ className }) {
   const [status, setStatus] = useState({ data: {}, loading: true, error: false })
+  const lastBlockTimestamp = status?.data?.tenderdash?.block?.timestamp
+  const msFromLastBlock = lastBlockTimestamp ? new Date() - new Date(lastBlockTimestamp) : null
+  const networkStatus = msFromLastBlock !== null && msFromLastBlock / 1000 / 60 < 15
+  const apiStatus = checkApiStatus(status)
 
   const fetchData = useCallback(() => {
     Api.getStatus()
@@ -21,13 +35,6 @@ function NetworkStatus ({ className }) {
   }, [])
 
   useEffect(fetchData, [fetchData])
-
-  const lastBlockTimestamp = status?.data?.tenderdash?.block?.timestamp
-  const msFromLastBlock = lastBlockTimestamp ? new Date() - new Date(lastBlockTimestamp) : null
-  const networkStatus = msFromLastBlock !== null && msFromLastBlock / 1000 / 60 < 15
-  const apiStatus = typeof status?.data?.tenderdash?.block?.timestamp === 'string' &&
-    new Date(status?.data?.api?.block?.timestamp).getTime() ===
-    new Date(status?.data?.tenderdash?.block?.timestamp).getTime()
 
   const NetworkStatusIcon = networkStatus
     ? <CheckCircleIcon mr={2}/>


### PR DESCRIPTION
# Issue
Sometimes the API status in the BetworkStatus block is displayed as "disrupted", while the API is working correctly. This is probably due to the fact that there is a slight delay in updating data in the API, it needs to be taken into account in the status condition.

# Things done
Updated condition of API status. Now the difference between timestamps is checked instead of an exact match.