### PR TITLE
Identity page hotfixes

### DIFF
--- a/packages/frontend/src/app/identity/[identifier]/Identity.js
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.js
@@ -204,7 +204,6 @@ function Identity ({ identifier }) {
               {!transfers.error
                 ? <TransfersList
                     transfers={transfers.data.resultSet}
-                    identityId={identity.data?.identifier}
                     pagination={{
                       onPageChange: pagination => paginationHandler(setTransfers, pagination.selected),
                       pageCount: Math.ceil(transfers.data?.pagination?.total / pageSize) || 1,

--- a/packages/frontend/src/components/publicKeys/PublicKeysListItem.js
+++ b/packages/frontend/src/components/publicKeys/PublicKeysListItem.js
@@ -52,7 +52,7 @@ function PublicKeysListItem ({ publicKey, className }) {
         </GridItem>
         <GridItem className={'PublicKeysListItem__Column PublicKeysListItem__Column--ReadOnly'}>
           {publicKey?.readOnly !== undefined
-            ? <ValueContainer colorScheme={publicKey?.readOnly ? 'green' : 'red'} size={'sm'}>
+            ? <ValueContainer colorScheme={publicKey?.readOnly ? 'red' : 'green'} size={'sm'}>
                 {publicKey?.readOnly ? 'True' : 'False'}
               </ValueContainer>
             : <span className={'PublicKeysListItem__NotActiveText'}>n/a</span>

--- a/packages/frontend/src/components/publicKeys/PublicKeysListItem.js
+++ b/packages/frontend/src/components/publicKeys/PublicKeysListItem.js
@@ -21,7 +21,8 @@ function PublicKeysListItem ({ publicKey, className }) {
           {publicKey?.hash !== undefined
             ? <ValueCard className={'PublicKeysListItem__PublicKeyHash'} size={'sm'} colorScheme={'transparent'}>
                 {publicKey?.hash}
-              </ValueCard>
+                <CopyButton text={publicKey?.hash}/>
+            </ValueCard>
             : <span className={'PublicKeysListItem__NotActiveText'}>n/a</span>
           }
         </GridItem>

--- a/packages/frontend/src/components/publicKeys/PublicKeysListItem.scss
+++ b/packages/frontend/src/components/publicKeys/PublicKeysListItem.scss
@@ -29,7 +29,6 @@
       align-items: flex-start;
       overflow: hidden;
       display: flex;
-      flex-direction: column;
       gap: 4px;
     }
 
@@ -42,18 +41,12 @@
     }
   }
 
-  &__PublicKeyHash {
-    display: block;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  &__Data {
+  &__Data, &__PublicKeyHash {
     display: flex;
     justify-content: space-between;
     align-items: center;
     word-break: break-all;
+    white-space: break-spaces;
     min-width: 100px;
     width: 100%;
 

--- a/packages/frontend/src/components/publicKeys/_variables.scss
+++ b/packages/frontend/src/components/publicKeys/_variables.scss
@@ -6,7 +6,7 @@
 
   grid-template-columns: 
     minmax(50px, 50px)
-    minmax(122px, 122px)
+    minmax(180px, 180px)
     minmax(133px, 113px)
     minmax(113px, 113px)
     minmax(115px, 115px)
@@ -28,7 +28,7 @@
   }
 
   &--PublicKeyHash {
-    max-width: 122px;
+    max-width: 180px;
     width: 100%;
   }
 

--- a/packages/frontend/src/components/transactions/TypeBadge.js
+++ b/packages/frontend/src/components/transactions/TypeBadge.js
@@ -1,34 +1,22 @@
 import { Badge } from '@chakra-ui/react'
 import { getTransitionTypeKeyById } from '../../util/index'
-import { TransactionTypesEnum, TransactionTypesColors } from '../../enums/state.transition.type'
+import { TransactionTypesInfo } from '../../enums/state.transition.type'
 import { Tooltip } from '../ui/Tooltips'
 
 function TypeBadge ({ typeId, type, ...props }) {
   const TransitionTypeKey = typeof typeId === 'number' ? getTransitionTypeKeyById(typeId) : type
 
-  const descriptions = {
-    DATA_CONTRACT_CREATE: 'Creates a new data contract. This contract defines the schema for storing data on the platform.',
-    DATA_CONTRACT_UPDATE: 'Updates an existing data contract. Increments the version and updates the schema of the data contract',
-    DOCUMENTS_BATCH: 'Creates a new document transitions. It is used to make create, modify, delete other document actions on the platform.',
-    IDENTITY_CREATE: 'Creates a new decentralized identity (DID) to manage digital assets and make actions.',
-    IDENTITY_TOP_UP: 'Adds credits to an existing decentralized identity (DID) balance.',
-    IDENTITY_UPDATE: 'Updates an identity by adding and removing associated public keys.',
-    IDENTITY_CREDIT_WITHDRAWAL: 'Withdraws credits from the platform, converting them into Dash.',
-    IDENTITY_CREDIT_TRANSFER: 'Transfers credits between identities or other network participants.',
-    MASTERNODE_VOTE: 'Vote for a contested resource on the Dash Platform'
-  }
-
   return (
     <Tooltip
-      title={TransactionTypesEnum[TransitionTypeKey]}
-      content={descriptions[TransitionTypeKey]}
+      title={TransactionTypesInfo?.[TransitionTypeKey]?.title}
+      content={TransactionTypesInfo?.[TransitionTypeKey]?.description}
       placement={'top'}
     >
       <Badge
-        colorScheme={TransactionTypesColors[TransitionTypeKey]}
+        colorScheme={TransactionTypesInfo?.[TransitionTypeKey]?.colorScheme}
         {...props}
       >
-        {TransactionTypesEnum[TransitionTypeKey]}
+        {TransactionTypesInfo?.[TransitionTypeKey]?.title}
       </Badge>
     </Tooltip>
   )

--- a/packages/frontend/src/components/transfers/TransfersList.js
+++ b/packages/frontend/src/components/transfers/TransfersList.js
@@ -6,7 +6,7 @@ import Pagination from '../pagination'
 import { ErrorMessageBlock } from '../Errors'
 import './TransfersList.scss'
 
-function TransfersList ({ transfers = [], identityId, pagination, headerStyles, loading, itemsCount = 10 }) {
+function TransfersList ({ transfers = [], pagination, headerStyles, loading, itemsCount = 10 }) {
   const headerExtraClass = {
     default: '',
     light: 'BlocksList__ColumnTitles--Light'
@@ -42,7 +42,6 @@ function TransfersList ({ transfers = [], identityId, pagination, headerStyles, 
                 <TransfersListItem
                   key={key}
                   transfer={transfer}
-                  identityId={identityId}
                 />
               )}
               {transfers?.length === 0 &&

--- a/packages/frontend/src/components/transfers/TransfersListItem.js
+++ b/packages/frontend/src/components/transfers/TransfersListItem.js
@@ -13,14 +13,10 @@ import './TransfersListItem.scss'
 
 const mobileWidth = 580
 
-function TransfersListItem ({ transfer, identityId, rate }) {
+function TransfersListItem ({ transfer, rate }) {
   const containerRef = useRef(null)
   const [isMobile, setIsMobile] = useState(false)
   const clickable = isMobile && transfer?.hash
-
-  const transferType = transfer.recipient === identityId
-    ? transfer.sender ? 'CREDIT_TRANSFER' : 'TOP_UP'
-    : transfer.recipient ? 'CREDIT_TRANSFER' : 'CREDIT_WITHDRAWAL'
 
   useResizeObserver(containerRef, () => {
     const { offsetWidth } = containerRef.current
@@ -105,7 +101,7 @@ function TransfersListItem ({ transfer, identityId, rate }) {
           </GridItem>
 
           <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Type'}>
-            <TypeBadge type={transferType}/>
+            <TypeBadge type={transfer.type}/>
           </GridItem>
         </Grid>
       </Wrapper>

--- a/packages/frontend/src/components/transfers/TransfersListItem.js
+++ b/packages/frontend/src/components/transfers/TransfersListItem.js
@@ -1,47 +1,31 @@
 'use client'
 
 import { Grid, GridItem } from '@chakra-ui/react'
-import { ValueContainer, LinkContainer } from '../ui/containers'
+import { LinkContainer } from '../ui/containers'
 import { Credits, Identifier } from '../data'
 import { RateTooltip } from '../ui/Tooltips'
 import Link from 'next/link'
-import { forwardRef, useRef, useState } from 'react'
-import useResizeObserver from '@react-hook/resize-observer'
+import { useRef } from 'react'
 import { getTimeDelta } from '../../util'
 import TypeBadge from './TypeBadge'
+import { useRouter } from 'next/navigation'
 import './TransfersListItem.scss'
-
-const mobileWidth = 580
 
 function TransfersListItem ({ transfer, rate }) {
   const containerRef = useRef(null)
-  const [isMobile, setIsMobile] = useState(false)
-  const clickable = isMobile && transfer?.hash
-
-  useResizeObserver(containerRef, () => {
-    const { offsetWidth } = containerRef.current
-    setIsMobile(offsetWidth <= mobileWidth)
-  })
-
-  const Wrapper = forwardRef(function Wrapper (props, ref) {
-    return clickable
-      ? <Link ref={ref} href={`/transaction/${transfer?.txHash}`} className={props.className}>{props.children}</Link>
-      : <div ref={ref} className={props.className}>{props.children}</div>
-  })
-
-  const ItemWrapper = ({ isLocal, children, ...props }) => {
-    return clickable
-      ? <div {...props}>{children}</div>
-      : isLocal
-        ? <Link {...props}>{children}</Link>
-        : <a {...props}>{children}</a>
-  }
+  const router = useRouter()
 
   const Recipient = () => {
     if (!transfer?.recipient) return <span className={'TransactionsListItem__NotActiveText'}>-</span>
 
     return (
-      <LinkContainer href={`/identity/${transfer?.recipient}`}>
+      <LinkContainer
+        onClick={e => {
+          e.stopPropagation()
+          e.preventDefault()
+          router.push(`/identity/${transfer?.recipient}`)
+        }}
+      >
         <Identifier
           avatar={true}
           styles={['highlight-both']}
@@ -54,58 +38,53 @@ function TransfersListItem ({ transfer, rate }) {
   }
 
   return (
-    <div ref={containerRef} className={`TransfersListItem ${clickable ? 'TransfersListItem--Clickable' : ''}`}>
-      <Wrapper className={'TransfersListItem__ContentWrapper'}>
-        <Grid className={'TransfersListItem__Content'}>
-          <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Timestamp'}>
-            {transfer?.timestamp
-              ? <span>{getTimeDelta(new Date(), new Date(transfer.timestamp))}</span>
-              : <span className={'TransactionsListItem__NotActiveText'}>n/a</span>
-            }
-          </GridItem>
+    <Link
+      href={`/transaction/${transfer?.txHash}`}
+      ref={containerRef}
+      className={'TransfersListItem TransfersListItem--Clickable'}
+    >
+      <Grid className={'TransfersListItem__Content'}>
+        <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Timestamp'}>
+          {transfer?.timestamp
+            ? <span>{getTimeDelta(new Date(), new Date(transfer.timestamp))}</span>
+            : <span className={'TransactionsListItem__NotActiveText'}>n/a</span>
+          }
+        </GridItem>
 
-          <GridItem className={'TransfersListItem__Column TransfersListItem__Column--TxHash'}>
-            {transfer?.txHash
-              ? <ItemWrapper
-                  className={'TransfersListItem__ColumnContent'} isLocal={true}
-                  href={'/transaction/' + transfer.txHash}
-                >
-                <ValueContainer className={''} light={true} clickable={true} size={'xxs'}>
-                  <Identifier styles={['highlight-both']}>{transfer.txHash}</Identifier>
-                </ValueContainer>
-              </ItemWrapper>
-              : <span className={'TransactionsListItem__NotActiveText'}>n/a</span>
-            }
-          </GridItem>
+        <GridItem className={'TransfersListItem__Column TransfersListItem__Column--TxHash'}>
+          {transfer?.txHash
+            ? <Identifier styles={['highlight-both']}>{transfer.txHash}</Identifier>
+            : <span className={'TransactionsListItem__NotActiveText'}>n/a</span>
+          }
+        </GridItem>
 
-          <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Recipient'}>
-            <Recipient/>
-          </GridItem>
+        <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Recipient'}>
+          <Recipient/>
+        </GridItem>
 
-          <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Amount'}>
-            {transfer?.amount
-              ? <RateTooltip credits={transfer.amount} rate={rate}>
-                  <span><Credits>{transfer.amount}</Credits></span>
-                </RateTooltip>
-              : <span className={'TransactionsListItem__NotActiveText'}>-</span>
-            }
-          </GridItem>
+        <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Amount'}>
+          {transfer?.amount
+            ? <RateTooltip credits={transfer.amount} rate={rate}>
+                <span><Credits>{transfer.amount}</Credits></span>
+              </RateTooltip>
+            : <span className={'TransactionsListItem__NotActiveText'}>-</span>
+          }
+        </GridItem>
 
-          <GridItem className={'TransfersListItem__Column TransfersListItem__Column--GasUsed'}>
-            {transfer?.gasUsed
-              ? <RateTooltip credits={transfer.gasUsed} rate={rate}>
-                  <span><Credits>{transfer.gasUsed}</Credits></span>
-                </RateTooltip>
-              : <span className={'TransactionsListItem__NotActiveText'}>-</span>
-            }
-          </GridItem>
+        <GridItem className={'TransfersListItem__Column TransfersListItem__Column--GasUsed'}>
+          {transfer?.gasUsed
+            ? <RateTooltip credits={transfer.gasUsed} rate={rate}>
+                <span><Credits>{transfer.gasUsed}</Credits></span>
+              </RateTooltip>
+            : <span className={'TransactionsListItem__NotActiveText'}>-</span>
+          }
+        </GridItem>
 
-          <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Type'}>
-            <TypeBadge type={transfer.type}/>
-          </GridItem>
-        </Grid>
-      </Wrapper>
-    </div>
+        <GridItem className={'TransfersListItem__Column TransfersListItem__Column--Type'}>
+          <TypeBadge type={transfer.type}/>
+        </GridItem>
+      </Grid>
+    </Link>
   )
 }
 

--- a/packages/frontend/src/components/transfers/TypeBadge.js
+++ b/packages/frontend/src/components/transfers/TypeBadge.js
@@ -1,39 +1,28 @@
 import { Badge } from '@chakra-ui/react'
-import { TransactionTypesEnum, TransactionTypesColors } from '../../enums/state.transition.type'
+import { TransactionTypesInfo } from '../../enums/state.transition.type'
 import { Tooltip } from '../ui/Tooltips'
+import { getTransitionTypeKeyById } from '../../util'
 
 function TypeBadge ({ type, ...props }) {
+  const transitionType = getTransitionTypeKeyById(type)
   const TransferTypesTitle = {
-    TOP_UP: 'Credit Top Up',
-    CREDIT_WITHDRAWAL: 'Credit Withdrawal',
-    CREDIT_TRANSFER: 'Credit Transfer'
-  }
-
-  const TransferTransitionTypes = {
-    TOP_UP: 'IDENTITY_TOP_UP',
-    CREDIT_WITHDRAWAL: 'IDENTITY_CREDIT_WITHDRAWAL',
-    CREDIT_TRANSFER: 'IDENTITY_CREDIT_TRANSFER'
-  }
-
-  const transitionType = TransferTransitionTypes[type]
-
-  const descriptions = {
-    TOP_UP: 'Adds credits to an existing decentralized identity (DID) balance.',
-    CREDIT_WITHDRAWAL: 'Withdraws credits from the platform, converting them into Dash.',
-    CREDIT_TRANSFER: 'Transfers credits between identities or other network participants.'
+    IDENTITY_TOP_UP: 'Credit Top Up',
+    IDENTITY_CREDIT_WITHDRAWAL: 'Credit Withdrawal',
+    IDENTITY_CREATE: 'Identity create',
+    IDENTITY_CREDIT_TRANSFER: 'Credit Transfer'
   }
 
   return (
     <Tooltip
-      title={TransactionTypesEnum[transitionType]}
-      content={descriptions[type]}
+      title={TransferTypesTitle[transitionType]}
+      content={TransactionTypesInfo?.[transitionType]?.description}
       placement={'top'}
     >
       <Badge
-        colorScheme={TransactionTypesColors[transitionType]}
+        colorScheme={TransactionTypesInfo?.[transitionType]?.colorScheme}
         {...props}
       >
-        {TransferTypesTitle[type]}
+        {TransferTypesTitle[transitionType]}
       </Badge>
     </Tooltip>
   )

--- a/packages/frontend/src/enums/state.transition.type.js
+++ b/packages/frontend/src/enums/state.transition.type.js
@@ -10,26 +10,50 @@ export const StateTransitionEnum = {
   MASTERNODE_VOTE: 8
 }
 
-export const TransactionTypesEnum = {
-  DATA_CONTRACT_CREATE: 'Data Contract Create',
-  DOCUMENTS_BATCH: 'Documents Batch',
-  IDENTITY_CREATE: 'Identity Create',
-  IDENTITY_TOP_UP: 'Identity Top Up',
-  DATA_CONTRACT_UPDATE: 'Data Contract Update',
-  IDENTITY_UPDATE: 'Identity Update',
-  IDENTITY_CREDIT_WITHDRAWAL: 'Credit Withdrawal',
-  IDENTITY_CREDIT_TRANSFER: 'Credit Transfer',
-  MASTERNODE_VOTE: 'Masternode Vote'
-}
-
-export const TransactionTypesColors = {
-  DATA_CONTRACT_CREATE: 'blue',
-  DATA_CONTRACT_UPDATE: 'yellow',
-  DOCUMENTS_BATCH: 'gray',
-  IDENTITY_CREATE: 'blue',
-  IDENTITY_TOP_UP: 'emerald',
-  IDENTITY_UPDATE: 'yellow',
-  IDENTITY_CREDIT_WITHDRAWAL: 'red',
-  IDENTITY_CREDIT_TRANSFER: 'orange',
-  MASTERNODE_VOTE: 'orange'
+export const TransactionTypesInfo = {
+  DATA_CONTRACT_CREATE: {
+    title: 'Data Contract Create',
+    description: 'Creates a new data contract. This contract defines the schema for storing data on the platform.',
+    colorScheme: 'blue'
+  },
+  DOCUMENTS_BATCH: {
+    title: 'Documents Batch',
+    description: 'Creates a new document transitions. It is used to make create, modify, delete other document actions on the platform.',
+    colorScheme: 'gray'
+  },
+  IDENTITY_CREATE: {
+    title: 'Identity Create',
+    description: 'Creates a new decentralized identity (DID) to manage digital assets and make actions.',
+    colorScheme: 'blue'
+  },
+  IDENTITY_TOP_UP: {
+    title: 'Identity Top Up',
+    description: 'Adds credits to an existing decentralized identity (DID) balance.',
+    colorScheme: 'emerald'
+  },
+  DATA_CONTRACT_UPDATE: {
+    title: 'Data Contract Update',
+    description: 'Updates an existing data contract. Increments the version and updates the schema of the data contract',
+    colorScheme: 'yellow'
+  },
+  IDENTITY_UPDATE: {
+    title: 'Identity Update',
+    description: 'Updates an identity by adding and removing associated public keys.',
+    colorScheme: 'yellow'
+  },
+  IDENTITY_CREDIT_WITHDRAWAL: {
+    title: 'Credit Withdrawal',
+    description: 'Withdraws credits from the platform, converting them into Dash.',
+    colorScheme: 'red'
+  },
+  IDENTITY_CREDIT_TRANSFER: {
+    title: 'Credit Transfer',
+    description: 'Transfers credits between identities or other network participants.',
+    colorScheme: 'orange'
+  },
+  MASTERNODE_VOTE: {
+    title: 'Masternode Vote',
+    description: 'Vote for a contested resource on the Dash Platform',
+    colorScheme: 'orange'
+  }
 }

--- a/packages/frontend/src/util/index.js
+++ b/packages/frontend/src/util/index.js
@@ -1,15 +1,7 @@
 import copyToClipboard from './copyToClipboard'
-import { StateTransitionEnum, TransactionTypesEnum } from '../enums/state.transition.type'
+import { StateTransitionEnum } from '../enums/state.transition.type'
 import currencyRound from './currencyRound'
 import { getDaysBetweenDates, getDynamicRange, getTimeDelta } from './datetime'
-
-function getTransitionTypeStringById (id) {
-  const [stateTransitionType] = Object.entries(StateTransitionEnum)
-    .filter(([key]) => StateTransitionEnum[key] === id)
-    .map(([key]) => key)
-
-  return TransactionTypesEnum[stateTransitionType] ?? 'UNKNOWN'
-}
 
 function getTransitionTypeKeyById (id) {
   const [stateTransitionType] = Object.entries(StateTransitionEnum)
@@ -89,7 +81,6 @@ function findActiveAlias (aliases = []) {
 }
 
 export {
-  getTransitionTypeStringById,
   fetchHandlerSuccess,
   fetchHandlerError,
   paginationHandler,


### PR DESCRIPTION
# Issue
After merging the identity page update, the following issues were identified:
- The badge type for transfers is displayed incorrectly in case of identity create
- The Public key hash cannot be viewed in full
- It would be more convenient to make the transfer list items fully clickable
- It will be more convenient if we change the colors of the read only badge to true - red, and false - green

# Things done
- Updated transfer TypeBadge titles
- Optimized transaction type enums
- Updated styles of hash in public key list
- TransfersListItem made fully clickable
- Colors of the read only badge changed