### PR TITLE
Update Identifiers styles on the specific Validator page

### DIFF
--- a/packages/frontend/src/app/validator/[hash]/ValidatorPage.scss
+++ b/packages/frontend/src/app/validator/[hash]/ValidatorPage.scss
@@ -94,7 +94,7 @@
 
     .InfoLine--Loading .InfoLine {
       &__Value {
-        height: 32px;
+        height: 28px;
       }
     }
   }

--- a/packages/frontend/src/components/validators/ValidatorCard.js
+++ b/packages/frontend/src/components/validators/ValidatorCard.js
@@ -1,8 +1,8 @@
-import './ValidatorCard.scss'
 import { Identifier, InfoLine, CreditsBlock } from '../data'
 import ImageGenerator from '../imageGenerator'
 import { HorisontalSeparator } from '../ui/separators'
 import Link from 'next/link'
+import './ValidatorCard.scss'
 
 export default function ValidatorCard ({ validator, rate, className }) {
   return (
@@ -54,62 +54,65 @@ export default function ValidatorCard ({ validator, rate, className }) {
 
       <HorisontalSeparator className={'ValidatorCard__Separator'}/>
 
-      {/* Will be activated later /*}
+      <div className={'ValidatorCard__CommonInfo'}>
 
-      {/* <InfoLine
-        className={'ValidatorCard__InfoLine'}
-        title={'Creation Date'}
-        value={<DateBlock timestamp={1727887511000}/>}
-        loading={validator.loading}
-        error={validator.error}
-      /> */}
+        {/* Will be activated later /*}
 
-      {/* <InfoLine
-        className={'ValidatorCard__InfoLine'}
-        title={'Block Height'}
-        value={(
-          <span className={'ValidatorCard__BlockHeighValue'}>#10225</span>
-        )}
-        loading={validator.loading}
-        error={validator.error}
-      /> */}
+        {/* <InfoLine
+          className={'ValidatorCard__InfoLine'}
+          title={'Creation Date'}
+          value={<DateBlock timestamp={1727887511000}/>}
+          loading={validator.loading}
+          error={validator.error}
+        /> */}
 
-      <InfoLine
-        className={'ValidatorCard__InfoLine'}
-        title={'Identity Address'}
-        value={(
-          <Link href={`/identity/${validator.data?.identity}`}>
+        {/* <InfoLine
+          className={'ValidatorCard__InfoLine'}
+          title={'Block Height'}
+          value={(
+            <span className={'ValidatorCard__BlockHeighValue'}>#10225</span>
+          )}
+          loading={validator.loading}
+          error={validator.error}
+        /> */}
+
+        <InfoLine
+          className={'ValidatorCard__InfoLine ValidatorCard__InfoLine--IdentityAddress'}
+          title={'Identity Address'}
+          value={(
+            <Link href={`/identity/${validator.data?.identity}`}>
+              <Identifier
+                className={''}
+                copyButton={true}
+                styles={['highlight-both']}
+                ellipsis={false}
+                clickable={true}
+              >
+                {validator.data?.identity}
+              </Identifier>
+            </Link>
+          )}
+          loading={validator.loading}
+          error={validator.error}
+        />
+
+        <InfoLine
+          className={'ValidatorCard__InfoLine  ValidatorCard__InfoLine--NodeId'}
+          title={'Node ID'}
+          value={(
             <Identifier
               className={''}
               copyButton={true}
               styles={['highlight-both']}
               ellipsis={false}
-              clickable={true}
             >
-              {validator.data?.identity}
+              {validator.data?.proTxInfo?.state?.platformNodeID}
             </Identifier>
-          </Link>
-        )}
-        loading={validator.loading}
-        error={validator.error}
-      />
-
-      <InfoLine
-        className={'ValidatorCard__InfoLine'}
-        title={'Node ID'}
-        value={(
-          <Identifier
-            className={''}
-            copyButton={true}
-            styles={['highlight-both']}
-            ellipsis={false}
-          >
-            {validator.data?.proTxInfo?.state?.platformNodeID}
-          </Identifier>
-        )}
-        loading={validator.loading}
-        error={validator.error}
-      />
+          )}
+          loading={validator.loading}
+          error={validator.error}
+        />
+      </div>
     </div>
   )
 }

--- a/packages/frontend/src/components/validators/ValidatorCard.scss
+++ b/packages/frontend/src/components/validators/ValidatorCard.scss
@@ -10,9 +10,49 @@
     align-items: center;
   }
 
+  &__CommonInfo {
+    display: flex;
+    flex-direction: column;
+    gap: 14px;
+  }
+
+  &__InfoLine {
+    &--IdentityAddress, &--NodeId {
+      .InfoLine__Value {
+        width: 100%;
+      }
+
+      .Identifier {
+        container-type: inline-size;
+        width: 100%;
+        justify-content: flex-end;
+      }
+    }
+
+    &--IdentityAddress {
+      .Identifier__SymbolsContainer {
+        @container (max-width: 22rem) {
+          max-width: 10rem;
+        }
+
+        @container (max-width: 11.5rem) {
+          max-width: 7rem;
+        }
+      }
+    }
+
+    &--NodeId {
+      .Identifier__SymbolsContainer {
+        @container (max-width: 20rem) {
+          max-width: 9.2rem;
+        }
+      }
+    }
+  }
+
   .InfoLine--Loading .InfoLine {
     &__Value {
-      height: 30px;
+      height: 26px !important;
     }
   }
 
@@ -71,6 +111,34 @@
   @media screen and (max-width: $breakpoint-md) {
     &__ProTxHash {
       padding-right: 100px;
+    }
+  }
+
+  @media screen and (max-width: $breakpoint-sm) {
+    &__CommonInfo {
+      .InfoLine {
+        flex-wrap: wrap;
+        justify-content: start;
+      }
+
+      .InfoLine--Loading .InfoLine {
+        &__Value {
+          min-width: 40px;
+          width: 100% !important;
+        }
+      }
+    }
+
+    &__InfoLine {
+      &--IdentityAddress, &--NodeId {
+        .Identifier {
+          justify-content: flex-start;
+        }
+      }
+
+      .InfoLine__Title {
+        margin-right: auto;
+      }
     }
   }
 }


### PR DESCRIPTION
# Issue
On some resolutions, identifiers look ugly due to text wrapping:
<img width="517" alt="Снимок экрана 2024-12-26 в 17 27 47" src="https://github.com/user-attachments/assets/add53c8a-f983-4c0c-8885-b2a76619784f" />

# Things done
- Updated responsive styles of identifiers to prevent ugly wrapping
- Updated size of loading lines on Validator page еo better match the height of the content