### PR TITLE
Entropy field for Documents batch 

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1447,6 +1447,7 @@ POST /transaction/decode
             "type": "domain",
             "action": 0,
             "data": {
+                "entropy": "f09a3ceacaa2f12b9879ba223d5b8c66c3106efe58edc511556f31ee9676412b",
                 "label": "Microsoft",
                 "normalizedLabel": "m1cr0s0ft",
                 "normalizedParentDomainName": "dash",

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -78,6 +78,8 @@ const decodeStateTransition = async (client, base64) => {
           case DocumentActionEnum.Create: {
             const prefundedBalance = documentTransition.getPrefundedVotingBalance()
 
+            out.entropy = Buffer.from(documentTransition.getEntropy()).toString('hex')
+
             out.data = documentTransition.getData()
             out.prefundedBalance = prefundedBalance
               ? Object.fromEntries(
@@ -91,7 +93,12 @@ const decodeStateTransition = async (client, base64) => {
           case DocumentActionEnum.Replace: {
             out.data = documentTransition.getData()
 
+            out.entropy = Buffer.from(documentTransition.getEntropy()).toString('hex')
+
             break
+          }
+          case DocumentActionEnum.Delete: {
+            out.entropy = Buffer.from(documentTransition.getEntropy()).toString('hex')
           }
         }
 

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -83,6 +83,7 @@ describe('Utils', () => {
             prefundedBalance: null,
             type: 'note',
             action: 0,
+            entropy: 'f09a3ceacaa2f12b9879ba223d5b8c66c3106efe58edc511556f31ee9676412b',
             data: {
               message: 'Tutorial CI Test @ Thu, 08 Aug 2024 20:25:03 GMT'
             }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -747,7 +747,7 @@ Return identity by given identifier
 GET /identity/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
 
 {
-  "identifier": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+  "identifier": "3igSMtXaaS9iRQHbWU1w4hHveKdxixwMpgmhLzjVhFZJ",
   "revision": 0,
   "balance": 49989647300,
   "timestamp": "2024-10-12T18:51:44.592Z",
@@ -1044,6 +1044,7 @@ Response codes:
 ### Transfers by Identity
 Return all transfers made by the given identity
 * `limit` cannot be more then 100
+* `type` cannot be less, then 0 and more then 8
 ```
 GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/transfers?hash=445E6F081DEE877867816AD3EF492E2C0BD1DDCCDC9C793B23DDDAF8AEA23118&page=1&limit=10&order=asc&type=6
 
@@ -1413,6 +1414,7 @@ POST /transaction/decode
             "type": "domain",
             "action": 0,
             "data": {
+                "entropy": "f09a3ceacaa2f12b9879ba223d5b8c66c3106efe58edc511556f31ee9676412b",
                 "label": "Microsoft",
                 "normalizedLabel": "m1cr0s0ft",
                 "normalizedParentDomainName": "dash",


### PR DESCRIPTION
# Issue
By design, we need to display entropy on Documents Batch Transitions

# Things done 
- Added new field in utils
- Updated test for new field
- Updated `README.md`
- With pshenmic we updated fork for [wasm-dpp](https://github.com/owl352/wasm-dpp)