### PR TITLE
Aliases status fix

### DIFF
--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -446,6 +446,7 @@ const buildIndexBuffer = (name) => {
 const getAliasStateByVote = (aliasInfo, alias, identifier) => {
   let status = null
 
+  
   if (!aliasInfo.contestedState) {
     return {
       alias,

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -446,7 +446,7 @@ const buildIndexBuffer = (name) => {
 const getAliasStateByVote = (aliasInfo, alias, identifier) => {
   let status = null
 
-  if (aliasInfo.contestedState === null) {
+  if (!aliasInfo.contestedState) {
     return {
       alias,
       status: 'ok',
@@ -458,12 +458,12 @@ const getAliasStateByVote = (aliasInfo, alias, identifier) => {
     Buffer.from(aliasInfo.contestedState?.finishedVoteInfo?.wonByIdentityId ?? '', 'base64')
   )
 
-  if (identifier !== bs58Identifier && bs58Identifier !== '') {
+  if (identifier === bs58Identifier) {
+    status = 'ok'
+  } else if (bs58Identifier !== '' || aliasInfo.contestedState?.finishedVoteInfo?.wonByIdentityId === '') {
     status = 'locked'
   } else if (aliasInfo.contestedState?.finishedVoteInfo?.wonByIdentityId === undefined) {
     status = 'pending'
-  } else {
-    status = 'ok'
   }
 
   return {

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -445,7 +445,6 @@ const buildIndexBuffer = (name) => {
 
 const getAliasStateByVote = (aliasInfo, alias, identifier) => {
   let status = null
-
   
   if (!aliasInfo.contestedState) {
     return {

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -445,7 +445,7 @@ const buildIndexBuffer = (name) => {
 
 const getAliasStateByVote = (aliasInfo, alias, identifier) => {
   let status = null
-  
+
   if (!aliasInfo.contestedState) {
     return {
       alias,

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -329,4 +329,141 @@ describe('Utils', () => {
       })
     })
   })
+  describe('getAliasStateByVote()', () => {
+    it('should return ok if our identifier equal to winner identifier', () => {
+      const mockVote = {
+        alias: 'pshenmic.dash',
+        contestedState: {
+          contendersList: [
+            {
+              identifier: 'n4ay5zy5fRyuqEYkMwlkmmIay6RP9mlhSjLeBK3puwM=',
+              voteCount: 16,
+              document: ''
+            }
+          ],
+          abstainVoteTally: 0,
+          lockVoteTally: 0,
+          finishedVoteInfo: {
+            finishedVoteOutcome: 0,
+            wonByIdentityId: 'n4ay5zy5fRyuqEYkMwlkmmIay6RP9mlhSjLeBK3puwM=',
+            finishedAtBlockHeight: 24407,
+            finishedAtCoreBlockHeight: 2158202,
+            finishedAtBlockTimeMs: 1729411671125,
+            finishedAtEpoch: 5
+          }
+        }
+      }
+
+      const info = utils.getAliasStateByVote(mockVote, mockVote.alias, 'BjixEUbqeUZK7BRdqtLgjzwFBovx4BRwS2iwhMriiYqp')
+
+      assert.deepEqual(info, {
+        alias: mockVote.alias,
+        status: 'ok',
+        contested: true
+      })
+    })
+
+    it('should return ok if we not contested', () => {
+      const mockVote = { contestedState: null }
+
+      const info = utils.getAliasStateByVote(mockVote, 'alias343', 'BjixEUbqeUZK7BRdqtLgjzwFBovx4BRwS2iwhMriiYqp')
+
+      assert.deepEqual(info, {
+        alias: 'alias343',
+        status: 'ok',
+        contested: false
+      })
+    })
+
+    it('should return pending if we don\'t have winner', () => {
+      const mockVote = {
+        alias: 'pshenmic.dash',
+        contestedState: {
+          contendersList: [
+            {
+              identifier: 'n4ay5zy5fRyuqEYkMwlkmmIay6RP9mlhSjLeBK3puwM=',
+              voteCount: 16,
+              document: ''
+            }
+          ],
+          abstainVoteTally: 0,
+          lockVoteTally: 0
+        }
+      }
+
+      const info = utils.getAliasStateByVote(mockVote, mockVote.alias, 'BjixEUbqeUZK7BRdqtLgjzwFBovx4BRwS2iwhMriiYqp')
+
+      assert.deepEqual(info, {
+        alias: mockVote.alias,
+        status: 'pending',
+        contested: true
+      })
+    })
+
+    it('should return locked if our identifier not equal to winner identifier', () => {
+      const mockVote = {
+        alias: 'pshenmic.dash',
+        contestedState: {
+          contendersList: [
+            {
+              identifier: 'n4ay5zy5fRyuqEYkMwlkmmIay6RP9mlhSjLeBK3puwM=',
+              voteCount: 16,
+              document: ''
+            }
+          ],
+          abstainVoteTally: 0,
+          lockVoteTally: 0,
+          finishedVoteInfo: {
+            finishedVoteOutcome: 0,
+            wonByIdentityId: 'n4ay5zy5fRyuqEYkMwlkmmIay6RP9mlhSjLeBK3puwM=',
+            finishedAtBlockHeight: 24407,
+            finishedAtCoreBlockHeight: 2158202,
+            finishedAtBlockTimeMs: 1729411671125,
+            finishedAtEpoch: 5
+          }
+        }
+      }
+
+      const info = utils.getAliasStateByVote(mockVote, mockVote.alias, 'AjixEUbqeUZK7BRdqtLgjzwFBovx4BRwS2iwhMriiYqp')
+
+      assert.deepEqual(info, {
+        alias: mockVote.alias,
+        status: 'locked',
+        contested: true
+      })
+    })
+
+    it('should return locked if winner identifier equal "" (empty string)', () => {
+      const mockVote = {
+        alias: 'pshenmic.dash',
+        contestedState: {
+          contendersList: [
+            {
+              identifier: 'n4ay5zy5fRyuqEYkMwlkmmIay6RP9mlhSjLeBK3puwM=',
+              voteCount: 16,
+              document: ''
+            }
+          ],
+          abstainVoteTally: 0,
+          lockVoteTally: 0,
+          finishedVoteInfo: {
+            finishedVoteOutcome: 0,
+            wonByIdentityId: '',
+            finishedAtBlockHeight: 24407,
+            finishedAtCoreBlockHeight: 2158202,
+            finishedAtBlockTimeMs: 1729411671125,
+            finishedAtEpoch: 5
+          }
+        }
+      }
+
+      const info = utils.getAliasStateByVote(mockVote, mockVote.alias, 'AjixEUbqeUZK7BRdqtLgjzwFBovx4BRwS2iwhMriiYqp')
+
+      assert.deepEqual(info, {
+        alias: mockVote.alias,
+        status: 'locked',
+        contested: true
+      })
+    })
+  })
 })


### PR DESCRIPTION
# Issue
After #392, we have new problems with `locked` status for some aliases. That not working, because we can have aliases, which locked for all and in this scenarios we getting status `ok`

# Things done
- Rewrited if-else conditions. 
- Writen new unit tests