### PR TITLE
Update description on Identities page

### DIFF
--- a/packages/frontend/src/app/identities/intro.md
+++ b/packages/frontend/src/app/identities/intro.md
@@ -1,6 +1,6 @@
-Identity in the [Dash Platform](/) is a unique digital representation of an entity within the network. This could be an individual, organization, or even another program acting within the blockchain ecosystem. Identities play a crucial role in enabling verifiable, enhancing security, and fostering trust within the decentralized environment.
+Identity in the [Dash Platform](/) is a unique digital representation of an entity within the network. This could be an individual, organization, or even another program acting within the blockchain ecosystem. Identities play a crucial role in enabling verification, enhancing security, and fostering trust within the decentralized environment.
 
 Each Identity contains several key pieces of information:
-- Balance: The amount of digital assets or tokens by the identity;
-- Identity ID: A unique identifier that distinguishes;
-- Associated [Transactions](/transactions), [Data Contracts](/dataContracts) and Documents.
+- Identity ID: A unique identifier that distinguishes this identity from all other identities;
+- Balance: The amount of digital assets or tokens owned by this identity;
+- Associated items: [Transactions](/transactions), [Data Contracts](/dataContracts) and Documents.


### PR DESCRIPTION
# Issue
A suggest was made in the chat to change the description on the /identities page
<img width="672" alt="image" src="https://github.com/user-attachments/assets/dc581563-dc2a-4e42-a60e-655211fe2dac" />

# Things done
Description updated