### PR TITLE
Quorums and DashcoreRPC code duplication fixes

### DIFF
--- a/packages/api/src/controllers/BlocksController.js
+++ b/packages/api/src/controllers/BlocksController.js
@@ -37,21 +37,22 @@ class BlocksController {
 
       const quorumsTypes = Object.keys(quorumsList)
 
-      const [quorumType] = quorumsTypes
-        .filter(type =>
-          quorumsList[type]
-            .some(quorum =>
-              Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()
-              )
+      const [quorumType] = quorumsTypes.filter(type =>
+        quorumsList[type]
+          .some(quorum =>
+            Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()
             )
-        )
+          )
+      )
 
-      const quorumInfo = quorumsList[quorumType]
-        .find(quorum => Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()))
+      if (quorumType) {
+        const quorumInfo = quorumsList[quorumType]
+          .find(quorum => Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()))
 
-      const quorumDetailedInfo = await DashCoreRPC.getQuorumInfo(lastCommit.quorum_hash, QuorumTypeEnum[quorumType])
+        const quorumDetailedInfo = await DashCoreRPC.getQuorumInfo(lastCommit.quorum_hash, QuorumTypeEnum[quorumType])
 
-      quorum = Quorum.fromObject({ ...quorumDetailedInfo, ...quorumInfo[lastCommit.quorum_hash.toLowerCase()] })
+        quorum = Quorum.fromObject({ ...quorumDetailedInfo, ...quorumInfo[lastCommit.quorum_hash.toLowerCase()] })
+      }
     }
 
     response.send(


### PR DESCRIPTION
# Issue
`dashcoreRpc.js` contains try-catch in every method and most methods catching the same type of error, as result, we getting a lot of duplicate lines. 
BlockController contains bug with block at height 1, we can't get quorums for this block and in previous PR's I'm forget to add null check for this block

# Things done
- For class `DashcoreRPC` was added new function `callMethod`, which allows to call any method by 2 arguments:
  - `method` - name of method, like `quorum`, `protx` and etc.
  - `args` - array of arguments for method.
  Also this function allows to call calback on error and return any data from this calback as response.
- Updated BlockController, now we returning `quorum: null` for block 1 and this logic allows to return null in anothers buggy situations (if they exists)