### PR TITLE
Fix scrollbar of public keys list

### DIFF
--- a/packages/frontend/src/components/publicKeys/PublicKeysList.scss
+++ b/packages/frontend/src/components/publicKeys/PublicKeysList.scss
@@ -4,7 +4,7 @@
 
 .PublicKeysList {
   @include mixins.BrandScroll();
-  overflow-x: scroll;
+  overflow-x: auto;
   container-type: inline-size;
 
   &__ScrollZone {


### PR DESCRIPTION
# Issue
The scrollbar in the PublicKeysList component is always visible, even at high resolutions where it is not needed:
![image](https://github.com/user-attachments/assets/dba919e9-bd12-40a5-b956-5e1b78bf0bf7)

# Things done
Now the scrollbar is only displayed when the area can be scrolled.