### PR TITLE
Remove trailing zeros

### DIFF
--- a/packages/frontend/src/components/data/CreditsBlock.js
+++ b/packages/frontend/src/components/data/CreditsBlock.js
@@ -1,6 +1,6 @@
 import './CreditsBlock.scss'
 import Credits from './Credits'
-import { roundUsd, creditsToDash } from '../../util'
+import { roundUsd, removeTrailingZeros, creditsToDash } from '../../util'
 
 export default function CreditsBlock ({ credits, rate }) {
   return (
@@ -8,7 +8,7 @@ export default function CreditsBlock ({ credits, rate }) {
       {typeof credits === 'number'
         ? <>
           <span className={'CreditsBlock__Credits'}><Credits>{credits}</Credits> CREDITS</span>
-            <span className={'CreditsBlock__Dash'}>({creditsToDash(Number(credits)).toFixed(8)} DASH)</span>
+            <span className={'CreditsBlock__Dash'}>({removeTrailingZeros(creditsToDash(Number(credits)).toFixed(8))} DASH)</span>
             {typeof rate?.data?.usd === 'number' &&
               <span className={'CreditsBlock__Usd'}>
                 ~{roundUsd(creditsToDash(Number(credits)) * rate?.data?.usd)}$

--- a/packages/frontend/src/components/ui/Tooltips/RateTooltip.js
+++ b/packages/frontend/src/components/ui/Tooltips/RateTooltip.js
@@ -10,7 +10,7 @@ export default function RateTooltip ({ credits, dash, usd, rate, children, place
     <Tooltip
       label={(
         <div className={'RateTooltip'}>
-          {typeof dash === 'number' && <div className={'RateTooltip__Dash'}>{removeTrailingZeros(Number(Number(dash).toFixed(8)), 8)} Dash</div>}
+          {typeof dash === 'number' && <div className={'RateTooltip__Dash'}>{removeTrailingZeros(Number(dash).toFixed(8))} Dash</div>}
           {typeof usd === 'number' && <div className={'RateTooltip__Usd'}>~{roundUsd(Number(usd))}$</div>}
         </div>
       )}

--- a/packages/frontend/src/components/ui/Tooltips/RateTooltip.js
+++ b/packages/frontend/src/components/ui/Tooltips/RateTooltip.js
@@ -1,5 +1,5 @@
 import Tooltip from './Tooltip'
-import { roundUsd, creditsToDash } from '../../../util'
+import { roundUsd, removeTrailingZeros, creditsToDash } from '../../../util'
 import './RateTooltip.scss'
 
 export default function RateTooltip ({ credits, dash, usd, rate, children, placement }) {
@@ -10,7 +10,7 @@ export default function RateTooltip ({ credits, dash, usd, rate, children, place
     <Tooltip
       label={(
         <div className={'RateTooltip'}>
-          {typeof dash === 'number' && <div className={'RateTooltip__Dash'}>{Number(dash).toFixed(8)} Dash</div>}
+          {typeof dash === 'number' && <div className={'RateTooltip__Dash'}>{removeTrailingZeros(Number(Number(dash).toFixed(8)), 8)} Dash</div>}
           {typeof usd === 'number' && <div className={'RateTooltip__Usd'}>~{roundUsd(Number(usd))}$</div>}
         </div>
       )}

--- a/packages/frontend/src/util/index.js
+++ b/packages/frontend/src/util/index.js
@@ -75,6 +75,14 @@ function roundUsd (usd, maxDecimals = 5) {
   return usd.toFixed(precision)
 }
 
+function removeTrailingZeros (value, maxDecimals = 8) {
+  if (typeof value !== 'number') value = Number(value)
+  if (isNaN(value)) return value
+
+  const fixedValue = value.toFixed(maxDecimals)
+  return parseFloat(fixedValue)
+}
+
 function findActiveAlias (aliases = []) {
   if (!aliases?.length) return null
   return aliases?.find(alias => alias.status === 'ok')
@@ -92,6 +100,7 @@ export {
   getTransitionTypeKeyById,
   creditsToDash,
   roundUsd,
+  removeTrailingZeros,
   getDaysBetweenDates,
   getDynamicRange,
   findActiveAlias


### PR DESCRIPTION
# Issue
Trailing zeros are displayed in the RateTooltip and CreditsBlock where they may not be displayed

# Things done
- Created removeTrailingZeros function
- Trailing zeros removed from dash value in RateTooltip
- Trailing zeros removed from dash value in CreditsBlock