### PR TITLE
Fix transaction breadcrumbs

### DIFF
--- a/packages/frontend/src/app/transaction/[hash]/TransactionPage.js
+++ b/packages/frontend/src/app/transaction/[hash]/TransactionPage.js
@@ -27,7 +27,7 @@ function Transaction ({ hash }) {
   useEffect(() => {
     setBreadcrumbs([
       { label: 'Home', path: '/' },
-      { label: 'Transactions', path: '/identities' },
+      { label: 'Transactions', path: '/transactions' },
       { label: hash }
     ])
   }, [setBreadcrumbs, hash])


### PR DESCRIPTION
# Issue
Link "transactions" in breadcrumbs on transaction page redirects to identities page

# Things done
Link fixed