### PR TITLE
Improve charts on the Validator page

### DIFF
--- a/packages/frontend/src/app/validator/[hash]/BlocksChart.js
+++ b/packages/frontend/src/app/validator/[hash]/BlocksChart.js
@@ -2,11 +2,9 @@ import * as Api from '../../../util/Api'
 import { useState, useEffect } from 'react'
 import { fetchHandlerSuccess, fetchHandlerError, getDaysBetweenDates } from '../../../util'
 import TabsChartBlock from '../../../components/charts/TabsChartBlock'
-import { defaultChartConfig } from '../../../components/charts/config'
 
-export default function BlocksChart ({ hash, isActive, loading }) {
+export default function BlocksChart ({ hash, isActive, loading, timespan, timespanChangeCallback }) {
   const [blocksHistory, setBlocksHistory] = useState({ data: {}, loading: true, error: false })
-  const [timespan, setTimespan] = useState(defaultChartConfig.timespan.values[defaultChartConfig.timespan.defaultIndex])
 
   useEffect(() => {
     const { start = null, end = null } = timespan?.range
@@ -22,7 +20,7 @@ export default function BlocksChart ({ hash, isActive, loading }) {
   return (
     <TabsChartBlock
       menuIsActive={isActive}
-      timespanChangeCallback={setTimespan}
+      timespanChangeCallback={timespanChangeCallback}
       timespan={timespan}
       data={blocksHistory.data?.resultSet?.map((item) => ({
         x: new Date(item.timestamp),

--- a/packages/frontend/src/app/validator/[hash]/RewardsChart.js
+++ b/packages/frontend/src/app/validator/[hash]/RewardsChart.js
@@ -2,11 +2,9 @@ import * as Api from '../../../util/Api'
 import { useState, useEffect } from 'react'
 import { fetchHandlerSuccess, fetchHandlerError, getDaysBetweenDates } from '../../../util'
 import TabsChartBlock from '../../../components/charts/TabsChartBlock'
-import { defaultChartConfig } from '../../../components/charts/config'
 
-export default function RewardsChart ({ hash, isActive, loading }) {
+export default function RewardsChart ({ hash, isActive, loading, timespan, timespanChangeCallback }) {
   const [rewardsHistory, setRewardsHistory] = useState({ data: {}, loading: true, error: false })
-  const [timespan, setTimespan] = useState(defaultChartConfig.timespan.values[defaultChartConfig.timespan.defaultIndex])
 
   useEffect(() => {
     const { start = null, end = null } = timespan?.range
@@ -22,7 +20,7 @@ export default function RewardsChart ({ hash, isActive, loading }) {
   return (
     <TabsChartBlock
       menuIsActive={isActive}
-      timespanChangeCallback={setTimespan}
+      timespanChangeCallback={timespanChangeCallback}
       timespan={timespan}
       data={rewardsHistory.data?.resultSet?.map((item) => ({
         x: new Date(item.timestamp),

--- a/packages/frontend/src/app/validator/[hash]/Validator.js
+++ b/packages/frontend/src/app/validator/[hash]/Validator.js
@@ -20,11 +20,12 @@ import { RateTooltip } from '../../../components/ui/Tooltips'
 import { networks } from '../../../constants/networks'
 import { WithdrawalsList } from '../../../components/transfers'
 import { useBreadcrumbs } from '../../../contexts/BreadcrumbsContext'
-import './ValidatorPage.scss'
+import { defaultChartConfig } from '../../../components/charts/config'
 import {
   Badge,
   Tabs, TabList, TabPanels, Tab, TabPanel
 } from '@chakra-ui/react'
+import './ValidatorPage.scss'
 
 function Validator ({ hash }) {
   const { setBreadcrumbs } = useBreadcrumbs()
@@ -39,6 +40,7 @@ function Validator ({ hash }) {
   const baseUrl = process.env.NEXT_PUBLIC_BASE_URL
   const activeNetwork = networks.find(network => network.explorerBaseUrl === baseUrl)
   const l1explorerBaseUrl = activeNetwork?.l1explorerBaseUrl || null
+  const [timespan, setTimespan] = useState(defaultChartConfig.timespan.values[defaultChartConfig.timespan.defaultIndex])
 
   useEffect(() => {
     setBreadcrumbs([
@@ -410,6 +412,8 @@ function Validator ({ hash }) {
                       hash={hash}
                       isActive={activeChartTab === 0}
                       loading={validator.loading}
+                      timespanChangeCallback={setTimespan}
+                      timespan={timespan}
                     />
                   </TabPanel>
                   <TabPanel className={'ValidatorPage__ChartTab'} position={'relative'}>
@@ -417,6 +421,8 @@ function Validator ({ hash }) {
                       hash={hash}
                       isActive={activeChartTab === 1}
                       loading={validator.loading}
+                      timespanChangeCallback={setTimespan}
+                      timespan={timespan}
                     />
                   </TabPanel>
               </TabPanels>

--- a/packages/frontend/src/components/charts/TabsChartBlock.js
+++ b/packages/frontend/src/components/charts/TabsChartBlock.js
@@ -51,10 +51,11 @@ export default function TabsChartBlock ({
         className={'TabsChartBlock__TimeframeSelector'}
         config={chartConfig}
         changeCallback={timespanChangeCallback}
+        forceTimespan={timespan}
         menuIsActive={menuIsActive}
         openStateCallback={setMenuIsOpen}
       />
-      <div className={`TabsChartBlock__ChartContiner ${menuIsOpen ? 'TabsChartBlock__ChartContiner--Hidden' : ''}`}>
+      <div className={`TabsChartBlock__ChartContainer ${menuIsOpen ? 'TabsChartBlock__ChartContainer--Hidden' : ''}`}>
         <LineChart
           data={data}
           dataLoading={loading}

--- a/packages/frontend/src/components/charts/TabsChartBlock.scss
+++ b/packages/frontend/src/components/charts/TabsChartBlock.scss
@@ -3,7 +3,7 @@
   height: 100%;
   transition: all .2s;
 
-  &__ChartContiner {
+  &__ChartContainer {
     height: 100%;
     visibility: visible;
     opacity: 1;

--- a/packages/frontend/src/components/charts/TimeframeMenu.js
+++ b/packages/frontend/src/components/charts/TimeframeMenu.js
@@ -1,12 +1,14 @@
-import { useState, forwardRef } from 'react'
+import { useState, forwardRef, useEffect } from 'react'
 import { Button } from '@chakra-ui/react'
 import { DateRangePicker } from '../calendar'
 import './TimeframeMenu.scss'
 
-const TimeframeMenu = forwardRef(function TimeframeMenu ({ config, changeCallback, className }, ref) {
+const TimeframeMenu = forwardRef(function TimeframeMenu ({ config, forceTimespan, changeCallback, className }, ref) {
   const [timespan, setTimespan] = useState(config.timespan.values[config.timespan.defaultIndex])
   const [selectedRange, setSelectedRange] = useState(null)
   const [calendarValue, setCalendarValue] = useState(null)
+
+  useEffect(() => setTimespan(forceTimespan), [forceTimespan])
 
   const changeHandler = (value) => {
     setTimespan(value)
@@ -55,7 +57,7 @@ const TimeframeMenu = forwardRef(function TimeframeMenu ({ config, changeCallbac
         <div className={'TimeframeMenu__Values'}>
           {config.timespan.values.map((iTimespan, i) => (
             <Button
-              className={`TimeframeMenu__ValueButton ${iTimespan.label === timespan.label ? 'TimeframeMenu__ValueButton--Active' : ''}`}
+              className={`TimeframeMenu__ValueButton ${iTimespan.label === timespan?.label ? 'TimeframeMenu__ValueButton--Active' : ''}`}
               onClick={() => {
                 changeHandler(iTimespan)
                 clearCalendarRange()

--- a/packages/frontend/src/components/charts/TimeframeSelector.js
+++ b/packages/frontend/src/components/charts/TimeframeSelector.js
@@ -10,10 +10,13 @@ export default function TimeframeSelector ({
   changeCallback,
   openStateCallback,
   menuRef,
+  forceTimespan,
   className
 }) {
   const [timespan, setTimespan] = useState(config.timespan.values[config.timespan.defaultIndex])
   const [menuIsOpen, setMenuIsOpen] = useState(false)
+
+  useEffect(() => setTimespan(forceTimespan), [forceTimespan])
 
   const changeHandler = (value) => {
     setTimespan(value)
@@ -36,13 +39,14 @@ export default function TimeframeSelector ({
         className={'TimeframeSelector__Menu'}
         config={config}
         changeCallback={changeHandler}
+        forceTimespan={timespan}
       />
       <Button
         className={`TimeframeSelector__Button ${menuIsOpen ? 'TimeframeSelector__Button--Active' : ''}`}
         onClick={() => setMenuIsOpen(state => !state)}
       >
         <CalendarIcon2 mr={'10px'}/>
-        {timespan.label}
+        {timespan?.label}
         <CloseIcon
           color={'gray.250'}
           style={{ transition: 'all .1s' }}

--- a/packages/frontend/src/components/charts/index.js
+++ b/packages/frontend/src/components/charts/index.js
@@ -428,10 +428,10 @@ const LineGraph = ({
                     </linearGradient>
                     <clipPath id={`clipPath-${uniqueComponentId}`}>
                         <rect
-                            x={marginLeft - 20}
-                            y={marginTop}
-                            width={width - (marginLeft - 20 + marginRight)}
-                            height={height - (marginTop + marginBottom)}
+                            x={Math.max(marginLeft - 20, 0)}
+                            y={Math.max(marginTop, 0)}
+                            width={Math.max(width - (marginLeft - 20 + marginRight), 0)}
+                            height={Math.max(height - (marginTop + marginBottom), 0)}
                         ></rect>
                     </clipPath>
                 </defs>


### PR DESCRIPTION
# Issue
Now on the validator page, the timespan of the charts is switched separately. It will be more convenient if the timespan is changed at once for two charts

# Things done
Created common timespan handler for charts on the validator page
