### PR TITLE
Update transactions chart format

### DIFF
--- a/packages/frontend/src/app/home/Home.js
+++ b/packages/frontend/src/app/home/Home.js
@@ -103,7 +103,7 @@ function Home () {
           mb={blockOffset}
         >
           <Container mb={0} p={0} maxW={blockMaxWidth}>
-            <TransactionsHistory height={'100%'} blockBorders={false}/>
+            <TransactionsHistory blockBorders={false}/>
           </Container>
 
           <Box flexShrink={'0'} w={blockOffset} h={blockOffset} />

--- a/packages/frontend/src/app/transactions/page.js
+++ b/packages/frontend/src/app/transactions/page.js
@@ -26,7 +26,7 @@ function TransactionsRoute ({ searchParams }) {
       <Intro
         title={'Transactions'}
         description={<Markdown>{introContent}</Markdown>}
-        block={<TransactionsHistory height={'400px'} blockBorders={false}/>}
+        block={<TransactionsHistory heightPx={400} blockBorders={false}/>}
       />
     </Container>
     <Transactions defaultPage={page} defaultPageSize={pageSize}/>

--- a/packages/frontend/src/components/charts/ChartBlock.scss
+++ b/packages/frontend/src/components/charts/ChartBlock.scss
@@ -50,7 +50,6 @@
     }
 
     .TimeframeMenu {
-      //padding: 36px 0 12px !important;
       padding-bottom: 12px !important;
     }
 
@@ -64,7 +63,6 @@
     }
 
     @container (max-width: 400px) {
-
       .TimeframeMenu__ValuesContainer {
         margin-top: 90px;
       }
@@ -80,12 +78,6 @@
           width: calc(100% - 24px);
         }
       }
-
-      .TimeframeMenu {
-        padding-top: 36px 0 12px !important;
-        //padding: 36px 0 12px !important;
-
-      }
     }
   }
 
@@ -97,7 +89,6 @@
   &__TimeframeButton {
     font-family: $font-heading;
     font-size: 12px;
-    margin-right: 10px;
     height: 27px !important;
     margin: 5px;
 

--- a/packages/frontend/src/components/charts/ChartBlock.scss
+++ b/packages/frontend/src/components/charts/ChartBlock.scss
@@ -36,6 +36,7 @@
     visibility: visible;
     opacity: 1;
     transition: all .2s;
+    transition-delay: .2s;
 
     &--Hidden {
       visibility: hidden;

--- a/packages/frontend/src/components/charts/ChartBlock.scss
+++ b/packages/frontend/src/components/charts/ChartBlock.scss
@@ -2,8 +2,22 @@
 @import '../../styles/variables.scss';
 
 .ChartBlock {
+  container-type: inline-size;
+  height: 100%;
   min-height: 300px;
   padding-bottom: 0 !important;
+  overflow: hidden;
+  transition: .1s;
+
+  .InfoBlock__Title, .TimeframeSelector__Button  {
+    position: relative;
+    z-index: 555;
+  }
+
+  &--MenuIsOpen {
+    padding-bottom: 24px !important;
+  }
+
 
   &__TimeframeTitle {
     margin: 5px 5px 5px 0;
@@ -15,6 +29,64 @@
     align-items: center;
     margin-left: auto;
     margin-top: -20px;
+  }
+
+  &__ChartContainer {
+    height: 100%;
+    visibility: visible;
+    opacity: 1;
+    transition: all .2s;
+
+    &--Hidden {
+      visibility: hidden;
+      opacity: 0;
+      transition-delay: 0s;
+    }
+  }
+
+  .TimeframeSelector {
+    &__Menu {
+      top: 0;
+    }
+
+    .TimeframeMenu {
+      //padding: 36px 0 12px !important;
+      padding-bottom: 12px !important;
+    }
+
+    .TimeframeMenu__ValuesContainer {
+      margin-top: 52px;
+    }
+
+    &__Button {
+      top: 12px;
+      right: 16px;
+    }
+
+    @container (max-width: 400px) {
+
+      .TimeframeMenu__ValuesContainer {
+        margin-top: 90px;
+      }
+
+      &__Button {
+        top: 50px;
+        z-index: 11;
+        width: 100px;
+        min-width: max-content;
+        transition: width .2s;
+
+        &--Active {
+          width: calc(100% - 24px);
+        }
+      }
+
+      .TimeframeMenu {
+        padding-top: 36px 0 12px !important;
+        //padding: 36px 0 12px !important;
+
+      }
+    }
   }
 
   &__TimeframeButtons {

--- a/packages/frontend/src/components/charts/LineChartBlock.js
+++ b/packages/frontend/src/components/charts/LineChartBlock.js
@@ -101,6 +101,7 @@ export default function LineChartBlock ({
                   timespan={timespan}
                   xAxis={xAxis}
                   yAxis={yAxis}
+                  chartIsHidden={menuIsOpen}
               />
               : <ErrorMessageBlock/>
           : <Container

--- a/packages/frontend/src/components/charts/LineChartBlock.js
+++ b/packages/frontend/src/components/charts/LineChartBlock.js
@@ -70,7 +70,8 @@ export default function LineChartBlock ({
         borderWidth={'1px'} borderRadius={'block'}
         direction={'column'}
         style={{
-          minHeight: menuIsOpen ? `${Math.max(selectorHeight, heightPx)}px` : `${heightPx}px`
+          height: menuIsOpen ? `${Math.max(selectorHeight, heightPx)}px` : `${heightPx}px`,
+          minHeight: '100%'
         }}
     >
       <Heading className={'InfoBlock__Title'} as={'h1'}>{title}</Heading>
@@ -101,7 +102,6 @@ export default function LineChartBlock ({
                   timespan={timespan}
                   xAxis={xAxis}
                   yAxis={yAxis}
-                  chartIsHidden={menuIsOpen}
               />
               : <ErrorMessageBlock/>
           : <Container

--- a/packages/frontend/src/components/charts/LineChartBlock.js
+++ b/packages/frontend/src/components/charts/LineChartBlock.js
@@ -5,7 +5,7 @@ import { LineChart, TimeframeSelector } from '../../components/charts/index.js'
 import { Container, Heading, Flex } from '@chakra-ui/react'
 import { WarningTwoIcon } from '@chakra-ui/icons'
 import './ChartBlock.scss'
-import useResizeObserver from "@react-hook/resize-observer";
+import useResizeObserver from '@react-hook/resize-observer'
 import { defaultChartConfig } from './config'
 
 function ErrorMessageBlock () {

--- a/packages/frontend/src/components/charts/TimeframeMenu.scss
+++ b/packages/frontend/src/components/charts/TimeframeMenu.scss
@@ -13,12 +13,12 @@
 
   &__Values {
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     justify-content: flex-end;
+    gap: 8px;
   }
 
   &__ValueButton {
-    margin-left: 10px;
     font-size: 0.75rem;
     height: 28px !important;
     padding: 3px 12px !important;
@@ -73,11 +73,9 @@
   @media screen and (max-width: 555px) {
     &__Values {
       flex-wrap: wrap;
-      margin-bottom: -8px;
     }
 
     &__ValueButton {
-      margin-bottom: 8px;
       font-size: 0.6rem !important;
       height: 24px !important;
     }

--- a/packages/frontend/src/components/charts/TimeframeSelector.js
+++ b/packages/frontend/src/components/charts/TimeframeSelector.js
@@ -46,8 +46,8 @@ export default function TimeframeSelector ({
         <CloseIcon
           color={'gray.250'}
           style={{ transition: 'all .1s' }}
-          ml={menuIsOpen ? '10px' : 0}
-          w={menuIsOpen ? '8px' : 0}
+          ml={menuIsOpen ? '10px' : '0px'}
+          w={menuIsOpen ? '8px' : '0px'}
           h={'8px'}
         />
       </Button>

--- a/packages/frontend/src/components/charts/TransactionsHistory.js
+++ b/packages/frontend/src/components/charts/TransactionsHistory.js
@@ -3,7 +3,7 @@
 import { useState, useEffect } from 'react'
 import * as Api from '../../util/Api'
 import { fetchHandlerSuccess, fetchHandlerError, getDaysBetweenDates } from '../../util'
-import { defaultChartConfig } from '../../components/charts/config'
+import { defaultChartConfig } from './config'
 import LineChartBlock from './LineChartBlock'
 
 export default function TransactionsHistory ({ heightPx = 300, blockBorders = true }) {

--- a/packages/frontend/src/components/charts/TransactionsHistory.js
+++ b/packages/frontend/src/components/charts/TransactionsHistory.js
@@ -2,24 +2,21 @@
 
 import { useState, useEffect } from 'react'
 import * as Api from '../../util/Api'
-import { fetchHandlerSuccess, fetchHandlerError } from '../../util'
+import { fetchHandlerSuccess, fetchHandlerError, getDaysBetweenDates } from '../../util'
+import { defaultChartConfig } from '../../components/charts/config'
 import LineChartBlock from './LineChartBlock'
 
-const transactionsChartConfig = {
-  timespan: {
-    default: '1w',
-    values: ['1h', '24h', '3d', '1w']
-  }
-}
-
-export default function TransactionsHistory ({ height = '220px', blockBorders = true }) {
+export default function TransactionsHistory ({ heightPx = 300, blockBorders = true }) {
   const [transactionsHistory, setTransactionsHistory] = useState({ data: {}, loading: true, error: false })
-  const [timespan, setTimespan] = useState(transactionsChartConfig.timespan.default)
+  const [timespan, setTimespan] = useState(defaultChartConfig.timespan.values[defaultChartConfig.timespan.defaultIndex])
 
   useEffect(() => {
+    const { start = null, end = null } = timespan?.range
+    if (!start || !end) return
+
     setTransactionsHistory(state => ({ ...state, loading: true }))
 
-    Api.getTransactionsHistory(timespan)
+    Api.getTransactionsHistory(start, end)
       .then(res => fetchHandlerSuccess(setTransactionsHistory, { resultSet: res }))
       .catch(err => fetchHandlerError(setTransactionsHistory, err))
   }, [timespan])
@@ -36,10 +33,9 @@ export default function TransactionsHistory ({ height = '220px', blockBorders = 
         })) || []}
         xAxis={{
           type: (() => {
-            if (timespan === '1h') return { axis: 'time' }
-            if (timespan === '24h') return { axis: 'time' }
-            if (timespan === '3d') return { axis: 'date', tooltip: 'datetime' }
-            if (timespan === '1w') return { axis: 'date' }
+            if (getDaysBetweenDates(timespan.range.start, timespan.range.end) > 7) return { axis: 'date' }
+            if (getDaysBetweenDates(timespan.range.start, timespan.range.end) > 3) return { axis: 'date', tooltip: 'datetime' }
+            return { axis: 'time' }
           })(),
           abbreviation: '',
           title: ''
@@ -49,7 +45,7 @@ export default function TransactionsHistory ({ height = '220px', blockBorders = 
           title: '',
           abbreviation: 'txs'
         }}
-        height={height}
+        heightPx={heightPx}
         blockBorders={blockBorders}
     />
   )

--- a/packages/frontend/src/components/charts/index.js
+++ b/packages/frontend/src/components/charts/index.js
@@ -32,8 +32,7 @@ const LineChart = ({
   yAxis = { title: '', type: { axis: 'number' } },
   width,
   height,
-  dataLoading,
-  chartIsHidden = false
+  dataLoading
 }) => {
   const chartContainer = useRef()
   const [chartElement, setChartElement] = useState(null)
@@ -54,10 +53,6 @@ const LineChart = ({
       render()
     }
   }, [data, render])
-
-  useEffect(() => {
-    if (!chartIsHidden) render()
-  }, [chartIsHidden])
 
   useResizeObserver(chartContainer.current, render)
 

--- a/packages/frontend/src/components/charts/index.js
+++ b/packages/frontend/src/components/charts/index.js
@@ -32,7 +32,8 @@ const LineChart = ({
   yAxis = { title: '', type: { axis: 'number' } },
   width,
   height,
-  dataLoading
+  dataLoading,
+  chartIsHidden = false
 }) => {
   const chartContainer = useRef()
   const [chartElement, setChartElement] = useState(null)
@@ -53,6 +54,10 @@ const LineChart = ({
       render()
     }
   }, [data, render])
+
+  useEffect(() => {
+    if (!chartIsHidden) render()
+  }, [chartIsHidden])
 
   useResizeObserver(chartContainer.current, render)
 

--- a/packages/frontend/src/util/Api.js
+++ b/packages/frontend/src/util/Api.js
@@ -39,8 +39,8 @@ const getBlockByHash = (hash) => {
   return call(`block/${hash}`, 'GET')
 }
 
-const getTransactionsHistory = (timespan = '24h') => {
-  return call(`transactions/history?timespan=${timespan}`, 'GET')
+const getTransactionsHistory = (start, end) => {
+  return call(`transactions/history?start=${start}&end=${end}`, 'GET')
 }
 
 const getTransactions = (page = 1, limit = 30, order = 'asc') => {


### PR DESCRIPTION
# Issue
The format of the api request for charts has changed. We also have an interface for selecting a date range for charts. We need to implement it in the transaction chart and update the format of the requests.

# Things done
- Implemented Calendar to transactions history chart
- Updated Api format of transactions/history route
- Fixed bug with button width in Timeframe menu (Safari)