### PR TITLE
Fix of documents from dapi search and documentation 

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -722,7 +722,7 @@ Return last revision of the document by given identifier.
 
 Allows to get withdrawals documents by contract id and document type
 ```
-GET /document/FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ?type_name=preorder&contract_id=GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
+GET /document/FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ?document_type_name=preorder&contract_id=GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
 
 {
   "identifier": "FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ",
@@ -1016,7 +1016,7 @@ Response codes:
 Return all documents by the given identity
 * `limit` cannot be more then 100
 ```
-GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/documents?page=1&limit=10&order=asc&type_name=preorder
+GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/documents?page=1&limit=10&order=asc&document_type_name=preorder
 
 {
     pagination: {

--- a/packages/api/src/controllers/DocumentsController.js
+++ b/packages/api/src/controllers/DocumentsController.js
@@ -55,9 +55,9 @@ class DocumentsController {
     response.send(Document.fromObject({
       dataContractIdentifier: dataContract.identifier,
       deleted: false,
-      identifier: extendedDocument?.getId(),
+      identifier: extendedDocument?.getId().toString(),
       system: false,
-      owner: extendedDocument.getOwnerId(),
+      owner: extendedDocument.getOwnerId().toString(),
       revision: extendedDocument.getRevision(),
       timestamp: extendedDocument.getCreatedAt(),
       txHash: document?.txHash ?? null,

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -689,7 +689,7 @@ Return last revision of the document by given identifier.
 
 Allows to get withdrawals documents by contract id and document type
 ```
-GET /document/FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ?type_name=preorder&contract_id=GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
+GET /document/FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ?document_type_name=preorder&contract_id=GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
 
 {
   "identifier": "FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ",
@@ -983,7 +983,7 @@ Response codes:
 Return all documents by the given identity
 * `limit` cannot be more then 100
 ```
-GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/documents?page=1&limit=10&order=asc&type_name=preorder
+GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/documents?page=1&limit=10&order=asc&document_type_name=preorder
 
 {
     pagination: {


### PR DESCRIPTION
# Issue
Was founded two mistakes: wrong parameter name in query string in documentation and error in types, which we trying to push to documents model

# Things done
- Updated docs 
- Added convertation for bad types