### PR TITLE
Update documents request to api

### DIFF
--- a/packages/frontend/src/app/document/[identifier]/Document.js
+++ b/packages/frontend/src/app/document/[identifier]/Document.js
@@ -6,9 +6,7 @@ import * as Api from '../../../util/Api'
 import { fetchHandlerSuccess, fetchHandlerError } from '../../../util'
 import { ErrorMessageBlock } from '../../../components/Errors'
 import { LoadingLine, LoadingBlock } from '../../../components/loading'
-
-import './Document.scss'
-
+import { useSearchParams } from 'next/navigation'
 import {
   Box,
   Container,
@@ -17,15 +15,19 @@ import {
   Flex,
   Code
 } from '@chakra-ui/react'
+import './Document.scss'
 
 function Document ({ identifier }) {
   const [document, setDocument] = useState({ data: {}, props: { printCount: 5 }, loading: true, error: false })
   const tdTitleWidth = 100
+  const searchParams = useSearchParams()
+  const dataContractId = searchParams.get('contract_id') || null
+  const typeName = searchParams.get('document_type_name') || null
 
   const fetchData = () => {
     setDocument(state => ({ ...state, loading: true }))
 
-    Api.getDocumentByIdentifier(identifier)
+    Api.getDocumentByIdentifier(identifier, dataContractId, typeName)
       .then(document => fetchHandlerSuccess(setDocument, document))
       .catch(err => fetchHandlerError(setDocument, err))
   }

--- a/packages/frontend/src/app/document/[identifier]/Document.js
+++ b/packages/frontend/src/app/document/[identifier]/Document.js
@@ -21,8 +21,8 @@ function Document ({ identifier }) {
   const [document, setDocument] = useState({ data: {}, props: { printCount: 5 }, loading: true, error: false })
   const tdTitleWidth = 100
   const searchParams = useSearchParams()
-  const dataContractId = searchParams.get('contract_id') || null
-  const typeName = searchParams.get('document_type_name') || null
+  const dataContractId = searchParams.get('contract-id') || null
+  const typeName = searchParams.get('document-type-name') || null
 
   const fetchData = () => {
     setDocument(state => ({ ...state, loading: true }))

--- a/packages/frontend/src/components/transfers/withdrawals/WithdrawalsListItem.js
+++ b/packages/frontend/src/components/transfers/withdrawals/WithdrawalsListItem.js
@@ -73,7 +73,7 @@ function WithdrawalsListItem ({ withdrawal, rate, defaultPayoutAddress, l1explor
 
           <GridItem className={'WithdrawalsListItem__Column WithdrawalsListItem__Column--Document'}>
             {withdrawal?.document
-              ? <ItemWrapper className={'WithdrawalsListItem__ColumnContent'} isLocal={true} href={'/document/' + withdrawal.document}>
+              ? <ItemWrapper className={'WithdrawalsListItem__ColumnContent'} isLocal={true} href={'/document/' + withdrawal.document + '?contract_id=4fJLR2GYTPFdomuTVvNy3VRrvWgvkKPzqehEBpNf2nk6'}>
                   <ValueContainer className={''} light={true} clickable={true}>
                     <Identifier styles={['highlight-both']}>{withdrawal.document}</Identifier>
                   </ValueContainer>

--- a/packages/frontend/src/components/transfers/withdrawals/WithdrawalsListItem.js
+++ b/packages/frontend/src/components/transfers/withdrawals/WithdrawalsListItem.js
@@ -73,7 +73,10 @@ function WithdrawalsListItem ({ withdrawal, rate, defaultPayoutAddress, l1explor
 
           <GridItem className={'WithdrawalsListItem__Column WithdrawalsListItem__Column--Document'}>
             {withdrawal?.document
-              ? <ItemWrapper className={'WithdrawalsListItem__ColumnContent'} isLocal={true} href={'/document/' + withdrawal.document + '?contract_id=4fJLR2GYTPFdomuTVvNy3VRrvWgvkKPzqehEBpNf2nk6'}>
+              ? <ItemWrapper
+                  className={'WithdrawalsListItem__ColumnContent'}
+                  isLocal={true}
+                  href={'/document/' + withdrawal.document + '?document-type-name=withdrawal&contract-id=4fJLR2GYTPFdomuTVvNy3VRrvWgvkKPzqehEBpNf2nk6'}>
                   <ValueContainer className={''} light={true} clickable={true}>
                     <Identifier styles={['highlight-both']}>{withdrawal.document}</Identifier>
                   </ValueContainer>

--- a/packages/frontend/src/util/Api.js
+++ b/packages/frontend/src/util/Api.js
@@ -68,10 +68,12 @@ const getDataContracts = (page = 1, limit = 30, order = 'asc', orderBy) => {
 }
 
 const getDocumentByIdentifier = (identifier, dataContractId, typeName) => {
-  // const parameters = '?' + `contract_id=${dataContractId}`
-  // document_type_name=withdrawal
-  // https://testnet.platform-explorer.pshenmic.dev/document/kc1bVgbqtu8TM6Qr2chWwxosmPiv2iJAJsqnqRUWqu5?type_name=withdrawals&contract_id=4fJLR2GYTPFdomuTVvNy3VRrvWgvkKPzqehEBpNf2nk6
-  return call(`document/${identifier}?${dataContractId ? `contract_id=${dataContractId}` : ''}${typeName ? `&document_type_name=${typeName}` : ''}`, 'GET')
+  const params = []
+  if (dataContractId) params.push(`contract_id=${dataContractId}`)
+  if (typeName) params.push(`document_type_name=${typeName}`)
+  const queryParams = params.join('&')
+
+  return call(`document/${identifier}?${queryParams ? `?${queryParams}` : ''}`, 'GET')
 }
 
 const getDocumentsByDataContract = (dataContractIdentifier, page = 1, limit = 30, order = 'asc') => {

--- a/packages/frontend/src/util/Api.js
+++ b/packages/frontend/src/util/Api.js
@@ -67,8 +67,11 @@ const getDataContracts = (page = 1, limit = 30, order = 'asc', orderBy) => {
   return call(`dataContracts?page=${page}&limit=${limit}&order=${order}${orderBy ? `&order_by=${orderBy}` : ''}`, 'GET')
 }
 
-const getDocumentByIdentifier = (identifier) => {
-  return call(`document/${identifier}`, 'GET')
+const getDocumentByIdentifier = (identifier, dataContractId, typeName) => {
+  // const parameters = '?' + `contract_id=${dataContractId}`
+  // document_type_name=withdrawal
+  // https://testnet.platform-explorer.pshenmic.dev/document/kc1bVgbqtu8TM6Qr2chWwxosmPiv2iJAJsqnqRUWqu5?type_name=withdrawals&contract_id=4fJLR2GYTPFdomuTVvNy3VRrvWgvkKPzqehEBpNf2nk6
+  return call(`document/${identifier}?${dataContractId ? `contract_id=${dataContractId}` : ''}${typeName ? `&document_type_name=${typeName}` : ''}`, 'GET')
 }
 
 const getDocumentsByDataContract = (dataContractIdentifier, page = 1, limit = 30, order = 'asc') => {


### PR DESCRIPTION
# Issue
System data contract pages open with error. The API has been updated with new parameters: ```contract_id``` and ```document_type_name``` to retrieve system document data.

# Things done
- Updated the API request that retrieved the data contract information
- Implemented new parameters to url on the document page
- Updated links to withdrawal documents on the validator page