### PR TITLE
Index prefunded voting balance in the documents

### DIFF
--- a/packages/indexer/migrations/V47__add_prefunded_voting_balance.sql
+++ b/packages/indexer/migrations/V47__add_prefunded_voting_balance.sql
@@ -1,0 +1,2 @@
+ALTER TABLE documents
+ADD COLUMN "prefunded_voting_balance" JSONB DEFAULT null;

--- a/packages/indexer/src/entities/document.rs
+++ b/packages/indexer/src/entities/document.rs
@@ -27,6 +27,7 @@ pub struct Document {
     pub deleted: bool,
     pub revision: Revision,
     pub is_system: bool,
+    pub prefunded_voting_balance: Option<(String, Credits)>,
 }
 
 impl From<DocumentTransition> for Document {
@@ -42,6 +43,7 @@ impl From<DocumentTransition> for Document {
                 let identifier = base.id();
                 let data_contract_identifier = base.data_contract_id();
                 let document_type_name = base.document_type_name().clone();
+                let prefunded_voting_balance = transition.prefunded_voting_balance().clone();
 
                 return Document {
                     id: None,
@@ -55,6 +57,7 @@ impl From<DocumentTransition> for Document {
                     revision: revision.unwrap(),
                     deleted: false,
                     is_system: false,
+                    prefunded_voting_balance,
                 };
             }
             DocumentTransition::Replace(transition) => {
@@ -77,6 +80,7 @@ impl From<DocumentTransition> for Document {
                     revision: revision.unwrap(),
                     deleted: false,
                     is_system: false,
+                    prefunded_voting_balance: None,
                 };
             }
             DocumentTransition::Delete(transition) => {
@@ -97,6 +101,7 @@ impl From<DocumentTransition> for Document {
                     revision: Revision::from(0 as u64),
                     deleted: true,
                     is_system: false,
+                    prefunded_voting_balance: None,
                 };
             }
             DocumentTransition::Transfer(transition) => {
@@ -119,6 +124,7 @@ impl From<DocumentTransition> for Document {
                     revision,
                     deleted: true,
                     is_system: false,
+                    prefunded_voting_balance: None,
                 };
             }
             DocumentTransition::UpdatePrice(transition) => {
@@ -141,6 +147,7 @@ impl From<DocumentTransition> for Document {
                     revision,
                     deleted: true,
                     is_system: false,
+                    prefunded_voting_balance: None,
                 };
             }
             DocumentTransition::Purchase(transition) => {
@@ -162,6 +169,7 @@ impl From<DocumentTransition> for Document {
                     revision: Revision::from(0 as u64),
                     deleted: true,
                     is_system: false,
+                    prefunded_voting_balance: None,
                 };
             }
         }
@@ -181,6 +189,7 @@ impl From<Row> for Document {
         let deleted: bool = row.get(7);
         let revision: i32 = row.get(8);
         let is_system: bool = row.get(9);
+        let prefunded_voting_balance: Option<Value> = row.get(10);
 
         let transition_type = match transition_type_i64 {
             0 => DocumentTransitionActionType::Create,
@@ -204,6 +213,13 @@ impl From<Row> for Document {
             is_system,
             revision: Revision::from(revision as u64),
             transition_type: DocumentTransitionActionType::try_from(transition_type).unwrap(),
+            prefunded_voting_balance: prefunded_voting_balance.map(|value|{
+                let test = value.as_object().unwrap();
+
+                let (index_name, credits) = test.iter().nth(0).unwrap();
+
+                (index_name.to_string(), credits.as_u64().unwrap())
+            }),
         }
     }
 }

--- a/packages/indexer/src/processor/psql/dao/mod.rs
+++ b/packages/indexer/src/processor/psql/dao/mod.rs
@@ -279,7 +279,7 @@ impl PostgresDAO {
 
         let stmt = client.prepare_cached("SELECT documents.id, documents.identifier,\
         documents.document_type_name,documents.transition_type,data_contracts.identifier,documents.owner,documents.price,\
-        documents.deleted,documents.revision,documents.is_system \
+        documents.deleted,documents.revision,documents.is_system,documents.prefunded_voting_balance \
         FROM documents \
         LEFT JOIN data_contracts ON data_contracts.id = documents.data_contract_id \
         WHERE documents.identifier = $1 \

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -444,6 +444,7 @@ impl PSQLProcessor {
                     is_system: true,
                     price: None,
                     transition_type: DocumentTransitionActionType::Create,
+                    prefunded_voting_balance: None,
                 };
 
                 self.dao.create_document(dash_tld_document, None).await.unwrap();


### PR DESCRIPTION
# Issue

We do not track prefunded voting balance for the documents in the database yet, that happens on on contested resources transactions. Indexing that field will enable backend to build a set of query APIs for retrieving contested resources.


# Things done
* Added prefunded_voting_balance column in the documents SQL schema
* Added a logic to write this field in to the table if applicable