### PR TITLE
Fix pagination of lists on the Identity page

### DIFF
--- a/packages/frontend/src/util/Api.js
+++ b/packages/frontend/src/util/Api.js
@@ -83,12 +83,12 @@ const getTransactionsByIdentity = (identifier, page = 1, limit = 10, order = 'as
   return call(`identity/${identifier}/transactions?page=${page}&limit=${limit}&order=${order}`, 'GET')
 }
 
-const getDataContractsByIdentity = (identifier) => {
-  return call(`identity/${identifier}/dataContracts`, 'GET')
+const getDataContractsByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {
+  return call(`identity/${identifier}/dataContracts?page=${page}&limit=${limit}&order=${order}`, 'GET')
 }
 
-const getDocumentsByIdentity = (identifier) => {
-  return call(`identity/${identifier}/documents`, 'GET')
+const getDocumentsByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {
+  return call(`identity/${identifier}/documents?page=${page}&limit=${limit}&order=${order}`, 'GET')
 }
 
 const getWithdrawalsByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {


### PR DESCRIPTION
# Issue
Pagination of documents and data contracts doesn't work on Identity page.

# Things done
Added pagination parameters to Api requests, pagination now works.