### PR TITLE
Naming fix for decoded MN vote TX

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1723,7 +1723,7 @@ IDENTITY_CREATE with instantLock
 ```
 {
     "type": 8,
-    "contestedResourcesVotePoll": [
+    "indexValues": [
         "EgRkYXNo",
         "EgN5MDE="
     ],

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -293,7 +293,7 @@ const decodeStateTransition = async (client, base64) => {
       break
     }
     case StateTransitionEnum.MASTERNODE_VOTE: {
-      decoded.contestedResourcesVotePoll = stateTransition.getContestedDocumentResourceVotePoll().indexValues.map(buff => buff.toString('base64'))
+      decoded.indexValues = stateTransition.getContestedDocumentResourceVotePoll().indexValues.map(buff => buff.toString('base64'))
       decoded.contractId = stateTransition.getContestedDocumentResourceVotePoll().contractId.toString()
       decoded.modifiedDataIds = stateTransition.getModifiedDataIds().map(identifier => identifier.toString())
       decoded.ownerId = stateTransition.getOwnerId().toString()

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -314,7 +314,7 @@ describe('Utils', () => {
 
       assert.deepEqual(decoded, {
         type: 8,
-        contestedResourcesVotePoll: [
+        indexValues: [
           'EgRkYXNo',
           'Egh0ZXN0MDEwMA=='
         ],

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1690,7 +1690,7 @@ IDENTITY_CREATE with instantLock
 ```
 {
     "type": 8,
-    "contestedResourcesVotePoll": [
+    "indexValues": [
         "EgRkYXNo",
         "EgN5MDE="
     ],


### PR DESCRIPTION
# Issue
At this moment `indexValues` named as `contestedResourcesVotePoll`
# Things done 
* rename to `indexValues`
* update readme.md and tests