### PR TITLE
Fix non-existent component bug

### DIFF
--- a/packages/frontend/src/components/transfers/withdrawals/WithdrawalsListItem.js
+++ b/packages/frontend/src/components/transfers/withdrawals/WithdrawalsListItem.js
@@ -1,6 +1,6 @@
 import { Grid, GridItem } from '@chakra-ui/react'
 import { ArrowCornerIcon } from '../../ui/icons'
-import { Identifier, Credits } from '../../data'
+import { Identifier, BigNumber } from '../../data'
 import { ValueContainer } from '../../ui/containers'
 import { RateTooltip } from '../../ui/Tooltips'
 import StatusIcon from './StatusIcon'
@@ -87,7 +87,7 @@ function WithdrawalsListItem ({ withdrawal, rate, defaultPayoutAddress, l1explor
 
           <GridItem className={'WithdrawalsListItem__Column WithdrawalsListItem__Column--Amount'}>
             <RateTooltip credits={withdrawal.amount} rate={rate}>
-              <span><Credits>{withdrawal.amount}</Credits></span>
+              <span><BigNumber>{withdrawal.amount}</BigNumber></span>
             </RateTooltip>
           </GridItem>
 


### PR DESCRIPTION
# Issue
In one of the previous commits we replaced the Credits component with a BigNumber component. The Credits component in the Withdrawals list was not replaced and now it displays an error due to the import of a non-existent component.

# Things done
Old component replaced, bug fixed