### PR TITLE
Fix timespan title in chart on the Home page

### DIFF
--- a/packages/frontend/src/components/charts/TimeframeSelector.js
+++ b/packages/frontend/src/components/charts/TimeframeSelector.js
@@ -16,7 +16,7 @@ export default function TimeframeSelector ({
   const [timespan, setTimespan] = useState(config.timespan.values[config.timespan.defaultIndex])
   const [menuIsOpen, setMenuIsOpen] = useState(false)
 
-  useEffect(() => setTimespan(forceTimespan), [forceTimespan])
+  useEffect(() => forceTimespan && setTimespan(forceTimespan), [forceTimespan])
 
   const changeHandler = (value) => {
     setTimespan(value)


### PR DESCRIPTION
# Issue
Timespan button title on the Home page is empty by default

# Things done
Fixed default title setting