### PR TITLE
Interval count fix for graphs

### DIFF
--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -58,41 +58,29 @@ class TransactionsController {
     const {
       start = new Date().getTime() - 3600000,
       end = new Date().getTime(),
-      timespan = null,
       intervalsCount = null
     } = request.query
+
+    if (!start || !end) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
 
     if (start > end) {
       return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
     }
 
-    let timespanStart = null
-    let timespanEnd = null
-
-    const timespanInterval = {
-      '1h': { offset: 3600000, step: 'PT5M' },
-      '24h': { offset: 86400000, step: 'PT2H' },
-      '3d': { offset: 259200000, step: 'PT6H' },
-      '1w': { offset: 604800000, step: 'PT14H' }
-    }[timespan]
-
-    if (timespanInterval) {
-      timespanStart = new Date().getTime() - timespanInterval.offset
-      timespanEnd = new Date().getTime()
-    }
-
     const intervalInMs =
       Math.ceil(
-        (new Date(timespanEnd ?? end).getTime() - new Date(timespanStart ?? start).getTime()) / Number(intervalsCount ?? NaN) / 1000
+        (new Date(end).getTime() - new Date(start).getTime()) / Number(intervalsCount ?? NaN) / 1000
       ) * 1000
 
     const interval = intervalsCount
       ? iso8601duration(intervalInMs)
-      : (timespanInterval?.step ?? calculateInterval(new Date(start), new Date(end)))
+      : calculateInterval(new Date(start), new Date(end))
 
     const timeSeries = await this.transactionsDAO.getHistorySeries(
-      new Date(timespanStart ?? start),
-      new Date(timespanEnd ?? end),
+      new Date(start),
+      new Date(end),
       interval,
       isNaN(intervalInMs) ? Intervals[interval] : intervalInMs
     )
@@ -104,41 +92,29 @@ class TransactionsController {
     const {
       start = new Date().getTime() - 3600000,
       end = new Date().getTime(),
-      timespan = null,
       intervalsCount = null
     } = request.query
+
+    if (!start || !end) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
 
     if (start > end) {
       return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
     }
 
-    let timespanStart = null
-    let timespanEnd = null
-
-    const timespanInterval = {
-      '1h': { offset: 3600000, step: 'PT5M' },
-      '24h': { offset: 86400000, step: 'PT2H' },
-      '3d': { offset: 259200000, step: 'PT6H' },
-      '1w': { offset: 604800000, step: 'PT14H' }
-    }[timespan]
-
-    if (timespanInterval) {
-      timespanStart = new Date().getTime() - timespanInterval.offset
-      timespanEnd = new Date().getTime()
-    }
-
     const intervalInMs =
       Math.ceil(
-        (new Date(timespanEnd ?? end).getTime() - new Date(timespanStart ?? start).getTime()) / Number(intervalsCount ?? NaN) / 1000
+        (new Date(end).getTime() - new Date(start).getTime()) / Number(intervalsCount ?? NaN) / 1000
       ) * 1000
 
     const interval = intervalsCount
       ? iso8601duration(intervalInMs)
-      : (timespanInterval?.step ?? calculateInterval(new Date(start), new Date(end)))
+      : calculateInterval(new Date(start), new Date(end))
 
     const timeSeries = await this.transactionsDAO.getGasHistorySeries(
-      new Date(timespanStart ?? start),
-      new Date(timespanEnd ?? end),
+      new Date(start),
+      new Date(end),
       interval,
       isNaN(intervalInMs) ? Intervals[interval] : intervalInMs
     )

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -134,7 +134,7 @@ module.exports = class TransactionsDAO {
   getHistorySeries = async (start, end, interval, intervalInMs) => {
     const startSql = `'${new Date(start.getTime() + intervalInMs).toISOString()}'::timestamptz`
 
-    const endSql = `'${new Date(end.getTime()).toISOString()}'::timestamptz`
+    const endSql = `'${new Date(end.getTime() + intervalInMs).toISOString()}'::timestamptz`
 
     const ranges = this.knex
       .from(this.knex.raw(`generate_series(${startSql}, ${endSql}, '${interval}'::interval) date_to`))

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -497,7 +497,7 @@ describe('Transaction routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      assert.equal(body.length, 12)
+      assert.equal(body.length, 13)
 
       const [firstPeriod] = body.toReversed()
       const firstTimestamp = new Date(firstPeriod.timestamp)
@@ -531,7 +531,7 @@ describe('Transaction routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      assert.equal(body.length, 4)
+      assert.equal(body.length, 5)
 
       const [firstPeriod] = body.toReversed()
       const firstTimestamp = new Date(firstPeriod.timestamp)
@@ -565,7 +565,7 @@ describe('Transaction routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      assert.equal(body.length, 4)
+      assert.equal(body.length, 5)
 
       const [firstPeriod] = body.toReversed()
       const firstTimestamp = new Date(firstPeriod.timestamp)
@@ -599,7 +599,7 @@ describe('Transaction routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      assert.equal(body.length, 5)
+      assert.equal(body.length, 6)
 
       const [firstPeriod] = body.toReversed()
       const firstTimestamp = new Date(firstPeriod.timestamp)
@@ -633,7 +633,7 @@ describe('Transaction routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      assert.equal(body.length, 7)
+      assert.equal(body.length, 8)
 
       const [firstPeriod] = body.toReversed()
       const firstTimestamp = new Date(firstPeriod.timestamp)
@@ -669,7 +669,7 @@ describe('Transaction routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      assert.equal(body.length, 3)
+      assert.equal(body.length, 4)
 
       const [firstPeriod] = body.toReversed()
       const firstTimestamp = new Date(firstPeriod.timestamp)


### PR DESCRIPTION
# Issue 
`generate_series` creates a series 1 interval shorter than necessary

# Things done
* Added 1 interval to the end timestamp
* Remove timespan logic