### PR TITLE
Improve charts render

### DIFF
--- a/packages/frontend/src/app/validator/[hash]/BlocksChart.js
+++ b/packages/frontend/src/app/validator/[hash]/BlocksChart.js
@@ -12,7 +12,7 @@ export default function BlocksChart ({ hash, isActive, loading, timespan, timesp
 
     setBlocksHistory(state => ({ ...state, loading: true }))
 
-    Api.getBlocksStatsByValidator(hash, start, end)
+    Api.getBlocksStatsByValidator(hash, start, end, timespan?.intervalsCount)
       .then(res => fetchHandlerSuccess(setBlocksHistory, { resultSet: res }))
       .catch(err => fetchHandlerError(setBlocksHistory, err))
   }, [timespan, hash])

--- a/packages/frontend/src/app/validator/[hash]/RewardsChart.js
+++ b/packages/frontend/src/app/validator/[hash]/RewardsChart.js
@@ -12,7 +12,7 @@ export default function RewardsChart ({ hash, isActive, loading, timespan, times
 
     setRewardsHistory(state => ({ ...state, loading: true }))
 
-    Api.getRewardsStatsByValidator(hash, start, end)
+    Api.getRewardsStatsByValidator(hash, start, end, timespan?.intervalsCount)
       .then(res => fetchHandlerSuccess(setRewardsHistory, { resultSet: res }))
       .catch(err => fetchHandlerError(setRewardsHistory, err))
   }, [timespan, hash])

--- a/packages/frontend/src/components/charts/TimeframeMenu.js
+++ b/packages/frontend/src/components/charts/TimeframeMenu.js
@@ -47,8 +47,9 @@ const TimeframeMenu = forwardRef(function TimeframeMenu ({ config, forceTimespan
       const daysRange = getDaysBetweenDates(selectedRange.start, selectedRange.end)
 
       if (daysRange > 50) return Math.min(daysRange, 100)
-      if (daysRange > 7) return Math.min(daysRange * 2, 100)
-      if (daysRange > 2) return Math.min(daysRange * 4, 100)
+      if (daysRange > 25) return Math.min(daysRange * 2, 100)
+      if (daysRange > 7) return Math.min(daysRange * 4, 100)
+      if (daysRange > 2) return Math.min(daysRange * 11, 100)
       return 24
     })()
 

--- a/packages/frontend/src/components/charts/TimeframeMenu.js
+++ b/packages/frontend/src/components/charts/TimeframeMenu.js
@@ -1,6 +1,7 @@
 import { useState, forwardRef, useEffect } from 'react'
 import { Button } from '@chakra-ui/react'
 import { DateRangePicker } from '../calendar'
+import { getDaysBetweenDates } from '../../util'
 import './TimeframeMenu.scss'
 
 const TimeframeMenu = forwardRef(function TimeframeMenu ({ config, forceTimespan, changeCallback, className }, ref) {
@@ -42,12 +43,22 @@ const TimeframeMenu = forwardRef(function TimeframeMenu ({ config, forceTimespan
 
     const label = `${labelFormatDate(selectedRange.start)} - ${labelFormatDate(selectedRange.end)}`
 
+    const intervalsCount = (() => {
+      const daysRange = getDaysBetweenDates(selectedRange.start, selectedRange.end)
+
+      if (daysRange > 50) return Math.min(daysRange, 100)
+      if (daysRange > 7) return Math.min(daysRange * 2, 100)
+      if (daysRange > 2) return Math.min(daysRange * 4, 100)
+      return 24
+    })()
+
     changeHandler({
       label,
       range: {
         start: selectedRange.start.toISOString(),
         end: selectedRange.end.toISOString()
-      }
+      },
+      intervalsCount
     })
   }
 

--- a/packages/frontend/src/components/charts/TimeframeMenu.js
+++ b/packages/frontend/src/components/charts/TimeframeMenu.js
@@ -46,8 +46,8 @@ const TimeframeMenu = forwardRef(function TimeframeMenu ({ config, forceTimespan
     const intervalsCount = (() => {
       const daysRange = getDaysBetweenDates(selectedRange.start, selectedRange.end)
 
-      if (daysRange > 50) return Math.min(daysRange, 100)
-      if (daysRange > 25) return Math.min(daysRange * 2, 100)
+      if (daysRange > 25) return Math.min(daysRange, 100)
+      if (daysRange > 14) return Math.min(daysRange * 2, 100)
       if (daysRange > 7) return Math.min(daysRange * 4, 100)
       if (daysRange > 2) return Math.min(daysRange * 11, 100)
       return 24

--- a/packages/frontend/src/components/charts/TransactionsHistory.js
+++ b/packages/frontend/src/components/charts/TransactionsHistory.js
@@ -16,7 +16,7 @@ export default function TransactionsHistory ({ heightPx = 300, blockBorders = tr
 
     setTransactionsHistory(state => ({ ...state, loading: true }))
 
-    Api.getTransactionsHistory(start, end)
+    Api.getTransactionsHistory(start, end, timespan.intervalsCount)
       .then(res => fetchHandlerSuccess(setTransactionsHistory, { resultSet: res }))
       .catch(err => fetchHandlerError(setTransactionsHistory, err))
   }, [timespan])

--- a/packages/frontend/src/components/charts/TransactionsHistory.js
+++ b/packages/frontend/src/components/charts/TransactionsHistory.js
@@ -16,7 +16,7 @@ export default function TransactionsHistory ({ heightPx = 300, blockBorders = tr
 
     setTransactionsHistory(state => ({ ...state, loading: true }))
 
-    Api.getTransactionsHistory(start, end, timespan.intervalsCount)
+    Api.getTransactionsHistory(start, end, timespan?.intervalsCount)
       .then(res => fetchHandlerSuccess(setTransactionsHistory, { resultSet: res }))
       .catch(err => fetchHandlerError(setTransactionsHistory, err))
   }, [timespan])

--- a/packages/frontend/src/components/charts/config.js
+++ b/packages/frontend/src/components/charts/config.js
@@ -6,19 +6,23 @@ export const defaultChartConfig = {
     values: [
       {
         label: '24 hours',
-        range: getDynamicRange(24 * 60 * 60 * 1000)
+        range: getDynamicRange(24 * 60 * 60 * 1000),
+        intervalsCount: 24
       },
       {
         label: '3 days',
-        range: getDynamicRange(3 * 24 * 60 * 60 * 1000)
+        range: getDynamicRange(3 * 24 * 60 * 60 * 1000),
+        intervalsCount: 36
       },
       {
         label: '1 week',
-        range: getDynamicRange(7 * 24 * 60 * 60 * 1000)
+        range: getDynamicRange(7 * 24 * 60 * 60 * 1000),
+        intervalsCount: 56
       },
       {
         label: '1 Month',
-        range: getDynamicRange(30 * 24 * 60 * 60 * 1000)
+        range: getDynamicRange(30 * 24 * 60 * 60 * 1000),
+        intervalsCount: 31
       }
     ]
   }

--- a/packages/frontend/src/components/charts/config.js
+++ b/packages/frontend/src/components/charts/config.js
@@ -17,12 +17,12 @@ export const defaultChartConfig = {
       {
         label: '1 week',
         range: getDynamicRange(7 * 24 * 60 * 60 * 1000),
-        intervalsCount: 56
+        intervalsCount: 28
       },
       {
         label: '1 Month',
         range: getDynamicRange(30 * 24 * 60 * 60 * 1000),
-        intervalsCount: 31
+        intervalsCount: 62
       }
     ]
   }

--- a/packages/frontend/src/components/charts/config.js
+++ b/packages/frontend/src/components/charts/config.js
@@ -22,7 +22,7 @@ export const defaultChartConfig = {
       {
         label: '1 Month',
         range: getDynamicRange(30 * 24 * 60 * 60 * 1000),
-        intervalsCount: 62
+        intervalsCount: 31
       }
     ]
   }

--- a/packages/frontend/src/util/Api.js
+++ b/packages/frontend/src/util/Api.js
@@ -39,8 +39,8 @@ const getBlockByHash = (hash) => {
   return call(`block/${hash}`, 'GET')
 }
 
-const getTransactionsHistory = (start, end) => {
-  return call(`transactions/history?start=${start}&end=${end}`, 'GET')
+const getTransactionsHistory = (start, end, intervalsCount) => {
+  return call(`transactions/history?start=${start}&end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
 }
 
 const getTransactions = (page = 1, limit = 30, order = 'asc') => {
@@ -120,12 +120,12 @@ const getValidatorByProTxHash = (proTxHash) => {
   return call(`validator/${proTxHash}`, 'GET')
 }
 
-const getBlocksStatsByValidator = (proTxHash, start, end) => {
-  return call(`validator/${proTxHash}/stats?start=${start}&end=${end}`, 'GET')
+const getBlocksStatsByValidator = (proTxHash, start, end, intervalsCount) => {
+  return call(`validator/${proTxHash}/stats?start=${start}&end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
 }
 
-const getRewardsStatsByValidator = (proTxHash, start, end) => {
-  return call(`validator/${proTxHash}/rewards/stats?start=${start}&end=${end}`, 'GET')
+const getRewardsStatsByValidator = (proTxHash, start, end, intervalsCount) => {
+  return call(`validator/${proTxHash}/rewards/stats?start=${start}&end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
 }
 
 const getStatus = () => {

--- a/packages/frontend/src/util/datetime.js
+++ b/packages/frontend/src/util/datetime.js
@@ -1,4 +1,5 @@
 function getDaysBetweenDates (startDate, endDate) {
+  if (!startDate || !endDate) return 0
   const start = new Date(startDate)
   const end = new Date(endDate)
   const diffInMilliseconds = Math.abs(end - start)


### PR DESCRIPTION
# Issue
Some chart ranges show too few dots. Sometimes the extreme dates are not visible on the chart.

# Things done
Added instervalsCount parameter in requests to Api on frontend. Now the points count is calculated in multiples of days or hours. But it can't be more than 100 due to API restrictions.