### PR TITLE
Gas used field for document revisions

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -63,7 +63,7 @@ Reference:
 * [Identities](#identities)
 * [Data Contracts by Identity](#data-contracts-by-identity)
 * [Documents by Identity](#documents-by-identity)
-* [Document Transactions](#document-transactions)
+* [Document Revisions](#document-revisions)
 * [Transactions By Identity](#transactions-by-identity)
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
@@ -781,38 +781,34 @@ Response codes:
 500: Internal Server Error
 ```
 ---
-### Document Transactions
-Return transactions for selected document
+### Document Revisions
+Return revisions for selected document
 
 * Valid `order_by` values are `asc` or `desc`
 * `limit` cannot be more then 100
 * `page` cannot be less then 1
 
 ```
-GET /document/ELEeNjGbqCsHNtkoJ51pFHvUyCk5sxgU1jYVuySMhQwN/transactions
+GET /document/y5DhJmM4unLTEaKAkMTbQHMoM8hh47ddowKYusgtHwL/revisions
 
 {
   "resultSet": [
     {
+      "identifier": "y5DhJmM4unLTEaKAkMTbQHMoM8hh47ddowKYusgtHwL",
+      "dataContractIdentifier": null,
       "revision": 1,
-      "gasUsed": 38201380,
-      "owner": "Gn15UqiQ6gpqzXcDhv4adwsJ1KgpG6xx9e3rij9n4ctP",
-      "hash": "437C949982B41E00506B88C62A94B3E032FADFB010BCA91F3A4C874EB75F9E23",
-      "timestamp": "2024-08-25T18:32:24.454Z",
+      "txHash": "8851ACE1E6EE41C3B7B812DD98867BD472135C54E6438111586E2510EC6E43E3",
+      "deleted": null,
+      "data": "{\"hash\":\"00000000001f60ce3577bb4ae48df85617143d082872231b01ef3f0f5300\",\"timeToLock\":0,\"receiveTime\":1732222851,\"isChainLocked\":false}",
+      "timestamp": "2024-11-21T16:01:22.905Z",
+      "system": null,
+      "entropy": null,
+      "prefundedVotingBalance": null,
+      "documentTypeName": null,
       "transitionType": 0,
-      "data": {
-        "label": "BurgerJoint2",
-        "records": {
-          "identity": "Gn15UqiQ6gpqzXcDhv4adwsJ1KgpG6xx9e3rij9n4ctP"
-        },
-        "preorderSalt": "GV43pQXjfaSZ5FryGKsyKJBja2L+fwxXz9Npe0MH2WQ=",
-        "subdomainRules": {
-          "allowSubdomains": false
-        },
-        "normalizedLabel": "burgerj01nt2",
-        "parentDomainName": "dash",
-        "normalizedParentDomainName": "dash"
-      }
+      "nonce": null,
+      "gasUsed": 78317180,
+      "owner": "AVGaxbN1apFAM4aWtkjUJvPhT1Nr3AeKzgb22sqWvKNe"
     }
   ],
   "pagination": {

--- a/packages/api/src/controllers/DocumentsController.js
+++ b/packages/api/src/controllers/DocumentsController.js
@@ -80,9 +80,9 @@ class DocumentsController {
     const { identifier } = request.params
     const { page = 1, limit = 10, order = 'asc' } = request.query
 
-    const transactions = await this.documentsDAO.getDocumentRevisions(identifier, Number(page ?? 1), Number(limit ?? 10), order)
+    const revisions = await this.documentsDAO.getDocumentRevisions(identifier, Number(page ?? 1), Number(limit ?? 10), order)
 
-    response.send(transactions)
+    response.send(revisions)
   }
 }
 

--- a/packages/api/src/dao/DocumentsDAO.js
+++ b/packages/api/src/dao/DocumentsDAO.js
@@ -146,7 +146,7 @@ module.exports = class DocumentsDAO {
 
     const subquery = this.knex('documents')
       .select(
-        'documents.id as id', 'revision', 'transition_type', 'gas_used', 'timestamp',
+        'documents.id as id', 'revision', 'transition_type', 'gas_used', 'timestamp', 'identifier',
         'documents.owner as owner', 'state_transitions.hash as hash', 'documents.data as data')
       .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
       .where('documents.identifier', '=', identifier)
@@ -155,7 +155,7 @@ module.exports = class DocumentsDAO {
       .as('subquery')
 
     const rows = await this.knex(subquery)
-      .select('revision', 'gas_used', 'subquery.owner', 'hash as tx_hash', 'timestamp', 'transition_type', 'data')
+      .select('revision', 'gas_used', 'subquery.owner', 'hash as tx_hash', 'timestamp', 'transition_type', 'data', 'identifier')
       .select(this.knex(subquery).count('*').as('total_count'))
       .whereBetween('rank', [fromRank, toRank])
       .orderBy('id', order)

--- a/packages/api/src/models/Document.js
+++ b/packages/api/src/models/Document.js
@@ -12,8 +12,9 @@ module.exports = class Document {
   documentTypeName
   transitionType
   nonce
+  gasUsed
 
-  constructor (identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, isSystem, documentTypeName, transitionType, prefundedVotingBalance, entropy, nonce) {
+  constructor (identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, isSystem, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, entropy, nonce) {
     this.identifier = identifier ? identifier.trim() : null
     this.owner = owner ? owner.trim() : null
     this.dataContractIdentifier = dataContractIdentifier ? dataContractIdentifier.trim() : null
@@ -30,14 +31,15 @@ module.exports = class Document {
     this.entropy = entropy ?? null
     this.prefundedVotingBalance = prefundedVotingBalance ?? null
     this.nonce = nonce ?? null
+    this.gasUsed = gasUsed ?? null
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow ({ identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data, timestamp, is_system, document_type_name, transition_type, prefunded_voting_balance }) {
-    return new Document(identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data ? JSON.stringify(data) : null, timestamp, is_system, document_type_name, Number(transition_type), prefunded_voting_balance)
+  static fromRow ({ identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data, timestamp, is_system, document_type_name, transition_type, prefunded_voting_balance, gas_used }) {
+    return new Document(identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data ? JSON.stringify(data) : null, timestamp, is_system, document_type_name, Number(transition_type), prefunded_voting_balance, Number(gas_used))
   }
 
-  static fromObject ({ identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, entropy, prefundedVotingBalance, nonce }) {
-    return new Document(identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, prefundedVotingBalance, entropy, nonce)
+  static fromObject ({ identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, entropy, prefundedVotingBalance, nonce, gasUsed }) {
+    return new Document(identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, entropy, nonce)
   }
 }

--- a/packages/api/test/integration/documents.spec.js
+++ b/packages/api/test/integration/documents.spec.js
@@ -169,6 +169,7 @@ describe('Documents routes', () => {
         owner: document.document.owner,
         system: document.document.is_system,
         nonce: 2,
+        gasUsed: null,
         transitionType: 0
       }
 
@@ -196,6 +197,7 @@ describe('Documents routes', () => {
         owner: document.document.owner,
         txHash: document.transaction.hash,
         nonce: 2,
+        gasUsed: null,
         transitionType: 0
       }
 
@@ -229,9 +231,10 @@ describe('Documents routes', () => {
         deleted: null,
         documentTypeName: null,
         entropy: null,
-        identifier: null,
+        identifier: document.document.identifier,
         nonce: null,
         prefundedVotingBalance: null,
+        gasUsed: 0,
         system: null
       }
 
@@ -266,6 +269,7 @@ describe('Documents routes', () => {
           documentTypeName: document.document_type_name,
           transitionType: document.transition_type,
           prefundedVotingBalance: null,
+          gasUsed: null,
           nonce: null
         }))
 
@@ -311,6 +315,7 @@ describe('Documents routes', () => {
           timestamp: block.timestamp,
           owner: document.owner,
           system: document.is_system,
+          gasUsed: null,
           nonce: null
         }))
 
@@ -343,6 +348,7 @@ describe('Documents routes', () => {
           system: document.is_system,
           entropy: null,
           prefundedVotingBalance: null,
+          gasUsed: null,
           nonce: null
         }))
 
@@ -388,6 +394,7 @@ describe('Documents routes', () => {
           system: document.is_system,
           entropy: null,
           prefundedVotingBalance: null,
+          gasUsed: null,
           nonce: null
         }))
 
@@ -428,6 +435,7 @@ describe('Documents routes', () => {
           system: document.is_system,
           entropy: null,
           prefundedVotingBalance: null,
+          gasUsed: null,
           nonce: null
         }))
 
@@ -468,6 +476,7 @@ describe('Documents routes', () => {
           system: document.is_system,
           entropy: null,
           prefundedVotingBalance: null,
+          gasUsed: null,
           nonce: null
         }))
 

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -973,7 +973,8 @@ describe('Identities routes', () => {
         timestamp: _document.block.timestamp.toISOString(),
         system: false,
         transitionType: 0,
-        nonce: null
+        nonce: null,
+        gasUsed: null
       }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -1034,6 +1035,7 @@ describe('Identities routes', () => {
           timestamp: _document.block.timestamp.toISOString(),
           system: false,
           transitionType: 0,
+          gasUsed: null,
           nonce: null
         }))
 
@@ -1097,6 +1099,7 @@ describe('Identities routes', () => {
           documentTypeName: 'my_type',
           prefundedVotingBalance: null,
           entropy: null,
+          gasUsed: null,
           nonce: null
         }))
 
@@ -1158,6 +1161,7 @@ describe('Identities routes', () => {
           timestamp: _document.block.timestamp.toISOString(),
           system: false,
           transitionType: 0,
+          gasUsed: null,
           nonce: null
         }))
 
@@ -1219,6 +1223,7 @@ describe('Identities routes', () => {
           timestamp: _document.block.timestamp.toISOString(),
           system: false,
           transitionType: 0,
+          gasUsed: null,
           nonce: null
         }))
 

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -351,6 +351,7 @@ describe('Other routes', () => {
         documentTypeName: document.document_type_name,
         transitionType: 0,
         owner: document.owner,
+        gasUsed: null,
         nonce: 2
       }
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -30,7 +30,7 @@ Reference:
 * [Identities](#identities)
 * [Data Contracts by Identity](#data-contracts-by-identity)
 * [Documents by Identity](#documents-by-identity)
-* [Document Transactions](#document-transactions)
+* [Document Revisions](#document-revisions)
 * [Transactions By Identity](#transactions-by-identity)
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
@@ -748,38 +748,34 @@ Response codes:
 500: Internal Server Error
 ```
 ---
-### Document Transactions
-Return transactions for selected document
+### Document Revisions
+Return revisions for selected document
 
 * Valid `order_by` values are `asc` or `desc`
 * `limit` cannot be more then 100
 * `page` cannot be less then 1
 
 ```
-GET /document/ELEeNjGbqCsHNtkoJ51pFHvUyCk5sxgU1jYVuySMhQwN/transactions
+GET /document/y5DhJmM4unLTEaKAkMTbQHMoM8hh47ddowKYusgtHwL/revisions
 
 {
   "resultSet": [
     {
+      "identifier": "y5DhJmM4unLTEaKAkMTbQHMoM8hh47ddowKYusgtHwL",
+      "dataContractIdentifier": null,
       "revision": 1,
-      "gasUsed": 38201380,
-      "owner": "Gn15UqiQ6gpqzXcDhv4adwsJ1KgpG6xx9e3rij9n4ctP",
-      "hash": "437C949982B41E00506B88C62A94B3E032FADFB010BCA91F3A4C874EB75F9E23",
-      "timestamp": "2024-08-25T18:32:24.454Z",
+      "txHash": "8851ACE1E6EE41C3B7B812DD98867BD472135C54E6438111586E2510EC6E43E3",
+      "deleted": null,
+      "data": "{\"hash\":\"00000000001f60ce3577bb4ae48df85617143d082872231b01ef3f0f5300\",\"timeToLock\":0,\"receiveTime\":1732222851,\"isChainLocked\":false}",
+      "timestamp": "2024-11-21T16:01:22.905Z",
+      "system": null,
+      "entropy": null,
+      "prefundedVotingBalance": null,
+      "documentTypeName": null,
       "transitionType": 0,
-      "data": {
-        "label": "BurgerJoint2",
-        "records": {
-          "identity": "Gn15UqiQ6gpqzXcDhv4adwsJ1KgpG6xx9e3rij9n4ctP"
-        },
-        "preorderSalt": "GV43pQXjfaSZ5FryGKsyKJBja2L+fwxXz9Npe0MH2WQ=",
-        "subdomainRules": {
-          "allowSubdomains": false
-        },
-        "normalizedLabel": "burgerj01nt2",
-        "parentDomainName": "dash",
-        "normalizedParentDomainName": "dash"
-      }
+      "nonce": null,
+      "gasUsed": 78317180,
+      "owner": "AVGaxbN1apFAM4aWtkjUJvPhT1Nr3AeKzgb22sqWvKNe"
     }
   ],
   "pagination": {


### PR DESCRIPTION
# Issue
In previous PR for documents revisions was forgot `gas_used` field in response
# Things done
* Implemented `gas_used` field in model and query 
* Updated `README.md`
* Updated tests