### PR TITLE
Order fix for data contract transactions

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -770,8 +770,9 @@ GET /dataContract/AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18/transactions
     {
       "type": 0,
       "action": null,
-      "owner": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
-      "aliases": [
+      "owner": {
+        "identifier": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
+        "aliases": [
         {
           "alias": "Tutorial-Test-000000.dash",
           "status": "ok",
@@ -785,6 +786,7 @@ GET /dataContract/AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18/transactions
           "timestamp": null
         }
       ],
+      }
       "timestamp": "2024-08-26T13:30:22.211Z",
       "gasUsed": 32230560,
       "error": null,

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -148,23 +148,21 @@ module.exports = class DataContractsDAO {
       .as('sub')
 
     const additionalDataSubquery = this.knex(unionSubquery)
-      .select('timestamp', 'sub.state_transition_hash as state_transition_hash', 'owner', 'gas_used', 'data', 'error', 'aliases')
-      .select(this.knex.raw('rank() over (order by state_transitions.id asc) as rank'))
+      .select(
+        'timestamp', 'sub.state_transition_hash as state_transition_hash',
+        'owner', 'gas_used', 'data', 'error', 'aliases', 'state_transitions.id as id'
+      )
+      .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) as rank`))
       .leftJoin('state_transitions', 'sub.state_transition_hash', 'state_transitions.hash')
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
       .leftJoin(aliasesSubquery, 'owner', 'aliases.identity_identifier')
       .as('additional_subquery')
 
     const rows = await this.knex(additionalDataSubquery)
-      .select('timestamp', 'state_transition_hash', 'owner', 'gas_used', 'data', 'error', 'aliases', 'rank')
+      .select('timestamp', 'state_transition_hash', 'owner', 'gas_used', 'data', 'error', 'aliases')
       .select(this.knex(additionalDataSubquery).count('*').as('total_count'))
       .whereBetween('rank', [fromRank, toRank])
-      .orderBy('rank', order)
-      .groupBy('timestamp', 'state_transition_hash', 'owner', 'gas_used', 'data', 'error', 'aliases', 'rank')
-
-    if (rows.length === 0) {
-      return null
-    }
+      .orderBy('id', order)
 
     const resultSet = await Promise.all(rows.map(async (row) => {
       let decodedTx
@@ -185,8 +183,10 @@ module.exports = class DataContractsDAO {
           action: transition.action,
           id: transition.id
         })) ?? null,
-        owner: row.owner?.trim() ?? null,
-        aliases: aliases ?? [],
+        owner: {
+          identifier: row.owner?.trim() ?? null,
+          aliases: aliases ?? []
+        },
         timestamp: row.timestamp,
         gasUsed: Number(row.gas_used ?? 0),
         error: row.error,

--- a/packages/api/test/integration/data.contracts.spec.js
+++ b/packages/api/test/integration/data.contracts.spec.js
@@ -362,44 +362,48 @@ describe('DataContracts routes', () => {
       assert.deepEqual(body.pagination.limit, 10)
       assert.deepEqual(body.pagination.total, 11)
 
-      const dataContractVersions = diferentVersionsDataContract.sort((a, b) => a.dataContract.id - b.dataContract.id).map(dataContractVersion => ({
+      const dataContractVersions = diferentVersionsDataContract.map(dataContractVersion => ({
         type: 0,
         action: null,
-        owner: dataContractVersion.dataContract.owner,
-        aliases: [],
+        owner: {
+          identifier: dataContractVersion.dataContract.owner,
+          aliases: []
+        },
         timestamp: dataContract.block.timestamp.toISOString(),
         gasUsed: 0,
         error: null,
-        hash: dataContractVersion.transaction.hash
+        hash: dataContractVersion.transaction.hash,
+        id: dataContractVersion.transaction.id
       }))
 
-      const documentsTransactions = documents.sort((a, b) => a.dataContract.id - b.dataContract.id).map(({ document, transaction, block }) => ({
+      const documentsTransactions = documents.map(({ document, transaction, block }) => ({
         type: 1,
         action: [{
           action: 3,
           id: '5iCdbVb5Tn3GLzqCzsX7SVXaZgFeNQ1NDmVZ51Rap1Tx'
         }],
-        owner: document.owner,
-        aliases: [],
+        owner: {
+          identifier: document.owner,
+          aliases: []
+        },
         timestamp: block.timestamp.toISOString(),
         gasUsed: 0,
         error: null,
-        hash: transaction.hash
+        hash: transaction.hash,
+        id: transaction.id
       }))
 
-      const expectedDataTransactions = [
-        dataContractVersions[0],
-        dataContractVersions[1],
-        documentsTransactions[0],
-        dataContractVersions[2],
-        documentsTransactions[1],
-        dataContractVersions[3],
-        documentsTransactions[2],
-        dataContractVersions[4],
-        documentsTransactions[3],
-        dataContractVersions[5],
-        documentsTransactions[4]
-      ]
+      const expectedDataTransactions = [...dataContractVersions, ...documentsTransactions]
+        .sort((a, b) => a.id - b.id)
+        .map(tx => ({
+          type: tx.type,
+          action: tx.action,
+          owner: tx.owner,
+          timestamp: tx.timestamp,
+          gasUsed: tx.gasUsed,
+          error: tx.error,
+          hash: tx.hash
+        }))
 
       assert.deepEqual(body.resultSet, expectedDataTransactions.slice(0, 10))
     })
@@ -416,44 +420,48 @@ describe('DataContracts routes', () => {
       assert.deepEqual(body.pagination.limit, 5)
       assert.deepEqual(body.pagination.total, 11)
 
-      const dataContractVersions = diferentVersionsDataContract.sort((a, b) => a.dataContract.id - b.dataContract.id).map(dataContractVersion => ({
+      const dataContractVersions = diferentVersionsDataContract.map(dataContractVersion => ({
         type: 0,
         action: null,
-        owner: dataContractVersion.dataContract.owner,
-        aliases: [],
+        owner: {
+          identifier: dataContractVersion.dataContract.owner,
+          aliases: []
+        },
         timestamp: dataContract.block.timestamp.toISOString(),
         gasUsed: 0,
         error: null,
-        hash: dataContractVersion.transaction.hash
+        hash: dataContractVersion.transaction.hash,
+        id: dataContractVersion.transaction.id
       }))
 
-      const documentsTransactions = documents.sort((a, b) => a.dataContract.id - b.dataContract.id).map(({ document, transaction, block }) => ({
+      const documentsTransactions = documents.map(({ document, transaction, block }) => ({
         type: 1,
         action: [{
           action: 3,
           id: '5iCdbVb5Tn3GLzqCzsX7SVXaZgFeNQ1NDmVZ51Rap1Tx'
         }],
-        owner: document.owner,
-        aliases: [],
+        owner: {
+          identifier: document.owner,
+          aliases: []
+        },
         timestamp: block.timestamp.toISOString(),
         gasUsed: 0,
         error: null,
-        hash: transaction.hash
+        hash: transaction.hash,
+        id: transaction.id
       }))
 
-      const expectedDataTransactions = [
-        dataContractVersions[0],
-        dataContractVersions[1],
-        documentsTransactions[0],
-        dataContractVersions[2],
-        documentsTransactions[1],
-        dataContractVersions[3],
-        documentsTransactions[2],
-        dataContractVersions[4],
-        documentsTransactions[3],
-        dataContractVersions[5],
-        documentsTransactions[4]
-      ]
+      const expectedDataTransactions = [...dataContractVersions, ...documentsTransactions]
+        .sort((a, b) => a.id - b.id)
+        .map(tx => ({
+          type: tx.type,
+          action: tx.action,
+          owner: tx.owner,
+          timestamp: tx.timestamp,
+          gasUsed: tx.gasUsed,
+          error: tx.error,
+          hash: tx.hash
+        }))
 
       assert.deepEqual(body.resultSet, expectedDataTransactions.slice(0, 5))
     })
@@ -470,52 +478,50 @@ describe('DataContracts routes', () => {
       assert.deepEqual(body.pagination.limit, 5)
       assert.deepEqual(body.pagination.total, 11)
 
-      const dataContractVersions = diferentVersionsDataContract.sort((a, b) => a.dataContract.id - b.dataContract.id).map(dataContractVersion => ({
+      const dataContractVersions = diferentVersionsDataContract.map(dataContractVersion => ({
         type: 0,
         action: null,
-        owner: dataContractVersion.dataContract.owner,
-        aliases: [],
+        owner: {
+          identifier: dataContractVersion.dataContract.owner,
+          aliases: []
+        },
         timestamp: dataContract.block.timestamp.toISOString(),
         gasUsed: 0,
         error: null,
-        hash: dataContractVersion.transaction.hash
+        hash: dataContractVersion.transaction.hash,
+        id: dataContractVersion.transaction.id
       }))
 
-      const documentsTransactions = documents.sort((a, b) => a.dataContract.id - b.dataContract.id).map(({ document, transaction, block }) => ({
+      const documentsTransactions = documents.map(({ document, transaction, block }) => ({
         type: 1,
         action: [{
           action: 3,
           id: '5iCdbVb5Tn3GLzqCzsX7SVXaZgFeNQ1NDmVZ51Rap1Tx'
         }],
-        owner: document.owner,
-        aliases: [],
+        owner: {
+          identifier: document.owner,
+          aliases: []
+        },
         timestamp: block.timestamp.toISOString(),
         gasUsed: 0,
         error: null,
-        hash: transaction.hash
+        hash: transaction.hash,
+        id: transaction.id
       }))
 
-      const expectedDataTransactions = [
-        dataContractVersions[0],
-        dataContractVersions[1],
-        documentsTransactions[0],
-        dataContractVersions[2],
-        documentsTransactions[1],
-        dataContractVersions[3],
-        documentsTransactions[2],
-        dataContractVersions[4],
-        documentsTransactions[3],
-        dataContractVersions[5],
-        documentsTransactions[4]
-      ]
+      const expectedDataTransactions = [...dataContractVersions, ...documentsTransactions]
+        .sort((a, b) => b.id - a.id)
+        .map(tx => ({
+          type: tx.type,
+          action: tx.action,
+          owner: tx.owner,
+          timestamp: tx.timestamp,
+          gasUsed: tx.gasUsed,
+          error: tx.error,
+          hash: tx.hash
+        }))
 
-      assert.deepEqual(body.resultSet, expectedDataTransactions.slice(0, 5).toReversed())
-    })
-
-    it('should return 404 if data contract not found', async () => {
-      await client.get('/dataContract/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/transactions')
-        .expect(404)
-        .expect('Content-Type', 'application/json; charset=utf-8')
+      assert.deepEqual(body.resultSet, expectedDataTransactions.slice(0, 5))
     })
   })
 })

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -737,8 +737,9 @@ GET /dataContract/AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18/transactions
     {
       "type": 0,
       "action": null,
-      "owner": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
-      "aliases": [
+      "owner": {
+        "identifier": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
+        "aliases": [
         {
           "alias": "Tutorial-Test-000000.dash",
           "status": "ok",
@@ -752,6 +753,7 @@ GET /dataContract/AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18/transactions
           "timestamp": null
         }
       ],
+      }
       "timestamp": "2024-08-26T13:30:22.211Z",
       "gasUsed": 32230560,
       "error": null,


### PR DESCRIPTION
# Issue
In PR #453  was added transactions endpoint for data contracts, but he contains mistake in `order`
# Things done
* Fixed order, now `asc` and `desc` works fine
* Changed structure for owner
```
old strucutre:
{
  ...
  "owner": "CyFHybT39z1VDsRnCzyobfEoSk4Gmi4gj6mRkUn2yyuH",
  "aliases": [],
  ...
}

new structure:

{
  ...
  "owner": {
    "identifier": "CyFHybT39z1VDsRnCzyobfEoSk4Gmi4gj6mRkUn2yyuH",
    "aliases": [],
  }
  ...
}

```
* Updated tests
* Updated `README.md`