### PR TITLE
Total gas used

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -826,6 +826,8 @@ GET /document/FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ?document_type_name=pr
     "parentNameAndLabel": 20000000000
   },
   "typeName": "preorder",
+  "gasUsed": null,
+  "totalGasUsed": 15999780,
   "owner": {
     "identifier": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
     "aliases": [

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -57,6 +57,7 @@ Reference:
 * [Data Contracts](#data-contracts)
 * [Data Contract Transactions](#data-contract-transactions)
 * [Document by Identifier](#document-by-identifier)
+* [Document Revisions](#document-revisions)
 * [Documents by Data Contract](#documents-by-data-contract)
 * [Identity by Identifier](#identity-by-identifier)
 * [Identity by DPNS](#identity-by-dpns)
@@ -64,7 +65,6 @@ Reference:
 * [Identities](#identities)
 * [Data Contracts by Identity](#data-contracts-by-identity)
 * [Documents by Identity](#documents-by-identity)
-* [Document Revisions](#document-revisions)
 * [Transactions By Identity](#transactions-by-identity)
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
@@ -896,6 +896,7 @@ GET /document/y5DhJmM4unLTEaKAkMTbQHMoM8hh47ddowKYusgtHwL/revisions
       "transitionType": 0,
       "nonce": null,
       "gasUsed": 78317180,
+      "totalGasUsed": null,
       "owner": {
         "identifier": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
         "aliases": [
@@ -945,6 +946,8 @@ GET /dataContract/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/documents?documen
       "entropy": null,
       "prefundedVotingBalance": null,
       "typeName": "domain",
+      "gasUsed": null,
+      "totalGasUsed": null,
       "owner": {
         "identifier": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
         "aliases": [

--- a/packages/api/src/dao/DocumentsDAO.js
+++ b/packages/api/src/dao/DocumentsDAO.js
@@ -99,8 +99,7 @@ module.exports = class DocumentsDAO {
         entropy: transitionWithEntropy?.entropy,
         prefundedVotingBalance: transitionWithEntropy?.prefundedVotingBalance,
         nonce: transitionWithEntropy?.nonce
-      }),
-      totalGasUsed: Number(row.total_gas_used ?? 0)
+      })
     }
   }
 

--- a/packages/api/src/models/Document.js
+++ b/packages/api/src/models/Document.js
@@ -13,8 +13,9 @@ module.exports = class Document {
   transitionType
   nonce
   gasUsed
+  totalGasUsed
 
-  constructor (identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, isSystem, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, entropy, nonce) {
+  constructor (identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, isSystem, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, totalGasUsed, entropy, nonce) {
     this.identifier = identifier ? identifier.trim() : null
     this.owner = owner ?? null
     this.dataContractIdentifier = dataContractIdentifier ? dataContractIdentifier.trim() : null
@@ -32,14 +33,15 @@ module.exports = class Document {
     this.prefundedVotingBalance = prefundedVotingBalance ?? null
     this.nonce = nonce ?? null
     this.gasUsed = gasUsed ?? null
+    this.totalGasUsed = totalGasUsed ?? null
   }
 
   // eslint-disable-next-line camelcase
-  static fromRow ({ identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data, timestamp, is_system, document_type_name, transition_type, prefunded_voting_balance, gas_used }) {
-    return new Document(identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data ? JSON.stringify(data) : null, timestamp, is_system, document_type_name, Number(transition_type), prefunded_voting_balance, Number(gas_used))
+  static fromRow ({ identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data, timestamp, is_system, document_type_name, transition_type, prefunded_voting_balance, gas_used, total_gas_used }) {
+    return new Document(identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data ? JSON.stringify(data) : null, timestamp, is_system, document_type_name, Number(transition_type), prefunded_voting_balance, Number(gas_used), Number(total_gas_used))
   }
 
-  static fromObject ({ identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, entropy, prefundedVotingBalance, nonce, gasUsed }) {
-    return new Document(identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, entropy, nonce)
+  static fromObject ({ identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, entropy, prefundedVotingBalance, nonce, gasUsed, totalGasUsed }) {
+    return new Document(identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, totalGasUsed, entropy, nonce)
   }
 }

--- a/packages/api/test/integration/documents.spec.js
+++ b/packages/api/test/integration/documents.spec.js
@@ -246,6 +246,7 @@ describe('Documents routes', () => {
         nonce: null,
         prefundedVotingBalance: null,
         gasUsed: 0,
+        totalGasUsed: null,
         system: null
       }
 
@@ -284,6 +285,7 @@ describe('Documents routes', () => {
           transitionType: document.transition_type,
           prefundedVotingBalance: null,
           gasUsed: null,
+          totalGasUsed: null,
           nonce: null
         }))
 
@@ -333,6 +335,7 @@ describe('Documents routes', () => {
           },
           system: document.is_system,
           gasUsed: null,
+          totalGasUsed: null,
           nonce: null
         }))
 
@@ -369,6 +372,7 @@ describe('Documents routes', () => {
           entropy: null,
           prefundedVotingBalance: null,
           gasUsed: null,
+          totalGasUsed: null,
           nonce: null
         }))
 
@@ -417,6 +421,7 @@ describe('Documents routes', () => {
           system: document.is_system,
           entropy: null,
           prefundedVotingBalance: null,
+          totalGasUsed: null,
           gasUsed: null,
           nonce: null
         }))
@@ -461,6 +466,7 @@ describe('Documents routes', () => {
           system: document.is_system,
           entropy: null,
           prefundedVotingBalance: null,
+          totalGasUsed: null,
           gasUsed: null,
           nonce: null
         }))
@@ -505,6 +511,7 @@ describe('Documents routes', () => {
           system: document.is_system,
           entropy: null,
           prefundedVotingBalance: null,
+          totalGasUsed: null,
           gasUsed: null,
           nonce: null
         }))

--- a/packages/api/test/integration/documents.spec.js
+++ b/packages/api/test/integration/documents.spec.js
@@ -173,6 +173,7 @@ describe('Documents routes', () => {
         system: document.document.is_system,
         nonce: 2,
         gasUsed: null,
+        totalGasUsed: 0,
         transitionType: 0
       }
 
@@ -204,6 +205,7 @@ describe('Documents routes', () => {
         txHash: document.transaction.hash,
         nonce: 2,
         gasUsed: null,
+        totalGasUsed: 0,
         transitionType: 0
       }
 

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -990,7 +990,8 @@ describe('Identities routes', () => {
         system: false,
         transitionType: 0,
         nonce: null,
-        gasUsed: null
+        gasUsed: null,
+        totalGasUsed: null
       }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -1052,7 +1053,8 @@ describe('Identities routes', () => {
           system: false,
           transitionType: 0,
           gasUsed: null,
-          nonce: null
+          nonce: null,
+          totalGasUsed: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -1116,7 +1118,8 @@ describe('Identities routes', () => {
           prefundedVotingBalance: null,
           entropy: null,
           gasUsed: null,
-          nonce: null
+          nonce: null,
+          totalGasUsed: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -1178,7 +1181,8 @@ describe('Identities routes', () => {
           system: false,
           transitionType: 0,
           gasUsed: null,
-          nonce: null
+          nonce: null,
+          totalGasUsed: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -1240,7 +1244,8 @@ describe('Identities routes', () => {
           system: false,
           transitionType: 0,
           gasUsed: null,
-          nonce: null
+          nonce: null,
+          totalGasUsed: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -370,6 +370,7 @@ describe('Other routes', () => {
           ]
         },
         gasUsed: null,
+        totalGasUsed: 0,
         nonce: 2
       }
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -793,6 +793,8 @@ GET /document/FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ?document_type_name=pr
     "parentNameAndLabel": 20000000000
   },
   "typeName": "preorder",
+  "gasUsed": null,
+  "totalGasUsed": 15999780,
   "owner": {
     "identifier": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
     "aliases": [

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -24,6 +24,7 @@ Reference:
 * [Data Contracts](#data-contracts)
 * [Data Contract Transactions](#data-contract-transactions)
 * [Document by Identifier](#document-by-identifier)
+* [Document Revisions](#document-revisions)
 * [Documents by Data Contract](#documents-by-data-contract)
 * [Identity by Identifier](#identity-by-identifier)
 * [Identity by DPNS](#identity-by-dpns)
@@ -31,7 +32,6 @@ Reference:
 * [Identities](#identities)
 * [Data Contracts by Identity](#data-contracts-by-identity)
 * [Documents by Identity](#documents-by-identity)
-* [Document Revisions](#document-revisions)
 * [Transactions By Identity](#transactions-by-identity)
 * [Transfers by Identity](#transfers-by-identity)
 * [Transactions history](#transactions-history)
@@ -863,6 +863,7 @@ GET /document/y5DhJmM4unLTEaKAkMTbQHMoM8hh47ddowKYusgtHwL/revisions
       "transitionType": 0,
       "nonce": null,
       "gasUsed": 78317180,
+      "totalGasUsed": null,
       "owner": {
         "identifier": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
         "aliases": [
@@ -912,6 +913,8 @@ GET /dataContract/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/documents?documen
       "entropy": null,
       "prefundedVotingBalance": null,
       "typeName": "domain",
+      "gasUsed": null,
+      "totalGasUsed": null,
       "owner": {
         "identifier": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
         "aliases": [


### PR DESCRIPTION
# Issue
We need to display total gas used in all revisions on documents
# Things done
* Implemented `total_gas_used` field in query for document by identifier
* Added field in output from endpoint
* Updated some tests and `README.md`