### PR TITLE
Contested Documents List API

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -72,7 +72,7 @@ Reference:
 * [Votes for contested resource](#votes-for-contested-resource)
 * [Contested Resource Value](#contested-resource-value)
 * [Contested Resources](#contested-resources)
-* [Contested Resources Status](#contested-resources-status)
+* [Contested Resources Stats](#contested-resources-stats)
 * [Rate](#rate)
 * [Masternode Votes](#masternode-votes)
 * [Search](#search)
@@ -1672,17 +1672,17 @@ Response codes:
 500: Internal Server Error
 ```
 ___
-### Contested Resources Status
-Return info about status about resource values
+### Contested Resources Stats
+Return info about stats about resource values
 
 ```
-GET /contestedResources/status
+GET /contestedResources/stats
 
 {
     "totalContestedResources": 235,
     "totalPendingContestedResources": 3,
     "totalVotesCount": 426,
-    "endingResourceValue": {
+    "expiringContestedResource": {
         "contenders": null,
         "indexName": null,
         "resourceValue": [

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -71,6 +71,8 @@ Reference:
 * [Transactions gas history](#transactions-gas-history)
 * [Votes for contested resource](#votes-for-contested-resource)
 * [Contested Resource Value](#contested-resource-value)
+* [Contested Resources](#contested-resources)
+* [Contested Resources Status](#contested-resources-status)
 * [Rate](#rate)
 * [Masternode Votes](#masternode-votes)
 * [Search](#search)
@@ -1599,6 +1601,92 @@ Response codes:
 ```
 200: OK
 400: Invalid input, check start/end values
+500: Internal Server Error
+```
+___
+### Contested Resources
+Return set of contested resources
+
+* `page` cannot be less than 1
+* `limit` cannot be more than 100
+
+```
+GET /contestedResources?page=1&limit=10&order=asc
+
+{
+    "resultSet": [
+        {
+            "contenders": null,
+            "indexName": "parentNameAndLabel",
+            "resourceValue": [
+                "dash",
+                "test111"
+            ],
+            "dataContractIdentifier": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+            "prefundedVotingBalance": null,
+            "documentTypeName": "domain",
+            "timestamp": "2024-08-26T22:14:06.680Z",
+            "totalGasUsed": null,
+            "totalDocumentsGasUsed": null,
+            "totalVotesGasUsed": null,
+            "totalCountVotes": null,
+            "totalCountLock": 0,
+            "totalCountAbstain": 0,
+            "totalCountTowardsIdentity": 1,
+            "status": null,
+            "endTimestamp": "2024-09-02T22:14:06.680Z"
+        },
+        ...
+    ],
+    "pagination": {
+        "page": 1,
+        "limit": 10,
+        "total": 195
+    }
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+```
+___
+### Contested Resources Status
+Return info about status about resource values
+
+```
+GET /contestedResources/status
+
+{
+    "totalContestedResources": 235,
+    "totalPendingContestedResources": 3,
+    "totalVotesCount": 426,
+    "endingResourceValue": {
+        "contenders": null,
+        "indexName": null,
+        "resourceValue": [
+            "dash",
+            "t0st010"
+        ],
+        "dataContractIdentifier": null,
+        "prefundedVotingBalance": null,
+        "documentTypeName": null,
+        "timestamp": "2025-02-12T14:08:55.321Z",
+        "totalGasUsed": null,
+        "totalDocumentsGasUsed": null,
+        "totalVotesGasUsed": null,
+        "totalCountVotes": null,
+        "totalCountLock": 0,
+        "totalCountAbstain": 0,
+        "totalCountTowardsIdentity": 0,
+        "status": null,
+        "endTimestamp": "2025-02-19T14:08:55.321Z"
+    }
+}
+```
+Response codes:
+```
+200: OK
 500: Internal Server Error
 ```
 ___

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -3,6 +3,7 @@ const TenderdashRPC = require('./tenderdashRpc')
 let genesisTime
 
 module.exports = {
+  CONTESTED_RESOURCE_VOTE_DEADLINE: Number(process.env.CONTESTED_RESOURCE_VOTE_DEADLINE ?? 25200000),
   WITHDRAWAL_CONTRACT_TYPE: 'withdrawal',
   EPOCH_CHANGE_TIME: Number(process.env.EPOCH_CHANGE_TIME),
   TCP_CONNECT_TIMEOUT: Number(process.env.TCP_CONNECT_TIMEOUT),

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -3,7 +3,7 @@ const TenderdashRPC = require('./tenderdashRpc')
 let genesisTime
 
 module.exports = {
-  CONTESTED_RESOURCE_VOTE_DEADLINE: Number(process.env.CONTESTED_RESOURCE_VOTE_DEADLINE ?? 25200000),
+  CONTESTED_RESOURCE_VOTE_DEADLINE: Number(process.env.CONTESTED_RESOURCE_VOTE_DEADLINE ?? 604800000),
   WITHDRAWAL_CONTRACT_TYPE: 'withdrawal',
   EPOCH_CHANGE_TIME: Number(process.env.EPOCH_CHANGE_TIME),
   TCP_CONNECT_TIMEOUT: Number(process.env.TCP_CONNECT_TIMEOUT),

--- a/packages/api/src/controllers/ContestedResourcesController.js
+++ b/packages/api/src/controllers/ContestedResourcesController.js
@@ -45,6 +45,12 @@ class ContestedResourcesController {
 
     response.send(votes)
   }
+
+  getContestedResourcesStatus = async (request, response) => {
+    const status = await this.contestedResourcesDAO.getContestedResourcesStatus()
+
+    response.send(status)
+  }
 }
 
 module.exports = ContestedResourcesController

--- a/packages/api/src/controllers/ContestedResourcesController.js
+++ b/packages/api/src/controllers/ContestedResourcesController.js
@@ -37,6 +37,14 @@ class ContestedResourcesController {
 
     response.send(votes)
   }
+
+  getContestedResources = async (request, response) => {
+    const { page = 1, limit = 10, order = 'asc' } = request.query
+
+    const votes = await this.contestedResourcesDAO.getContestedResources(Number(page ?? 1), Number(limit ?? 10), order)
+
+    response.send(votes)
+  }
 }
 
 module.exports = ContestedResourcesController

--- a/packages/api/src/dao/ContestedResourcesDAO.js
+++ b/packages/api/src/dao/ContestedResourcesDAO.js
@@ -413,7 +413,7 @@ module.exports = class ContestedDAO {
 
     const [{ resource_value: resourceValue, timestamp }] = rows.filter(row => row.resource_value !== null)
 
-    const endingResourceValue = rows
+    const expiringContestedResource = rows
       .filter(row => row.resourceValue !== null)
       .reduce((accumulator, currentValue) => {
         switch (Number(currentValue.choice ?? -1)) {
@@ -439,7 +439,7 @@ module.exports = class ContestedDAO {
 
     return ContestedResourceStatus.fromObject({
       ...ContestedResourceStatus.fromRow(status),
-      endingResourceValue
+      expiringContestedResource
     })
   }
 }

--- a/packages/api/src/models/ContestedResource.js
+++ b/packages/api/src/models/ContestedResource.js
@@ -57,7 +57,7 @@ module.exports = class ContestedResource {
     return new ContestedResource(contenders, index_name, resource_value, data_contract_identifier?.trim(), prefunded_voting_balance, document_type_name, timestamp, totalGasUsed, totalDocumentsGasUsed, totalVotesGasUsed, totalCountVotes, totalCountLock, totalCountAbstain, totalCountTowardsIdentity, status ? 'finished' : 'pending', endTimestamp)
   }
 
-  static fromObject({contenders, indexName, resourceValue, dataContractIdentifier, prefundedVotingBalance, documentTypeName, timestamp, totalGasUsed, totalDocumentsGasUsed, totalVotesGasUsed, totalCountVotes, totalCountLock, totalCountAbstain, totalCountTowardsIdentity, status, endTimestamp}) {
+  static fromObject ({ contenders, indexName, resourceValue, dataContractIdentifier, prefundedVotingBalance, documentTypeName, timestamp, totalGasUsed, totalDocumentsGasUsed, totalVotesGasUsed, totalCountVotes, totalCountLock, totalCountAbstain, totalCountTowardsIdentity, status, endTimestamp }) {
     return new ContestedResource(contenders, indexName, resourceValue, dataContractIdentifier?.trim(), prefundedVotingBalance, documentTypeName, timestamp, totalGasUsed, totalDocumentsGasUsed, totalVotesGasUsed, totalCountVotes, totalCountLock, totalCountAbstain, totalCountTowardsIdentity, status, endTimestamp)
   }
 }

--- a/packages/api/src/models/ContestedResource.js
+++ b/packages/api/src/models/ContestedResource.js
@@ -56,4 +56,8 @@ module.exports = class ContestedResource {
   }) {
     return new ContestedResource(contenders, index_name, resource_value, data_contract_identifier?.trim(), prefunded_voting_balance, document_type_name, timestamp, totalGasUsed, totalDocumentsGasUsed, totalVotesGasUsed, totalCountVotes, totalCountLock, totalCountAbstain, totalCountTowardsIdentity, status ? 'finished' : 'pending', endTimestamp)
   }
+
+  static fromObject({contenders, indexName, resourceValue, dataContractIdentifier, prefundedVotingBalance, documentTypeName, timestamp, totalGasUsed, totalDocumentsGasUsed, totalVotesGasUsed, totalCountVotes, totalCountLock, totalCountAbstain, totalCountTowardsIdentity, status, endTimestamp}) {
+    return new ContestedResource(contenders, indexName, resourceValue, dataContractIdentifier?.trim(), prefundedVotingBalance, documentTypeName, timestamp, totalGasUsed, totalDocumentsGasUsed, totalVotesGasUsed, totalCountVotes, totalCountLock, totalCountAbstain, totalCountTowardsIdentity, status, endTimestamp)
+  }
 }

--- a/packages/api/src/models/ContestedResourcesStatus.js
+++ b/packages/api/src/models/ContestedResourcesStatus.js
@@ -2,17 +2,17 @@ module.exports = class ContestedResourcesStatus {
   totalContestedResources
   totalPendingContestedResources
   totalVotesCount
-  endingResourceValue
+  expiringContestedResource
 
-  constructor (totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue) {
+  constructor (totalContestedResources, totalPendingContestedResources, totalVotesCount, expiringContestedResource) {
     this.totalContestedResources = totalContestedResources ?? null
     this.totalPendingContestedResources = totalPendingContestedResources ?? null
     this.totalVotesCount = totalVotesCount ?? null
-    this.endingResourceValue = endingResourceValue ?? null
+    this.expiringContestedResource = expiringContestedResource ?? null
   }
 
-  static fromObject ({ totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue }) {
-    return new ContestedResourcesStatus(totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue)
+  static fromObject ({ totalContestedResources, totalPendingContestedResources, totalVotesCount, expiringContestedResource }) {
+    return new ContestedResourcesStatus(totalContestedResources, totalPendingContestedResources, totalVotesCount, expiringContestedResource)
   }
 
   /* eslint-disable camelcase */

--- a/packages/api/src/models/ContestedResourcesStatus.js
+++ b/packages/api/src/models/ContestedResourcesStatus.js
@@ -11,12 +11,12 @@ module.exports = class ContestedResourcesStatus {
     this.endingResourceValue = endingResourceValue ?? null
   }
 
-  static fromObject({totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue}){
+  static fromObject ({ totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue }) {
     return new ContestedResourcesStatus(totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue)
   }
 
-  // eslint-disable-next-line camelcase
-  static fromRow({total_contested_documents_count, pending_contested_documents_count, total_votes_count}){
-    return new ContestedResourcesStatus(Number(total_contested_documents_count??0), Number(pending_contested_documents_count??0), Number(total_votes_count??0))
+  /* eslint-disable camelcase */
+  static fromRow ({ total_contested_documents_count, pending_contested_documents_count, total_votes_count }) {
+    return new ContestedResourcesStatus(Number(total_contested_documents_count ?? 0), Number(pending_contested_documents_count ?? 0), Number(total_votes_count ?? 0))
   }
 }

--- a/packages/api/src/models/ContestedResourcesStatus.js
+++ b/packages/api/src/models/ContestedResourcesStatus.js
@@ -1,0 +1,22 @@
+module.exports = class ContestedResourcesStatus {
+  totalContestedResources
+  totalPendingContestedResources
+  totalVotesCount
+  endingResourceValue
+
+  constructor (totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue) {
+    this.totalContestedResources = totalContestedResources ?? null
+    this.totalPendingContestedResources = totalPendingContestedResources ?? null
+    this.totalVotesCount = totalVotesCount ?? null
+    this.endingResourceValue = endingResourceValue ?? null
+  }
+
+  static fromObject({totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue}){
+    return new ContestedResourcesStatus(totalContestedResources, totalPendingContestedResources, totalVotesCount, endingResourceValue)
+  }
+
+  // eslint-disable-next-line camelcase
+  static fromRow({total_contested_documents_count, pending_contested_documents_count, total_votes_count}){
+    return new ContestedResourcesStatus(Number(total_contested_documents_count??0), Number(pending_contested_documents_count??0), Number(total_votes_count??0))
+  }
+}

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -224,6 +224,11 @@ module.exports = ({
       }
     },
     {
+      path: '/contestedResources/status',
+      method: 'GET',
+      handler: contestedResourcesController.getContestedResourcesStatus,
+    },
+    {
       path: '/identities',
       method: 'GET',
       handler: identitiesController.getIdentities,

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -206,13 +206,21 @@ module.exports = ({
       method: 'GET',
       handler: contestedResourcesController.getContestedResourceVotes,
       schema: {
-        querystring: { $ref: 'paginationOptions#' }
-      },
-      params: {
-        type: 'object',
-        properties: {
-          resourceValue: { type: 'string' }
+        querystring: { $ref: 'paginationOptions#' },
+        params: {
+          type: 'object',
+          properties: {
+            resourceValue: { type: 'string' }
+          }
         }
+      },
+    },
+    {
+      path: '/contestedResources',
+      method: 'GET',
+      handler: contestedResourcesController.getContestedResources,
+      schema: {
+        querystring: { $ref: 'paginationOptions#' }
       }
     },
     {

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -224,7 +224,7 @@ module.exports = ({
       }
     },
     {
-      path: '/contestedResources/status',
+      path: '/contestedResources/stats',
       method: 'GET',
       handler: contestedResourcesController.getContestedResourcesStatus
     },

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -213,7 +213,7 @@ module.exports = ({
             resourceValue: { type: 'string' }
           }
         }
-      },
+      }
     },
     {
       path: '/contestedResources',
@@ -226,7 +226,7 @@ module.exports = ({
     {
       path: '/contestedResources/status',
       method: 'GET',
-      handler: contestedResourcesController.getContestedResourcesStatus,
+      handler: contestedResourcesController.getContestedResourcesStatus
     },
     {
       path: '/identities',

--- a/packages/api/test/integration/contested.spec.js
+++ b/packages/api/test/integration/contested.spec.js
@@ -427,14 +427,14 @@ describe('Contested documents routes', () => {
   })
 
   describe('get contested resources status', async () => {
-    it('should return status of contested resources', async () => {
-      const { body } = await client.get('/contestedResources/status')
+    it('should return stats of contested resources', async () => {
+      const { body } = await client.get('/contestedResources/stats')
 
       const expectedBody = {
         totalContestedResources: 40,
         totalPendingContestedResources: 0,
         totalVotesCount: 40,
-        endingResourceValue: null
+        expiringContestedResource: null
       }
 
       assert.deepEqual(body, expectedBody)
@@ -476,13 +476,13 @@ describe('Contested documents routes', () => {
         state_transition_hash: documentTransaction.hash
       })
 
-      const { body } = await client.get('/contestedResources/status')
+      const { body } = await client.get('/contestedResources/stats')
 
       const expectedBody = {
         totalContestedResources: 41,
         totalPendingContestedResources: 1,
         totalVotesCount: 40,
-        endingResourceValue: {
+        expiringContestedResource: {
           contenders: null,
           indexName: null,
           resourceValue: ['dash', 'xyy'],

--- a/packages/api/test/integration/contested.spec.js
+++ b/packages/api/test/integration/contested.spec.js
@@ -5,6 +5,8 @@ const server = require('../../src/server')
 const fixtures = require('../utils/fixtures')
 const { getKnex } = require('../../src/utils')
 const DAPI = require('../../src/DAPI')
+const { CONTESTED_RESOURCE_VOTE_DEADLINE } = require('../../src/constants')
+const ChoiceEnum = require('../../src/enums/ChoiceEnum')
 
 describe('Contested documents routes', () => {
   let app
@@ -66,7 +68,8 @@ describe('Contested documents routes', () => {
 
     for (let i = 0; i < 10; i++) {
       const block = await fixtures.block(knex, {
-        timestamp: new Date(i)
+        timestamp: new Date(i),
+        height: i + 1
       })
       const contender = await fixtures.identity(knex, {
         block_hash: block.hash
@@ -132,6 +135,78 @@ describe('Contested documents routes', () => {
       })
     }
 
+    for (let i = 0; i < 30; i++) {
+      const block = await fixtures.block(knex, {
+        timestamp: new Date((i + 10) * 100),
+        height: i + 11
+      })
+      const contender = await fixtures.identity(knex, {
+        block_hash: block.hash
+      })
+      const documentTransaction = await fixtures.transaction(knex, {
+        block_hash: block.hash,
+        type: 0,
+        owner: contender.identifier,
+        gas_used: 11
+      })
+
+      const randomName = `${Math.round(Math.random() * 1000)}${Math.round(Math.random() * 1000)}${Math.round(Math.random() * 1000)}`
+
+      const document = await fixtures.document(knex, {
+        owner: contender.identifier,
+        data_contract_id: dataContract.id,
+        data: {
+          label: i % 2 === 0 ? randomName : contestedResources[contestedResources.length - 1].document.data.label,
+          records: {
+            identity: '36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm'
+          },
+          preorderSalt: 'r9uAaZjEz+lsPrpqt+rqGQ+qIxZS40Ci7wkV8cGI7k4=',
+          subdomainRules: {
+            allowSubdomains: false
+          },
+          normalizedLabel: i % 2 === 0 ? randomName : contestedResources[contestedResources.length - 1].document.data.label,
+          parentDomainName: 'dash',
+          normalizedParentDomainName: 'dash'
+        },
+        prefunded_voting_balance: {
+          parentNameAndLabel: 20000000
+        },
+        state_transition_hash: documentTransaction.hash
+      })
+
+      const masternodeIdentity = await fixtures.identity(knex, {
+        block_hash: block.hash
+      })
+
+      const masternodeTransaction = await fixtures.transaction(knex, {
+        block_hash: block.hash,
+        type: 0,
+        owner: masternodeIdentity.identifier,
+        gas_used: 13
+      })
+
+      const masternodeVote = await fixtures.masternodeVote(knex, {
+        state_transition_hash: masternodeTransaction.hash,
+        voter_identity_id: masternodeIdentity.identifier,
+        data_contract_id: dataContract.id,
+        choice: i % 3 === 0 ? 0 : (i % 3 === 1 ? 1 : 2),
+        towards_identity_identifier: i % 3 === 0 ? contender.identifier : undefined,
+        index_values: JSON.stringify(['dash', i % 2 === 0 ? randomName : contestedResources[contestedResources.length - 1].document.data.label]),
+        document_type_name: 'domain',
+        index_name: 'parentNameAndLabel'
+      })
+
+      contestedResources.push({
+        block,
+        contender,
+        documentTransaction,
+        document,
+        masternodeIdentity,
+        masternodeTransaction,
+        masternodeVote
+      })
+    }
+
     mock.method(DAPI.prototype, 'getContestedState', async () => ({ finishedVoteInfo: {} }))
   })
 
@@ -147,16 +222,18 @@ describe('Contested documents routes', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       const expectedResource = {
-        contenders: contestedResources.map(resource => ({
-          identifier: resource.contender.identifier,
-          timestamp: resource.block.timestamp.toISOString(),
-          documentIdentifier: resource.document.identifier,
-          documentStateTransition: resource.document.state_transition_hash,
-          aliases: [],
-          totalCountTowardsIdentity: contestedResources.filter(res => res.masternodeVote.towards_identity_identifier === resource.contender.identifier).length,
-          abstainVotes: 3,
-          lockVotes: 7 - contestedResources.filter(res => res.masternodeVote.towards_identity_identifier === resource.contender.identifier).length
-        })),
+        contenders: contestedResources
+          .filter(resource => resource.document.data.label === 'xyz')
+          .map(resource => ({
+            identifier: resource.contender.identifier,
+            timestamp: resource.block.timestamp.toISOString(),
+            documentIdentifier: resource.document.identifier,
+            documentStateTransition: resource.document.state_transition_hash,
+            aliases: [],
+            totalCountTowardsIdentity: contestedResources.filter(res => res.masternodeVote.towards_identity_identifier === resource.contender.identifier).length,
+            abstainVotes: 3,
+            lockVotes: 7 - contestedResources.filter(res => res.masternodeVote.towards_identity_identifier === resource.contender.identifier).length
+          })),
         indexName: 'parentNameAndLabel',
         resourceValue: ['dash', 'xyz'],
         dataContractIdentifier: dataContract.identifier,
@@ -168,12 +245,12 @@ describe('Contested documents routes', () => {
         totalGasUsed: 240,
         totalDocumentsGasUsed: 110,
         totalVotesGasUsed: 130,
-        totalCountVotes: contestedResources.length,
+        totalCountVotes: contestedResources.filter(resource => resource.document.data.label === 'xyz').length,
         totalCountLock: 3,
         totalCountAbstain: 3,
         totalCountTowardsIdentity: 4,
         status: 'finished',
-        endTimestamp: null
+        endTimestamp: new Date(contestedResources[0].block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString()
       }
 
       assert.deepEqual(body, expectedResource)
@@ -222,6 +299,7 @@ describe('Contested documents routes', () => {
       assert.equal(body.pagination.page, 1)
 
       const expectedVotes = contestedResources
+        .filter(resource => resource.document.data.label === 'xyz')
         .filter(vote => (vote.masternodeVote.choice === 2))
         .sort((a, b) => a.masternodeVote.id - b.masternodeVote.id)
         .slice(0, 10)
@@ -241,6 +319,110 @@ describe('Contested documents routes', () => {
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
+    })
+  })
+
+  describe('getContestedResources()', async () => {
+    it('should return default set on contested resources', async () => {
+      const { body } = await client.get('/contestedResources')
+
+      const uniqueResources = contestedResources
+        .sort((a, b) => a.block.height - b.block.height)
+        .filter((item, pos, self) => self
+          .findIndex((resource) => resource.document.data.label === self[pos].document.data.label) === pos
+        )
+
+      const expectedResources = uniqueResources
+        .sort((a, b) => a.block.height - b.block.height)
+        .slice(0, 10)
+        .map((resource) => ({
+          contenders: null,
+          indexName: resource.masternodeVote.index_name,
+          resourceValue: JSON.parse(resource.masternodeVote.index_values),
+          dataContractIdentifier: dataContract.identifier,
+          prefundedVotingBalance: null,
+          documentTypeName: resource.document.document_type_name,
+          timestamp: resource.block.timestamp.toISOString(),
+          totalGasUsed: null,
+          totalVotesGasUsed: null,
+          totalCountVotes: null,
+          totalDocumentsGasUsed: null,
+          totalCountLock: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.LOCK).length,
+          totalCountAbstain: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.ABSTAIN).length,
+          totalCountTowardsIdentity: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.TowardsIdentity).length,
+          status: null,
+          endTimestamp: new Date(resource.block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString()
+        }))
+
+      assert.deepEqual(body.resultSet, expectedResources)
+    })
+
+    it('should return default set on contested resources with desc order', async () => {
+      const { body } = await client.get('/contestedResources?order=desc')
+
+      const uniqueResources = contestedResources
+        .sort((a, b) => b.block.height - a.block.height)
+        .filter((item, pos, self) => self
+          .findIndex((resource) => resource.document.data.label === self[pos].document.data.label) === pos
+        )
+
+      const expectedResources = uniqueResources
+        .sort((a, b) => b.block.height - a.block.height)
+        .slice(0, 10)
+        .map((resource) => ({
+          contenders: null,
+          indexName: resource.masternodeVote.index_name,
+          resourceValue: JSON.parse(resource.masternodeVote.index_values),
+          dataContractIdentifier: dataContract.identifier,
+          prefundedVotingBalance: null,
+          documentTypeName: resource.document.document_type_name,
+          timestamp: resource.block.timestamp.toISOString(),
+          totalGasUsed: null,
+          totalVotesGasUsed: null,
+          totalCountVotes: null,
+          totalDocumentsGasUsed: null,
+          totalCountLock: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.LOCK).length,
+          totalCountAbstain: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.ABSTAIN).length,
+          totalCountTowardsIdentity: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.TowardsIdentity).length,
+          status: null,
+          endTimestamp: new Date(resource.block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString()
+        }))
+
+      assert.deepEqual(body.resultSet, expectedResources)
+    })
+
+    it('should return default set on contested resources with desc order and custom page size', async () => {
+      const { body } = await client.get('/contestedResources?order=desc&page=2&limit=5')
+
+      const uniqueResources = contestedResources
+        .sort((a, b) => b.block.height - a.block.height)
+        .filter((item, pos, self) => self
+          .findIndex((resource) => resource.document.data.label === self[pos].document.data.label) === pos
+        )
+
+      const expectedResources = uniqueResources
+        .sort((a, b) => b.block.height - a.block.height)
+        .slice(5, 10)
+        .map((resource) => ({
+          contenders: null,
+          indexName: resource.masternodeVote.index_name,
+          resourceValue: JSON.parse(resource.masternodeVote.index_values),
+          dataContractIdentifier: dataContract.identifier,
+          prefundedVotingBalance: null,
+          documentTypeName: resource.document.document_type_name,
+          timestamp: resource.block.timestamp.toISOString(),
+          totalGasUsed: null,
+          totalVotesGasUsed: null,
+          totalCountVotes: null,
+          totalDocumentsGasUsed: null,
+          totalCountLock: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.LOCK).length,
+          totalCountAbstain: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.ABSTAIN).length,
+          totalCountTowardsIdentity: contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.TowardsIdentity).length,
+          status: null,
+          endTimestamp: new Date(resource.block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString()
+        }))
+
+      assert.deepEqual(body.resultSet, expectedResources)
     })
   })
 })

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -38,6 +38,8 @@ Reference:
 * [Transactions gas history](#transactions-gas-history)
 * [Votes for contested resource](#votes-for-contested-resource)
 * [Contested Resource Value](#contested-resource-value)
+* [Contested Resources](#contested-resources)
+* [Contested Resources Status](#contested-resources-status)
 * [Rate](#rate)
 * [Masternode Votes](#masternode-votes)
 * [Search](#search)
@@ -1566,6 +1568,92 @@ Response codes:
 ```
 200: OK
 400: Invalid input, check start/end values
+500: Internal Server Error
+```
+___
+### Contested Resources
+Return set of contested resources
+
+* `page` cannot be less than 1
+* `limit` cannot be more than 100
+
+```
+GET /contestedResources?page=1&limit=10&order=asc
+
+{
+    "resultSet": [
+        {
+            "contenders": null,
+            "indexName": "parentNameAndLabel",
+            "resourceValue": [
+                "dash",
+                "test111"
+            ],
+            "dataContractIdentifier": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+            "prefundedVotingBalance": null,
+            "documentTypeName": "domain",
+            "timestamp": "2024-08-26T22:14:06.680Z",
+            "totalGasUsed": null,
+            "totalDocumentsGasUsed": null,
+            "totalVotesGasUsed": null,
+            "totalCountVotes": null,
+            "totalCountLock": 0,
+            "totalCountAbstain": 0,
+            "totalCountTowardsIdentity": 1,
+            "status": null,
+            "endTimestamp": "2024-09-02T22:14:06.680Z"
+        },
+        ...
+    ],
+    "pagination": {
+        "page": 1,
+        "limit": 10,
+        "total": 195
+    }
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+```
+___
+### Contested Resources Status
+Return info about status about resource values
+
+```
+GET /contestedResources/status
+
+{
+    "totalContestedResources": 235,
+    "totalPendingContestedResources": 3,
+    "totalVotesCount": 426,
+    "endingResourceValue": {
+        "contenders": null,
+        "indexName": null,
+        "resourceValue": [
+            "dash",
+            "t0st010"
+        ],
+        "dataContractIdentifier": null,
+        "prefundedVotingBalance": null,
+        "documentTypeName": null,
+        "timestamp": "2025-02-12T14:08:55.321Z",
+        "totalGasUsed": null,
+        "totalDocumentsGasUsed": null,
+        "totalVotesGasUsed": null,
+        "totalCountVotes": null,
+        "totalCountLock": 0,
+        "totalCountAbstain": 0,
+        "totalCountTowardsIdentity": 0,
+        "status": null,
+        "endTimestamp": "2025-02-19T14:08:55.321Z"
+    }
+}
+```
+Response codes:
+```
+200: OK
 500: Internal Server Error
 ```
 ___

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -39,7 +39,7 @@ Reference:
 * [Votes for contested resource](#votes-for-contested-resource)
 * [Contested Resource Value](#contested-resource-value)
 * [Contested Resources](#contested-resources)
-* [Contested Resources Status](#contested-resources-status)
+* [Contested Resources Stats](#contested-resources-stats)
 * [Rate](#rate)
 * [Masternode Votes](#masternode-votes)
 * [Search](#search)
@@ -1639,17 +1639,17 @@ Response codes:
 500: Internal Server Error
 ```
 ___
-### Contested Resources Status
-Return info about status about resource values
+### Contested Resources Stats
+Return info about stats about resource values
 
 ```
-GET /contestedResources/status
+GET /contestedResources/stats
 
 {
     "totalContestedResources": 235,
     "totalPendingContestedResources": 3,
     "totalVotesCount": 426,
-    "endingResourceValue": {
+    "expiringContestedResource": {
         "contenders": null,
         "indexName": null,
         "resourceValue": [


### PR DESCRIPTION
# Issue
For new design we need new endpoint for list of all contested resources

# Things done
* Implemented new request, which allows to get response by 10-30% faster, then for one contested resource
* Implemented status request for contested resources
* Added new model for contested resources status
* Added new env var `CONTESTED_RESOURCE_VOTE_DEADLINE` which contains dealine for voting in ms, by default equal 1 week
* Added calculations of voting end for contested resources
* Added new tests for new endpoints
* Updated README.md