### PR TITLE
Fix for Resource Value convertation

### DIFF
--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -433,7 +433,7 @@ const iso8601duration = function (milliseconds) {
 
 const buildIndexBuffer = (name) => {
   const lengthBuffer = Buffer.alloc(1)
-  lengthBuffer.writeUInt8(name.length.toString(16), 0)
+  lengthBuffer.writeUInt8(name.length, 0)
 
   return Buffer.concat(
     [

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -12,6 +12,7 @@ const identityWithdrawal = require('./mocks/identity_withdrawal.json')
 const masternodeVote = require('./mocks/masternode_vote.json')
 const Dash = require('dash')
 const Alias = require('../../src/models/Alias')
+const { buildIndexBuffer } = require('../../src/utils')
 
 describe('Utils', () => {
   let client
@@ -332,6 +333,24 @@ describe('Utils', () => {
         userFeeIncrease: 0,
         nonce: 16
       })
+    })
+  })
+
+  describe('buildIndexBuffer()', () => {
+    it('should build buffer for short value', async () => {
+      const value = 'dash'
+
+      const buildedValue = buildIndexBuffer(value).toString('base64')
+
+      assert.deepEqual(buildedValue, 'EgRkYXNo')
+    })
+
+    it('should build buffer for long value', async () => {
+      const value = 'qu1ntup1ec0asta1'
+
+      const buildedValue = buildIndexBuffer(value).toString('base64')
+
+      assert.deepEqual(buildedValue, 'EhBxdTFudHVwMWVjMGFzdGEx')
     })
   })
   describe('getAliasStateByVote()', () => {


### PR DESCRIPTION
# Issue
We started noticing a lot of status failures for aliases recently, so a little investigation was done to find the bug that led us to the error of converting a normalized name to a buffer with the format `\x12\x4dash`. The error was related to the conversion of values between number systems, which caused a number of names to be displayed incorrectly
# Things done
* Fixed mistake
* Added new tests