### PR TITLE
Fix alias render in document info

### DIFF
--- a/packages/frontend/src/app/document/[identifier]/Document.js
+++ b/packages/frontend/src/app/document/[identifier]/Document.js
@@ -78,7 +78,7 @@ function Document ({ identifier }) {
                                     <LoadingLine loading={document.loading}>
                                         <Link href={`/identity/${document.data?.owner?.identifier}`}>
                                           {activeAlias
-                                            ? <Alias avatarSource={document.data?.owner?.identifier}>activeAlias.alias</Alias>
+                                            ? <Alias avatarSource={document.data?.owner?.identifier}>{activeAlias.alias}</Alias>
                                             : <Identifier ellipsis={true} styles={['highlight-both']}>{document.data?.owner?.identifier}</Identifier>
                                           }
                                         </Link>


### PR DESCRIPTION
# Issue
Due to a typo, the alias on the document page is displayed incorrectly

# Things done
Fixed