### PR TITLE
Data Contracts document count fix and identities aliases

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -692,22 +692,42 @@ Return data contract by given identifier
 * `name` field is nullable
 
 ```
-GET /dataContract/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
+GET /dataContract/H4wBXB2RCu58EP7H7gGyehVmD7ij5MLZkAXW9SVUGPYb
 
 {
-  "identifier": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
-  "name": "DPNS",
-  "owner": "11111111111111111111111111111111",
-  "schema": "{\"domain\":{\"type\":\"object\",\"indices\":[{\"name\":\"parentNameAndLabel\",\"unique\":true,\"contested\":{\"resolution\":0,\"description\":\"If the normalized label part of this index is less than 20 characters (all alphabet a-z, A-Z, 0, 1, and -) then a masternode vote contest takes place to give out the name\",\"fieldMatches\":[{\"field\":\"normalizedLabel\",\"regexPattern\":\"^[a-zA-Z01-]{3,19}$\"}]},\"properties\":[{\"normalizedParentDomainName\":\"asc\"},{\"normalizedLabel\":\"asc\"}]},{\"name\":\"identityId\",\"properties\":[{\"records.identity\":\"asc\"}],\"nullSearchable\":false}],\"$comment\":\"In order to register a domain you need to create a preorder. The preorder step is needed to prevent man-in-the-middle attacks. normalizedLabel + '.' + normalizedParentDomain must not be longer than 253 chars length as defined by RFC 1035. Domain documents are immutable: modification and deletion are restricted\",\"required\":[\"$createdAt\",\"$updatedAt\",\"$transferredAt\",\"label\",\"normalizedLabel\",\"normalizedParentDomainName\",\"preorderSalt\",\"records\",\"subdomainRules\"],\"tradeMode\":1,\"transient\":[\"preorderSalt\"],\"properties\":{\"label\":{\"type\":\"string\",\"pattern\":\"^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$\",\"position\":0,\"maxLength\":63,\"minLength\":3,\"description\":\"Domain label. e.g. 'Bob'.\"},\"records\":{\"type\":\"object\",\"position\":5,\"properties\":{\"identity\":{\"type\":\"array\",\"maxItems\":32,\"minItems\":32,\"position\":1,\"byteArray\":true,\"description\":\"Identifier name record that refers to an Identity\",\"contentMediaType\":\"application/x.dash.dpp.identifier\"}},\"minProperties\":1,\"additionalProperties\":false},\"preorderSalt\":{\"type\":\"array\",\"maxItems\":32,\"minItems\":32,\"position\":4,\"byteArray\":true,\"description\":\"Salt used in the preorder document\"},\"subdomainRules\":{\"type\":\"object\",\"position\":6,\"required\":[\"allowSubdomains\"],\"properties\":{\"allowSubdomains\":{\"type\":\"boolean\",\"$comment\":\"Only the domain owner is allowed to create subdomains for non top-level domains\",\"position\":0,\"description\":\"This option defines who can create subdomains: true - anyone; false - only the domain owner\"}},\"description\":\"Subdomain rules allow domain owners to define rules for subdomains\",\"additionalProperties\":false},\"normalizedLabel\":{\"type\":\"string\",\"pattern\":\"^[a-hj-km-np-z0-9][a-hj-km-np-z0-9-]{0,61}[a-hj-km-np-z0-9]$\",\"$comment\":\"Must be equal to the label in lowercase. \\\"o\\\", \\\"i\\\" and \\\"l\\\" must be replaced with \\\"0\\\" and \\\"1\\\".\",\"position\":1,\"maxLength\":63,\"description\":\"Domain label converted to lowercase for case-insensitive uniqueness validation. \\\"o\\\", \\\"i\\\" and \\\"l\\\" replaced with \\\"0\\\" and \\\"1\\\" to mitigate homograph attack. e.g. 'b0b'\"},\"parentDomainName\":{\"type\":\"string\",\"pattern\":\"^$|^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$\",\"position\":2,\"maxLength\":63,\"minLength\":0,\"description\":\"A full parent domain name. e.g. 'dash'.\"},\"normalizedParentDomainName\":{\"type\":\"string\",\"pattern\":\"^$|^[a-hj-km-np-z0-9][a-hj-km-np-z0-9-\\\\.]{0,61}[a-hj-km-np-z0-9]$\",\"$comment\":\"Must either be equal to an existing domain or empty to create a top level domain. \\\"o\\\", \\\"i\\\" and \\\"l\\\" must be replaced with \\\"0\\\" and \\\"1\\\". Only the data contract owner can create top level domains.\",\"position\":3,\"maxLength\":63,\"minLength\":0,\"description\":\"A parent domain name in lowercase for case-insensitive uniqueness validation. \\\"o\\\", \\\"i\\\" and \\\"l\\\" replaced with \\\"0\\\" and \\\"1\\\" to mitigate homograph attack. e.g. 'dash'\"}},\"canBeDeleted\":true,\"transferable\":1,\"documentsMutable\":false,\"additionalProperties\":false},\"preorder\":{\"type\":\"object\",\"indices\":[{\"name\":\"saltedHash\",\"unique\":true,\"properties\":[{\"saltedDomainHash\":\"asc\"}]}],\"$comment\":\"Preorder documents are immutable: modification and deletion are restricted\",\"required\":[\"saltedDomainHash\"],\"properties\":{\"saltedDomainHash\":{\"type\":\"array\",\"maxItems\":32,\"minItems\":32,\"position\":0,\"byteArray\":true,\"description\":\"Double sha-256 of the concatenation of a 32 byte random salt and a normalized domain name\"}},\"canBeDeleted\":true,\"documentsMutable\":false,\"additionalProperties\":false}}",
-  "version": 0,
-  "txHash": null,
-  "timestamp": null,
-  "isSystem": true,
-  "documentsCount": 593,
-  "topIdentity": "BNnn19SAJZuvsUu787dMzPDXASwuCrm4yQ864tEpQFvo",
-  "identitiesInteracted": 136,
-  "totalGasUsed": 19706727280,
-  "averageGasUsed": 33176309
+  "identifier": "H4wBXB2RCu58EP7H7gGyehVmD7ij5MLZkAXW9SVUGPYb",
+  "name": null,
+  "owner": {
+    "identifier": "Atx8CpmKMgDvxWXrRfgCJ44GmUSPiB1qXkfoyotttHd",
+    "aliases": [
+      {
+        "alias": "ajcwebdev20250128.dash",
+        "status": "ok",
+        "contested": false,
+        "timestamp": null
+      }
+    ]
+  },
+  "schema": "{\"note\":{\"type\":\"object\",\"properties\":{\"author\":{\"type\":\"string\",\"position\":1},\"message\":{\"type\":\"string\",\"position\":0}},\"additionalProperties\":false}}",
+  "version": 2,
+  "txHash": "90525E94FFCDA0C55053E0E4629862CF57D3264462E8CC25A8B55CDAD3B601B2",
+  "timestamp": "2025-01-31T00:30:08.174Z",
+  "isSystem": false,
+  "documentsCount": 1,
+  "topIdentity": {
+    "identifier": "Atx8CpmKMgDvxWXrRfgCJ44GmUSPiB1qXkfoyotttHd",
+    "aliases": [
+      {
+        "alias": "ajcwebdev20250128.dash",
+        "status": "ok",
+        "contested": false,
+        "timestamp": null
+      }
+    ]
+  },
+  "identitiesInteracted": 1,
+  "totalGasUsed": 51529650,
+  "averageGasUsed": 10305930
 }
 ```
 Response codes:

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -690,6 +690,7 @@ Response codes:
 Return data contract by given identifier
 
 * `name` field is nullable
+* `topIdentity` - identity with the largest number of documents
 
 ```
 GET /dataContract/H4wBXB2RCu58EP7H7gGyehVmD7ij5MLZkAXW9SVUGPYb

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -13,7 +13,7 @@ const API_VERSION = require('../../package.json').version
 class MainController {
   constructor (knex, dapi, client) {
     this.blocksDAO = new BlocksDAO(knex, dapi)
-    this.dataContractsDAO = new DataContractsDAO(knex)
+    this.dataContractsDAO = new DataContractsDAO(knex, client, dapi)
     this.documentsDAO = new DocumentsDAO(knex, dapi, client)
     this.transactionsDAO = new TransactionsDAO(knex, dapi)
     this.identitiesDAO = new IdentitiesDAO(knex, dapi, client)

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -25,7 +25,7 @@ module.exports = class DataContractsDAO {
     }
 
     const sumDocuments = this.knex('documents')
-      .select('documents.id', 'data_contracts.identifier as dc_identifier', 'documents.data_contract_id')
+      .select('documents.id', 'data_contracts.identifier as dc_identifier', 'documents.data_contract_id', 'revision')
       .leftJoin('data_contracts', 'data_contracts.id', 'documents.data_contract_id')
       .as('sum_documents')
 
@@ -37,6 +37,7 @@ module.exports = class DataContractsDAO {
       .select(this.knex(sumDocuments)
         .count('*')
         .whereRaw('data_contracts.identifier = sum_documents.dc_identifier')
+        .andWhere('revision', '=', '1')
         .as('documents_count'))
       .select(this.knex.raw('rank() over (partition by identifier order by version desc) rank'))
 
@@ -65,6 +66,10 @@ module.exports = class DataContractsDAO {
   }
 
   getDataContractByIdentifier = async (identifier) => {
+    const aliasesSubquery = this.knex('identity_aliases')
+      .select('identity_identifier', this.knex.raw('array_agg(alias) as aliases'))
+      .groupBy('identity_identifier')
+
     const identitiesSubquery = this.knex('documents')
       .select(this.knex.raw('COUNT(*) OVER(PARTITION BY documents.owner) as documents_count'))
       .select('documents.owner as identity')
@@ -82,12 +87,10 @@ module.exports = class DataContractsDAO {
       .select('documents.state_transition_hash as state_transition_hash')
       .where('data_contracts.identifier', '=', identifier)
       .leftJoin('data_contracts', 'data_contracts.id', 'documents.data_contract_id')
-    // .as('documents_txs')
 
     const dataContractsTransactionsSubquery = this.knex('data_contracts')
       .select('state_transition_hash')
       .where('identifier', '=', identifier)
-    // .as('data_contracts_txs')
 
     const unionTransactionsSubquery = this.knex
       .union([documentsTransactionsSubquery, dataContractsTransactionsSubquery])
@@ -98,7 +101,7 @@ module.exports = class DataContractsDAO {
       .select(this.knex.raw('count(*) as total_count'))
       .leftJoin('state_transitions', 'hash', 'state_transition_hash')
 
-    const rows = await this.knex('data_contracts')
+    const dataSubquery = this.knex('data_contracts')
       .with('gas_sub', gasSubquery)
       .select('data_contracts.identifier as identifier', 'data_contracts.name as name', 'data_contracts.owner as owner',
         'data_contracts.schema as schema', 'data_contracts.is_system as is_system',
@@ -116,14 +119,50 @@ module.exports = class DataContractsDAO {
       .where('data_contracts.identifier', identifier)
       .orderBy('data_contracts.id', 'desc')
       .limit(1)
+      .as('data_sub')
+
+    const rows = await this.knex(dataSubquery)
+      .with('aliases_subquery', aliasesSubquery)
+      .select('identifier', 'owner', 'name', 'schema', 'is_system', 'version', 'tx_hash', 'timestamp',
+        'documents_count', 'top_identity', 'identities_interacted', 'total_gas_used', 'average_gas_used')
+      .select(this.knex('aliases_subquery').select('aliases').whereRaw('identity_identifier = owner').limit(1).as('owner_aliases'))
+      .select(this.knex('aliases_subquery').select('aliases').whereRaw('identity_identifier = top_identity').limit(1).as('top_identity_aliases'))
 
     const [row] = rows
+
+    const ownerAliases = await Promise.all((row.owner_aliases ?? []).map(async alias => {
+      const aliasInfo = await getAliasInfo(alias, this.dapi)
+
+      return getAliasStateByVote(aliasInfo, { alias }, row.owner)
+    }))
+
+    let topIdentityAliases = []
+
+    if (row.owner === row.top_identity) {
+      topIdentityAliases = ownerAliases
+    } else {
+      topIdentityAliases = await Promise.all((row.top_identity_aliases ?? []).map(async alias => {
+        const aliasInfo = await getAliasInfo(alias, this.dapi)
+
+        return getAliasStateByVote(aliasInfo, { alias }, row.owner)
+      }))
+    }
 
     if (!row) {
       return null
     }
 
-    return DataContract.fromRow(row)
+    return DataContract.fromRow({
+      ...row,
+      owner: {
+        identifier: row.owner?.trim(),
+        aliases: ownerAliases
+      },
+      top_identity: {
+        identifier: row.top_identity?.trim(),
+        aliases: topIdentityAliases
+      }
+    })
   }
 
   getDataContractTransactions = async (identifier, page, limit, order) => {

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -130,6 +130,10 @@ module.exports = class DataContractsDAO {
 
     const [row] = rows
 
+    if (!row) {
+      return null
+    }
+
     const ownerAliases = await Promise.all((row.owner_aliases ?? []).map(async alias => {
       const aliasInfo = await getAliasInfo(alias, this.dapi)
 
@@ -148,18 +152,14 @@ module.exports = class DataContractsDAO {
       }))
     }
 
-    if (!row) {
-      return null
-    }
-
     return DataContract.fromRow({
       ...row,
       owner: {
-        identifier: row.owner?.trim(),
+        identifier: row.owner?.trim() ?? null,
         aliases: ownerAliases
       },
       top_identity: {
-        identifier: row.top_identity?.trim(),
+        identifier: row.top_identity?.trim() ?? null,
         aliases: topIdentityAliases
       }
     })

--- a/packages/api/src/models/DataContract.js
+++ b/packages/api/src/models/DataContract.js
@@ -16,14 +16,14 @@ module.exports = class DataContract {
   constructor (identifier, name, owner, schema, version, txHash, timestamp, isSystem, documentsCount, topIdentity, identitiesInteracted, totalGasUsed, averageGasUsed) {
     this.identifier = identifier ? identifier.trim() : null
     this.name = name ? name.trim() : null
-    this.owner = owner ? owner.trim() : null
+    this.owner = owner ?? null
     this.schema = schema ?? null
     this.version = version ?? null
     this.txHash = txHash ?? null
     this.timestamp = timestamp ?? null
     this.isSystem = isSystem ?? null
     this.documentsCount = documentsCount ?? null
-    this.topIdentity = topIdentity ? topIdentity.trim() : null
+    this.topIdentity = topIdentity ?? null
     this.identitiesInteracted = identitiesInteracted ?? null
     this.totalGasUsed = totalGasUsed ?? null
     this.averageGasUsed = averageGasUsed ?? null

--- a/packages/api/src/models/DataContract.js
+++ b/packages/api/src/models/DataContract.js
@@ -29,8 +29,8 @@ module.exports = class DataContract {
     this.averageGasUsed = averageGasUsed ?? null
   }
 
-  // eslint-disable-next-line camelcase
+  /* eslint-disable camelcase */
   static fromRow ({ identifier, name, owner, schema, version, tx_hash, timestamp, is_system, documents_count, top_identity, identities_interacted, total_gas_used, average_gas_used }) {
-    return new DataContract(identifier, name, owner, schema ? JSON.stringify(schema) : null, version, tx_hash, timestamp, is_system, Number(documents_count), top_identity, Number(identities_interacted), Number(total_gas_used), Number(average_gas_used))
+    return new DataContract(identifier, name, typeof owner === 'string' ? owner.trim() : owner, schema ? JSON.stringify(schema) : null, version, tx_hash, timestamp, is_system, Number(documents_count), typeof top_identity === 'string' ? top_identity.trim() : top_identity, Number(identities_interacted), Number(total_gas_used), Number(average_gas_used))
   }
 }

--- a/packages/api/test/integration/data.contracts.spec.js
+++ b/packages/api/test/integration/data.contracts.spec.js
@@ -300,7 +300,10 @@ describe('DataContracts routes', () => {
       const expectedDataContract = {
         identifier: dataContract.dataContract.identifier,
         name: dataContract.dataContract.name,
-        owner: identity.identifier,
+        owner: {
+          identifier: identity.identifier.trim(),
+          aliases: []
+        },
         schema: '{}',
         version: 0,
         txHash: null,
@@ -309,7 +312,10 @@ describe('DataContracts routes', () => {
         documentsCount: 0,
         averageGasUsed: 0,
         identitiesInteracted: 0,
-        topIdentity: null,
+        topIdentity: {
+          identifier: null,
+          aliases: []
+        },
         totalGasUsed: 0
       }
 
@@ -326,7 +332,10 @@ describe('DataContracts routes', () => {
       const expectedDataContract = {
         identifier: dataContract.dataContract.identifier,
         name: dataContract.dataContract.name,
-        owner: identity.identifier,
+        owner: {
+          identifier: identity.identifier.trim(),
+          aliases: []
+        },
         schema: '{}',
         version: dataContract.dataContract.version,
         txHash: dataContract.transaction.hash,
@@ -335,7 +344,10 @@ describe('DataContracts routes', () => {
         documentsCount: dataContract.dataContract.documents.length,
         averageGasUsed: 0,
         identitiesInteracted: 1,
-        topIdentity: dataContract.dataContract.owner,
+        topIdentity: {
+          identifier: dataContract.dataContract.owner.trim(),
+          aliases: []
+        },
         totalGasUsed: 0
       }
 

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -300,7 +300,17 @@ describe('Other routes', () => {
       const expectedDataContract = {
         identifier: dataContract.identifier,
         name: dataContract.name,
-        owner: identity.identifier.trim(),
+        owner: {
+          identifier: identity.identifier.trim(),
+          aliases: [
+            {
+              alias: 'dpns.dash',
+              contested: false,
+              status: 'ok',
+              timestamp: null
+            }
+          ]
+        },
         schema: JSON.stringify(dataContract.schema),
         version: 0,
         txHash: dataContractTransaction.hash,
@@ -310,7 +320,17 @@ describe('Other routes', () => {
         averageGasUsed: 0,
         identitiesInteracted: 1,
         totalGasUsed: 0,
-        topIdentity: dataContract.owner
+        topIdentity: {
+          identifier: identity.identifier.trim(),
+          aliases: [
+            {
+              alias: 'dpns.dash',
+              contested: false,
+              status: 'ok',
+              timestamp: null
+            }
+          ]
+        }
       }
 
       assert.deepEqual({ dataContract: expectedDataContract }, body)

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -659,22 +659,42 @@ Return data contract by given identifier
 * `name` field is nullable
 
 ```
-GET /dataContract/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec
+GET /dataContract/H4wBXB2RCu58EP7H7gGyehVmD7ij5MLZkAXW9SVUGPYb
 
 {
-  "identifier": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
-  "name": "DPNS",
-  "owner": "11111111111111111111111111111111",
-  "schema": "{\"domain\":{\"type\":\"object\",\"indices\":[{\"name\":\"parentNameAndLabel\",\"unique\":true,\"contested\":{\"resolution\":0,\"description\":\"If the normalized label part of this index is less than 20 characters (all alphabet a-z, A-Z, 0, 1, and -) then a masternode vote contest takes place to give out the name\",\"fieldMatches\":[{\"field\":\"normalizedLabel\",\"regexPattern\":\"^[a-zA-Z01-]{3,19}$\"}]},\"properties\":[{\"normalizedParentDomainName\":\"asc\"},{\"normalizedLabel\":\"asc\"}]},{\"name\":\"identityId\",\"properties\":[{\"records.identity\":\"asc\"}],\"nullSearchable\":false}],\"$comment\":\"In order to register a domain you need to create a preorder. The preorder step is needed to prevent man-in-the-middle attacks. normalizedLabel + '.' + normalizedParentDomain must not be longer than 253 chars length as defined by RFC 1035. Domain documents are immutable: modification and deletion are restricted\",\"required\":[\"$createdAt\",\"$updatedAt\",\"$transferredAt\",\"label\",\"normalizedLabel\",\"normalizedParentDomainName\",\"preorderSalt\",\"records\",\"subdomainRules\"],\"tradeMode\":1,\"transient\":[\"preorderSalt\"],\"properties\":{\"label\":{\"type\":\"string\",\"pattern\":\"^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$\",\"position\":0,\"maxLength\":63,\"minLength\":3,\"description\":\"Domain label. e.g. 'Bob'.\"},\"records\":{\"type\":\"object\",\"position\":5,\"properties\":{\"identity\":{\"type\":\"array\",\"maxItems\":32,\"minItems\":32,\"position\":1,\"byteArray\":true,\"description\":\"Identifier name record that refers to an Identity\",\"contentMediaType\":\"application/x.dash.dpp.identifier\"}},\"minProperties\":1,\"additionalProperties\":false},\"preorderSalt\":{\"type\":\"array\",\"maxItems\":32,\"minItems\":32,\"position\":4,\"byteArray\":true,\"description\":\"Salt used in the preorder document\"},\"subdomainRules\":{\"type\":\"object\",\"position\":6,\"required\":[\"allowSubdomains\"],\"properties\":{\"allowSubdomains\":{\"type\":\"boolean\",\"$comment\":\"Only the domain owner is allowed to create subdomains for non top-level domains\",\"position\":0,\"description\":\"This option defines who can create subdomains: true - anyone; false - only the domain owner\"}},\"description\":\"Subdomain rules allow domain owners to define rules for subdomains\",\"additionalProperties\":false},\"normalizedLabel\":{\"type\":\"string\",\"pattern\":\"^[a-hj-km-np-z0-9][a-hj-km-np-z0-9-]{0,61}[a-hj-km-np-z0-9]$\",\"$comment\":\"Must be equal to the label in lowercase. \\\"o\\\", \\\"i\\\" and \\\"l\\\" must be replaced with \\\"0\\\" and \\\"1\\\".\",\"position\":1,\"maxLength\":63,\"description\":\"Domain label converted to lowercase for case-insensitive uniqueness validation. \\\"o\\\", \\\"i\\\" and \\\"l\\\" replaced with \\\"0\\\" and \\\"1\\\" to mitigate homograph attack. e.g. 'b0b'\"},\"parentDomainName\":{\"type\":\"string\",\"pattern\":\"^$|^[a-zA-Z0-9][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$\",\"position\":2,\"maxLength\":63,\"minLength\":0,\"description\":\"A full parent domain name. e.g. 'dash'.\"},\"normalizedParentDomainName\":{\"type\":\"string\",\"pattern\":\"^$|^[a-hj-km-np-z0-9][a-hj-km-np-z0-9-\\\\.]{0,61}[a-hj-km-np-z0-9]$\",\"$comment\":\"Must either be equal to an existing domain or empty to create a top level domain. \\\"o\\\", \\\"i\\\" and \\\"l\\\" must be replaced with \\\"0\\\" and \\\"1\\\". Only the data contract owner can create top level domains.\",\"position\":3,\"maxLength\":63,\"minLength\":0,\"description\":\"A parent domain name in lowercase for case-insensitive uniqueness validation. \\\"o\\\", \\\"i\\\" and \\\"l\\\" replaced with \\\"0\\\" and \\\"1\\\" to mitigate homograph attack. e.g. 'dash'\"}},\"canBeDeleted\":true,\"transferable\":1,\"documentsMutable\":false,\"additionalProperties\":false},\"preorder\":{\"type\":\"object\",\"indices\":[{\"name\":\"saltedHash\",\"unique\":true,\"properties\":[{\"saltedDomainHash\":\"asc\"}]}],\"$comment\":\"Preorder documents are immutable: modification and deletion are restricted\",\"required\":[\"saltedDomainHash\"],\"properties\":{\"saltedDomainHash\":{\"type\":\"array\",\"maxItems\":32,\"minItems\":32,\"position\":0,\"byteArray\":true,\"description\":\"Double sha-256 of the concatenation of a 32 byte random salt and a normalized domain name\"}},\"canBeDeleted\":true,\"documentsMutable\":false,\"additionalProperties\":false}}",
-  "version": 0,
-  "txHash": null,
-  "timestamp": null,
-  "isSystem": true,
-  "documentsCount": 593,
-  "topIdentity": "BNnn19SAJZuvsUu787dMzPDXASwuCrm4yQ864tEpQFvo",
-  "identitiesInteracted": 136,
-  "totalGasUsed": 19706727280,
-  "averageGasUsed": 33176309
+  "identifier": "H4wBXB2RCu58EP7H7gGyehVmD7ij5MLZkAXW9SVUGPYb",
+  "name": null,
+  "owner": {
+    "identifier": "Atx8CpmKMgDvxWXrRfgCJ44GmUSPiB1qXkfoyotttHd",
+    "aliases": [
+      {
+        "alias": "ajcwebdev20250128.dash",
+        "status": "ok",
+        "contested": false,
+        "timestamp": null
+      }
+    ]
+  },
+  "schema": "{\"note\":{\"type\":\"object\",\"properties\":{\"author\":{\"type\":\"string\",\"position\":1},\"message\":{\"type\":\"string\",\"position\":0}},\"additionalProperties\":false}}",
+  "version": 2,
+  "txHash": "90525E94FFCDA0C55053E0E4629862CF57D3264462E8CC25A8B55CDAD3B601B2",
+  "timestamp": "2025-01-31T00:30:08.174Z",
+  "isSystem": false,
+  "documentsCount": 1,
+  "topIdentity": {
+    "identifier": "Atx8CpmKMgDvxWXrRfgCJ44GmUSPiB1qXkfoyotttHd",
+    "aliases": [
+      {
+        "alias": "ajcwebdev20250128.dash",
+        "status": "ok",
+        "contested": false,
+        "timestamp": null
+      }
+    ]
+  },
+  "identitiesInteracted": 1,
+  "totalGasUsed": 51529650,
+  "averageGasUsed": 10305930
 }
 ```
 Response codes:

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -657,6 +657,7 @@ Response codes:
 Return data contract by given identifier
 
 * `name` field is nullable
+* `topIdentity` - identity with the largest number of documents
 
 ```
 GET /dataContract/H4wBXB2RCu58EP7H7gGyehVmD7ij5MLZkAXW9SVUGPYb


### PR DESCRIPTION
# Issue
For new designs we need also aliases for owner and top-identity in data contract info. Also we had forgot update documents count after new indexer update
# Things done
* Implemented aliases and new structure for owner and top-identity
* Updated `README.md`
* Updated tests