### PR TITLE
Fix empty transactions for data contract

### DIFF
--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -183,7 +183,9 @@ module.exports = class DataContractsDAO {
       .where('data_contracts.identifier', '=', identifier)
       .leftJoin('data_contracts', 'data_contracts.id', 'documents.data_contract_id')
 
-    const unionSubquery = this.knex.unionAll([dataContractsSubquery, documentsSubquery])
+    const unionSubquery = this.knex
+      .unionAll([dataContractsSubquery, documentsSubquery])
+      .whereRaw('state_transition_hash is not null')
       .as('sub')
 
     const additionalDataSubquery = this.knex(unionSubquery)

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -177,15 +177,16 @@ module.exports = class DataContractsDAO {
     const dataContractsSubquery = this.knex('data_contracts')
       .select('state_transition_hash')
       .where('data_contracts.identifier', '=', identifier)
+      .andWhereRaw('data_contracts.state_transition_hash is not null')
 
     const documentsSubquery = this.knex('documents')
       .select('documents.state_transition_hash as state_transition_hash')
       .where('data_contracts.identifier', '=', identifier)
+      .andWhereRaw('documents.state_transition_hash is not null')
       .leftJoin('data_contracts', 'data_contracts.id', 'documents.data_contract_id')
 
     const unionSubquery = this.knex
       .unionAll([dataContractsSubquery, documentsSubquery])
-      .whereRaw('state_transition_hash is not null')
       .as('sub')
 
     const additionalDataSubquery = this.knex(unionSubquery)


### PR DESCRIPTION
# Issue 
At this moment on some system data contracts we have empty txs, which means that document/dataContract created by system and they don't have `state_transition_hash`, which means we cannot get any info about this tx
# Things done
* Added additional `where` in query to DB, which excludes all txs without hash