### PR TITLE
Documents owner structure in Documents by identity

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1227,7 +1227,10 @@ GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/documents?page=1&li
       "entropy": null,
       "prefundedVotingBalance": null,
       "typeName": "domain",
-      "owner": "8J8k9aQ5Hotx8oLdnYAhYpyBJJGg4wZALptKLuDE9Df6"
+      "owner": {
+        "identifier": "8J8k9aQ5Hotx8oLdnYAhYpyBJJGg4wZALptKLuDE9Df6",
+        "aliases": []
+      }
     }, ...
   ],
   "pagination": {

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -358,6 +358,11 @@ module.exports = class IdentitiesDAO {
       queryBindings.push(typeName)
     }
 
+    const aliasesSubquery = this.knex('identity_aliases')
+      .select('identity_identifier', this.knex.raw('array_agg(alias) as aliases'))
+      .groupBy('identity_identifier')
+      .as('aliases')
+
     const subquery = this.knex('documents')
       .select('documents.id', 'documents.identifier as identifier', 'documents.owner as document_owner', 'documents.data_contract_id as data_contract_id',
         'documents.revision as revision', 'documents.state_transition_hash as tx_hash',
@@ -377,7 +382,8 @@ module.exports = class IdentitiesDAO {
     const rows = await this.knex(filteredDocuments)
       .select('document_id', 'documents.identifier as identifier', 'document_owner', 'data_contracts.identifier as data_contract_identifier',
         'revision', 'deleted', 'tx_hash', 'total_count', 'row_number', 'document_type_name', 'transition_type',
-        'data_contract_id', 'blocks.timestamp as timestamp', 'document_is_system')
+        'data_contract_id', 'blocks.timestamp as timestamp', 'document_is_system', 'aliases')
+      .leftJoin(aliasesSubquery, 'aliases.identity_identifier', 'document_owner')
       .leftJoin('state_transitions', 'state_transitions.hash', 'tx_hash')
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
       .leftJoin('data_contracts', 'data_contracts.id', 'data_contract_id')
@@ -386,9 +392,22 @@ module.exports = class IdentitiesDAO {
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 
-    return new PaginatedResultSet(rows.map(row => Document.fromRow({
-      ...row, is_system: row.document_is_system, owner: row.document_owner?.trim()
-    })), page, limit, totalCount)
+    const resultSet = await Promise.all(rows.map(async (row) => {
+      const aliases = await Promise.all((row.aliases ?? []).map(async alias => {
+        const aliasInfo = await getAliasInfo(alias, this.dapi)
+
+        return getAliasStateByVote(aliasInfo, { alias }, row.owner)
+      }))
+
+      return Document.fromRow({
+        ...row, is_system: row.document_is_system, owner: {
+          identifier: row.document_owner?.trim() ?? null,
+          aliases: aliases ?? []
+        }
+      })
+    }))
+
+    return new PaginatedResultSet(resultSet, page, limit, totalCount)
   }
 
   getTransactionsByIdentity = async (identifier, page, limit, order) => {

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -400,7 +400,9 @@ module.exports = class IdentitiesDAO {
       }))
 
       return Document.fromRow({
-        ...row, is_system: row.document_is_system, owner: {
+        ...row,
+        is_system: row.document_is_system,
+        owner: {
           identifier: row.document_owner?.trim() ?? null,
           aliases: aliases ?? []
         }

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -977,7 +977,10 @@ describe('Identities routes', () => {
 
       const expectedDocuments = documents.slice(0, 10).map((_document) => ({
         identifier: _document.document.identifier,
-        owner: identity.identifier,
+        owner: {
+          identifier: identity.identifier,
+          aliases: []
+        },
         dataContractIdentifier: _document.dataContract.identifier,
         revision: 1,
         txHash: _document.transaction.hash,
@@ -1039,7 +1042,10 @@ describe('Identities routes', () => {
         .slice(0, 10)
         .map((_document) => ({
           identifier: _document.document.identifier,
-          owner: identity.identifier,
+          owner: {
+            identifier: identity.identifier,
+            aliases: []
+          },
           dataContractIdentifier: _document.dataContract.identifier,
           revision: 1,
           txHash: _document.transaction.hash,
@@ -1103,7 +1109,10 @@ describe('Identities routes', () => {
         .slice(0, 10)
         .map((_document) => ({
           identifier: _document.document.identifier,
-          owner: identity.identifier,
+          owner: {
+            identifier: identity.identifier,
+            aliases: []
+          },
           dataContractIdentifier: _document.dataContract.identifier,
           revision: 1,
           txHash: _document.transaction.hash,
@@ -1165,7 +1174,10 @@ describe('Identities routes', () => {
         .slice(3, 6)
         .map((_document) => ({
           identifier: _document.document.identifier,
-          owner: identity.identifier,
+          owner: {
+            identifier: identity.identifier,
+            aliases: []
+          },
           dataContractIdentifier: _document.dataContract.identifier,
           revision: 1,
           txHash: _document.transaction.hash,
@@ -1227,7 +1239,10 @@ describe('Identities routes', () => {
         .slice(3, 6)
         .map((_document) => ({
           identifier: _document.document.identifier,
-          owner: identity.identifier,
+          owner: {
+            identifier: identity.identifier,
+            aliases: []
+          },
           dataContractIdentifier: _document.dataContract.identifier,
           revision: 1,
           txHash: _document.transaction.hash,

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1194,7 +1194,10 @@ GET /identities/GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec/documents?page=1&li
       "entropy": null,
       "prefundedVotingBalance": null,
       "typeName": "domain",
-      "owner": "8J8k9aQ5Hotx8oLdnYAhYpyBJJGg4wZALptKLuDE9Df6"
+      "owner": {
+        "identifier": "8J8k9aQ5Hotx8oLdnYAhYpyBJJGg4wZALptKLuDE9Df6",
+        "aliases": []
+      }
     }, ...
   ],
   "pagination": {


### PR DESCRIPTION
# Issue
As part of the renewal of the `owner` structure, we need to update this strucutre also for documents by identity method

# Things done
* Implemented aliases for owners in documents by identity
* Updated data to new structure
* Updated Readme.md
* Updated tests