### PR TITLE
Fix transfers list columns size

### DIFF
--- a/packages/frontend/src/components/transfers/_variables.scss
+++ b/packages/frontend/src/components/transfers/_variables.scss
@@ -7,7 +7,7 @@
   grid-template-columns:
     70px
     minmax(0, 400px)
-    minmax(0, 300px)
+    minmax(0, 400px)
     minmax(185px, 185px)
     minmax(100px, 100px)
     128px;
@@ -24,7 +24,7 @@
   @container (max-width: 44em) {
     grid-template-columns:
     70px
-    minmax(0px, 200px)
+    minmax(0px, 300px)
     minmax(185px, 185px)
     128px;
   }


### PR DESCRIPTION
# Issue
There is extra empty space in the transfer list. The list element needs to be stretched to full width.
![image](https://github.com/user-attachments/assets/754c44f4-c9c9-4b4e-a58b-a7d9aa63a524)

# Things done
Updated the size of the transfers list columns so that the element takes up the full width.