### PR TITLE
Fix tab style

### DIFF
--- a/packages/frontend/src/styles/components/Tabs.js
+++ b/packages/frontend/src/styles/components/Tabs.js
@@ -48,6 +48,9 @@ const Tabs = {
           width: `calc(100% - ${tabPaddingSize.base * 2}px)`
         }
       },
+      _focusVisible: {
+        boxShadow: 'none'
+      },
       _hover: {
         color: 'white',
 


### PR DESCRIPTION
# Issue
When switching tabs using cursors, an unnecessary outline appears
![image](https://github.com/user-attachments/assets/726a45e0-1ca8-4a54-b6cd-d77e8db553d9)

# Things done
Remove box-shadow from tab with focus-visible pseudo-class
