### PR TITLE
Update field title in TransitionCard

### DIFF
--- a/packages/frontend/src/components/transactions/TransitionCard.js
+++ b/packages/frontend/src/components/transactions/TransitionCard.js
@@ -153,7 +153,7 @@ function TransitionCard ({ transition, owner, rate, className }) {
       {fields.indexOf('SellerIdentifier') !== -1 && owner && // purchase
         <InfoLine
           className={'TransitionCard__InfoLine TransitionCard__InfoLine--DataContract'}
-          title={'Seller Identifier'}
+          title={'Buyer Identifier'}
           value={(
             <ValueCard link={`/identity/${owner}`}>
               <Identifier avatar={true} copyButton={true} ellipsis={true} styles={['highlight-both']}>

--- a/packages/frontend/src/components/transactions/TransitionCard.js
+++ b/packages/frontend/src/components/transactions/TransitionCard.js
@@ -91,7 +91,7 @@ function TransitionCard ({ transition, owner, rate, className }) {
 
       {fields.indexOf('DataContractIdentifier') !== -1 &&
         <InfoLine
-          className={'TransitionCard__InfoLine TransitionCard__InfoLine--DataContract'}
+          className={'TransitionCard__InfoLine TransitionCard__InfoLine--IdContainer'}
           title={'Data Contract Identifier'}
           value={(
             <ValueCard link={`/dataContract/${transition.dataContractId}`}>
@@ -106,7 +106,7 @@ function TransitionCard ({ transition, owner, rate, className }) {
 
       {fields.indexOf('DocumentIdentifier') !== -1 &&
         <InfoLine
-          className={'TransitionCard__InfoLine TransitionCard__InfoLine--DataContract'}
+          className={'TransitionCard__InfoLine TransitionCard__InfoLine--IdContainer'}
           title={'Document Identifier'}
           value={(
             <ValueCard link={`/document/${transition.id}`}>
@@ -124,7 +124,7 @@ function TransitionCard ({ transition, owner, rate, className }) {
           <>
             {owner &&
               <InfoLine
-                className={'TransitionCard__InfoLine TransitionCard__InfoLine--DataContract'}
+                className={'TransitionCard__InfoLine TransitionCard__InfoLine--IdContainer'}
                 title={'Sender Identifier:'}
                 value={(
                   <ValueCard link={`/identity/${owner}`}>
@@ -137,7 +137,7 @@ function TransitionCard ({ transition, owner, rate, className }) {
             }
 
             <InfoLine
-              className={'TransitionCard__InfoLine TransitionCard__InfoLine--DataContract'}
+              className={'TransitionCard__InfoLine TransitionCard__InfoLine--IdContainer'}
               title={'Receiver Identifier'}
               value={(
                 <ValueCard link={`/identity/${transition?.receiverId}`}>
@@ -152,7 +152,7 @@ function TransitionCard ({ transition, owner, rate, className }) {
 
       {fields.indexOf('SellerIdentifier') !== -1 && owner && // purchase
         <InfoLine
-          className={'TransitionCard__InfoLine TransitionCard__InfoLine--DataContract'}
+          className={'TransitionCard__InfoLine TransitionCard__InfoLine--IdContainer'}
           title={'Buyer Identifier'}
           value={(
             <ValueCard link={`/identity/${owner}`}>
@@ -166,7 +166,7 @@ function TransitionCard ({ transition, owner, rate, className }) {
 
       {fields.indexOf('Price') !== -1 &&
         <InfoLine
-          className={'TransitionCard__InfoLine TransitionCard__InfoLine--DataContract'}
+          className={'TransitionCard__InfoLine'}
           title={'Price'}
           value={<CreditsBlock credits={transition?.price} rate={rate}/>}
           error={!transition?.price}

--- a/packages/frontend/src/components/transactions/TransitionCard.scss
+++ b/packages/frontend/src/components/transactions/TransitionCard.scss
@@ -13,7 +13,7 @@
       margin-bottom: 0;
     }
 
-    &--DataContract {
+    &--IdContainer {
       .InfoLine__Value {
         flex-grow: 0;
         max-width: max-content;


### PR DESCRIPTION
# Issue
It is necessary to replace field title  'Seller' with 'Buyer'. Also, some names of class modifiers in TransitionCard component  are semantically incorrect.

# Things done
- Renamed incorrect field title: 'Seller' to 'Buyer' in document purchase.
- Renamed class modifier