### PR TITLE
API 500 on bad validator host

### DIFF
--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -35,8 +35,8 @@ class ValidatorsController {
 
     const isActive = validators.some(validator => validator.pro_tx_hash === hash)
 
-    const [host] = proTxInfo?.state.service ? proTxInfo?.state.service.match(/^\d+\.\d+\.\d+\.\d+/) ?? [null] : [null]
-    const [servicePort] = proTxInfo?.state.service ? proTxInfo?.state.service.match(/\d+$/) : [null]
+    const [host] = proTxInfo?.state?.service?.match(/^\d+\.\d+\.\d+\.\d+/) ?? [null]
+    const [servicePort] = proTxInfo?.state?.service?.match(/\d+$/) ?? [null]
 
     const [coreStatus, platformStatus, grpcStatus] = (await Promise.allSettled([
       checkTcpConnect(servicePort, host),

--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -35,7 +35,7 @@ class ValidatorsController {
 
     const isActive = validators.some(validator => validator.pro_tx_hash === hash)
 
-    const [host] = proTxInfo?.state.service ? proTxInfo?.state.service.match(/^\d+\.\d+\.\d+\.\d+/) : [null]
+    const [host] = proTxInfo?.state.service ? proTxInfo?.state.service.match(/^\d+\.\d+\.\d+\.\d+/) ?? [null] : [null]
     const [servicePort] = proTxInfo?.state.service ? proTxInfo?.state.service.match(/\d+$/) : [null]
 
     const [coreStatus, platformStatus, grpcStatus] = (await Promise.allSettled([


### PR DESCRIPTION
# Issue
At this moment if validator have state.service equal to `[::]:0`, we get 500 error response
# Things done
* added default value 