### PR TITLE
Incorrect quorum index calculation

### DIFF
--- a/packages/api/src/controllers/BlocksController.js
+++ b/packages/api/src/controllers/BlocksController.js
@@ -38,9 +38,16 @@ class BlocksController {
       const quorumInfo = quorumsList[quorumTypeName]
         .find(quorum => Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()))
 
+      const quorumIndex = quorumsList[quorumTypeName]
+        .find(quorum => Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()))
+
       const quorumDetailedInfo = await DashCoreRPC.getQuorumInfo(lastCommit.quorum_hash, quorumType)
 
-      quorum = Quorum.fromObject({ ...quorumDetailedInfo, ...quorumInfo[lastCommit.quorum_hash.toLowerCase()] })
+      quorum = Quorum.fromObject({
+        ...quorumDetailedInfo,
+        ...quorumInfo[lastCommit.quorum_hash.toLowerCase()],
+        quorumIndex: quorumIndex
+      })
     }
 
     response.send(


### PR DESCRIPTION
# Issue
At this moment, we getting quorum index via `getQuorumInfo`, but this method always returns quorum index 0

# Things done
* Replaced `quorumIndex` from `getQuorumInfo` to `findIndex` on `getQuorumsListExtended` array for current quorum type