### PR TITLE
Invalid filter in #493

### DIFF
--- a/packages/api/src/controllers/BlocksController.js
+++ b/packages/api/src/controllers/BlocksController.js
@@ -39,7 +39,7 @@ class BlocksController {
         .find(quorum => Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()))
 
       const quorumIndex = quorumsList[quorumTypeName]
-        .find(quorum => Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()))
+        .findIndex(quorum => Object.keys(quorum).includes(lastCommit.quorum_hash.toLowerCase()))
 
       const quorumDetailedInfo = await DashCoreRPC.getQuorumInfo(lastCommit.quorum_hash, quorumType)
 


### PR DESCRIPTION
# Issue
In #493 pr, we use method `find`, but correct method is `findIndex`
# Thigns done
* changed method