### PR TITLE
Dapi get documents method architecture fix

### DIFF
--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -40,14 +40,14 @@ class DAPI {
   async getDocuments (type, dataContractObject, query, limit, orderBy, skip) {
     const dataContract = await this.dpp.dataContract.createFromObject(dataContractObject)
 
-    const {startAt, startAfter} = skip ?? {}
+    const { startAt, startAfter } = skip ?? {}
 
     const { documents } = await this.dapi.platform.getDocuments(Identifier.from(dataContractObject.id), type, {
       limit,
       where: query,
       orderBy,
       startAt,
-      startAfter,
+      startAfter
     })
 
     return documents.map(

--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -32,20 +32,22 @@ class DAPI {
    * @typedef {getDocuments}
    * @param {string} type
    * @param {object} dataContractObject
-   * @param {string} identifier
-   * @param {string} owner
+   * @param {Array<Array>} query
    * @param {number} limit
-  */
-  async getDocuments (type, dataContractObject, identifier, owner, limit) {
+   * @param {Array<Array>} orderBy
+   * @param {Object} skip - {startAfter?: {Buffer}, startAt?: {Buffer}}
+   */
+  async getDocuments (type, dataContractObject, query, limit, orderBy, skip) {
     const dataContract = await this.dpp.dataContract.createFromObject(dataContractObject)
+
+    const {startAt, startAfter} = skip ?? {}
 
     const { documents } = await this.dapi.platform.getDocuments(Identifier.from(dataContractObject.id), type, {
       limit,
-      where: [
-        identifier
-          ? ['$id', '=', Identifier.from(identifier)]
-          : ['$ownerId', '=', Identifier.from(owner)]
-      ]
+      where: query,
+      orderBy,
+      startAt,
+      startAfter,
     })
 
     return documents.map(

--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -50,7 +50,7 @@ class DAPI {
       startAfter
     })
 
-    return documents.map(
+    return (documents ?? []).map(
       (document) => this.dpp.document.createExtendedDocumentFromDocumentBuffer(document, type, dataContract).getDocument()
     )
   }

--- a/packages/api/src/controllers/BlocksController.js
+++ b/packages/api/src/controllers/BlocksController.js
@@ -46,7 +46,7 @@ class BlocksController {
       quorum = Quorum.fromObject({
         ...quorumDetailedInfo,
         ...quorumInfo[lastCommit.quorum_hash.toLowerCase()],
-        quorumIndex: quorumIndex
+        quorumIndex
       })
     }
 

--- a/packages/api/src/controllers/DocumentsController.js
+++ b/packages/api/src/controllers/DocumentsController.js
@@ -1,6 +1,7 @@
 const DocumentsDAO = require('../dao/DocumentsDAO')
 const DataContractsDAO = require('../dao/DataContractsDAO')
 const Document = require('../models/Document')
+const {Identifier} = require("@dashevo/wasm-dpp");
 
 class DocumentsController {
   constructor (client, knex, dapi) {
@@ -43,8 +44,7 @@ class DocumentsController {
         version: dataContract.version,
         documentSchemas: JSON.parse(dataContract.schema)
       },
-      identifier,
-      undefined,
+      [['$id', '=', Identifier.from(identifier)]],
       1
     )
 

--- a/packages/api/src/controllers/DocumentsController.js
+++ b/packages/api/src/controllers/DocumentsController.js
@@ -1,7 +1,7 @@
 const DocumentsDAO = require('../dao/DocumentsDAO')
 const DataContractsDAO = require('../dao/DataContractsDAO')
 const Document = require('../models/Document')
-const {Identifier} = require("@dashevo/wasm-dpp");
+const { Identifier } = require('@dashevo/wasm-dpp')
 
 class DocumentsController {
   constructor (client, knex, dapi) {

--- a/packages/api/src/controllers/DocumentsController.js
+++ b/packages/api/src/controllers/DocumentsController.js
@@ -39,12 +39,12 @@ class DocumentsController {
       documentTypeName,
       {
         $format_version: '0',
-        ownerId: dataContract.owner,
+        ownerId: dataContract.owner.identifier,
         id: dataContract.identifier,
         version: dataContract.version,
         documentSchemas: JSON.parse(dataContract.schema)
       },
-      [['$id', '=', Identifier.from(identifier)]],
+      [['$id', '=', Buffer.from(Identifier.from(identifier))]],
       1
     )
 

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -3,7 +3,7 @@ const { WITHDRAWAL_CONTRACT_TYPE } = require('../constants')
 const WithdrawalsContract = require('../../data_contracts/withdrawals.json')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 const { decodeStateTransition } = require('../utils')
-const {Identifier} = require("@dashevo/wasm-dpp");
+const { Identifier } = require('@dashevo/wasm-dpp')
 
 class IdentitiesController {
   constructor (client, knex, dapi) {

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -91,7 +91,12 @@ class IdentitiesController {
     const { identifier } = request.params
     const { limit = 100 } = request.query
 
-    const documents = await this.dapi.getDocuments(WITHDRAWAL_CONTRACT_TYPE, WithdrawalsContract, [['$ownerId', '=', Identifier.from(identifier)]], limit)
+    const documents = await this.dapi.getDocuments(
+      WITHDRAWAL_CONTRACT_TYPE,
+      WithdrawalsContract,
+      [['$ownerId', '=', Identifier.from(identifier)]],
+      limit
+    )
 
     if (documents.length === 0) {
       return response.send(new PaginatedResultSet([], null, null, null))

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -3,6 +3,7 @@ const { WITHDRAWAL_CONTRACT_TYPE } = require('../constants')
 const WithdrawalsContract = require('../../data_contracts/withdrawals.json')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 const { decodeStateTransition } = require('../utils')
+const {Identifier} = require("@dashevo/wasm-dpp");
 
 class IdentitiesController {
   constructor (client, knex, dapi) {
@@ -90,7 +91,7 @@ class IdentitiesController {
     const { identifier } = request.params
     const { limit = 100 } = request.query
 
-    const documents = await this.dapi.getDocuments(WITHDRAWAL_CONTRACT_TYPE, WithdrawalsContract, undefined, identifier, limit)
+    const documents = await this.dapi.getDocuments(WITHDRAWAL_CONTRACT_TYPE, WithdrawalsContract, [['$ownerId', '=', Identifier.from(identifier)]], limit)
 
     if (documents.length === 0) {
       return response.send(new PaginatedResultSet([], null, null, null))

--- a/packages/api/src/server.js
+++ b/packages/api/src/server.js
@@ -13,34 +13,31 @@ const DocumentsController = require('./controllers/DocumentsController')
 const IdentitiesController = require('./controllers/IdentitiesController')
 const DataContractsController = require('./controllers/DataContractsController')
 const ValidatorsController = require('./controllers/ValidatorsController')
-const {getKnex} = require('./utils')
+const { getKnex } = require('./utils')
 const BlocksDAO = require('./dao/BlocksDAO')
 const DAPI = require('./DAPI')
 const RateController = require('./controllers/RateController')
 const DAPIClient = require('@dashevo/dapi-client')
 const MasternodeVotesController = require('./controllers/MasternodeVotesController')
 const ContestedResourcesController = require('./controllers/ContestedResourcesController')
-const {default: loadWasmDpp} = require('dash').PlatformProtocol
-const dataContract = require('../data_contracts/withdrawals.json')
-const {Identifier} = require("@dashevo/wasm-dpp");
+const { default: loadWasmDpp } = require('dash').PlatformProtocol
 
-
-function errorHandler(err, req, reply) {
+function errorHandler (err, req, reply) {
   if (err instanceof ServiceNotAvailableError) {
-    return reply.status(503).send({error: 'tenderdash/dashcore backend is not available'})
+    return reply.status(503).send({ error: 'tenderdash/dashcore backend is not available' })
   }
 
   if (err?.constructor?.name === 'InvalidStateTransitionError') {
     const [error] = err.getErrors()
-    const {code, message} = error
+    const { code, message } = error
 
-    return reply.status(500).send({error: message, code})
+    return reply.status(500).send({ error: message, code })
   }
 
   console.error(err)
   reply.status(500)
 
-  reply.send({error: err.message})
+  reply.send({ error: err.message })
 }
 
 let client
@@ -61,20 +58,9 @@ module.exports = {
       network: process.env.NETWORK ?? 'testnet'
     })
 
-    const {dpp} = client.platform
+    const { dpp } = client.platform
 
     dapi = new DAPI(dapiClient, dpp)
-
-    const t = await dapi.getDocuments(
-      'withdrawal',
-      dataContract,
-      undefined,
-      10,
-      [['transactionIndex', 'asc']],
-      {
-        startAt: Buffer.from(Identifier.from('MV4xg8XPUXL87T1b8mnUC2S3tdPRHJUnjXuoxFHuBsY'))
-      },
-    )
 
     fastify = Fastify()
 
@@ -125,9 +111,9 @@ module.exports = {
     new fastify.metrics.client.Gauge({
       name: 'platform_explorer_api_block_height',
       help: 'The latest block height in the API',
-      async collect() {
+      async collect () {
         const blockDAO = new BlocksDAO(knex)
-        const {resultSet: [block]} = await blockDAO.getBlocks(1, 1, 'desc')
+        const { resultSet: [block] } = await blockDAO.getBlocks(1, 1, 'desc')
 
         this.set(block.header.height)
       }

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -316,9 +316,9 @@ describe('Identities routes', () => {
       })))
     })
 
-    it('should return 404 whe identity not exist', async () => {
+    it('should return 404 when identity not exist', async () => {
       mock.method(DAPI.prototype, 'getDocuments', async () => [])
-      const { body } = await client.get('/identity/1234123123PFdomuTVvNy3VRrvWgvkKPzqehEBpNf2nk6/withdrawals')
+      const { body } = await client.get('/identity/D1111QnZXVpMW9yg4X6MjuWzSZ5Nui8TmCLUDY18FBtq/withdrawals')
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       assert.deepEqual(body.resultSet, [])


### PR DESCRIPTION
# Issue
In old PR's for `getDocumtns` method was created wrong architecture for this method, which disallows to make different calls to DAPI. Also after update of owners structure some code stop working
# Things done
* Updated method by changing arguments and adding new
* Updated method code documentation
* Updated calls with new structure of identifiers