### PR TITLE
Statistics for graphs query optimization

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -49,8 +49,8 @@ Reference:
 * [Validators](#validators)
 * [Validator by ProTxHash](#validator-by-protxhash)
 * [Validator by Masternode Identifier](#validator-by-masternode-identifier)
-* [Validator Blocks Statistic](#validator-stats-by-protxhash)
 * [Validator Rewards Statistic](#validator-rewards-stats-by-protxhash)
+* [Validator Blocks Statistic](#validator-stats-by-protxhash)
 * [Transaction by hash](#transaction-by-hash)
 * [Transactions](#transactions)
 * [Data Contract By Identifier](#data-contract-by-identifier)
@@ -558,12 +558,12 @@ GET /validator/identity/8tsWRSwsTM5AXv4ViCF9gu39kzjbtfFDM6rCyL2RcFzd
 ### Validator rewards stats by ProTxHash
 Return a series data for the reward from proposed blocks by validator chart with
 
-* `start` lower interval threshold in ISO string ( _optional_ )
-* `end` upper interval threshold in ISO string ( _optional_ )
-
+* `start` lower interval threshold in ISO string
+* `end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
 
 ```
-GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/reward/stats?start=2024-01-01T00:00:00&end=2025-01-01T00:00:00
+GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/rewards/stats?start=2024-01-01T00:00:00&end=2025-01-01T00:00:00
 [
     {
         timestamp: "2024-06-23T13:51:44.154Z",
@@ -577,8 +577,8 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/
 ### Validator stats by ProTxHash
 Return a series data for the amount of proposed blocks by validator chart with
 
-* `start` lower interval threshold in ISO string ( _optional_ )
-* `end` upper interval threshold in ISO string ( _optional_ )
+* `start` lower interval threshold in ISO string
+* `end` upper interval threshold in ISO string
 * `intervalsCount` intervals count in response ( _optional_ )
 
 ```
@@ -1440,8 +1440,8 @@ ___
 ### Transactions history
 Return a series data for the amount of transactions chart
 
-* `start` lower interval threshold in ISO string ( _optional_ )
-* `end` upper interval threshold in ISO string ( _optional_ )
+* `start` lower interval threshold in ISO string
+* `end` upper interval threshold in ISO string
 * `intervalsCount` intervals count in response ( _optional_ )
 
 ```
@@ -1475,8 +1475,8 @@ ___
 ### Transactions Gas history
 Return a series data for the used gas of transactions chart
 
-* `start` lower interval threshold in ISO string ( _optional_ )
-* `end` upper interval threshold in ISO string ( _optional_ )
+* `start` lower interval threshold in ISO string
+* `end` upper interval threshold in ISO string
 * `intervalsCount` intervals count in response ( _optional_ )
 
 ```

--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -142,42 +142,30 @@ class ValidatorsController {
     const {
       start = new Date().getTime() - 3600000,
       end = new Date().getTime(),
-      timespan = null,
       intervalsCount = null
     } = request.query
+
+    if (!start || !end) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
 
     if (start > end) {
       return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
     }
 
-    let timespanStart = null
-    let timespanEnd = null
-
-    const timespanInterval = {
-      '1h': { offset: 3600000, step: 'PT5M' },
-      '24h': { offset: 86400000, step: 'PT2H' },
-      '3d': { offset: 259200000, step: 'PT6H' },
-      '1w': { offset: 604800000, step: 'PT14H' }
-    }[timespan]
-
-    if (timespanInterval) {
-      timespanStart = new Date().getTime() - timespanInterval.offset
-      timespanEnd = new Date().getTime()
-    }
-
     const intervalInMs =
       Math.ceil(
-        (new Date(timespanEnd ?? end).getTime() - new Date(timespanStart ?? start).getTime()) / Number(intervalsCount ?? NaN) / 1000
+        (new Date(end).getTime() - new Date(start).getTime()) / Number(intervalsCount ?? NaN) / 1000
       ) * 1000
 
     const interval = intervalsCount
       ? iso8601duration(intervalInMs)
-      : (timespanInterval?.step ?? calculateInterval(new Date(start), new Date(end)))
+      : calculateInterval(new Date(start), new Date(end))
 
     const stats = await this.validatorsDAO.getValidatorStatsByProTxHash(
       hash,
-      new Date(timespanStart ?? start),
-      new Date(timespanEnd ?? end),
+      new Date(start),
+      new Date(end),
       interval,
       isNaN(intervalInMs) ? Intervals[interval] : intervalInMs
     )
@@ -190,44 +178,32 @@ class ValidatorsController {
     const {
       start = new Date().getTime() - 3600000,
       end = new Date().getTime(),
-      timespan = null
+      intervalsCount = null
     } = request.query
 
-    if (timespan) {
-      const possibleValues = ['1h', '24h', '3d', '1w']
-
-      if (possibleValues.indexOf(timespan) === -1) {
-        return response.status(400)
-          .send({ message: `invalid timespan value ${timespan}. only one of '${possibleValues}' is valid` })
-      }
+    if (!start || !end) {
+      return response.status(400).send({ message: 'start and end must be set' })
     }
-
-    let timespanStart = null
-    let timespanEnd = null
-
-    const timespanInterval = {
-      '1h': { offset: 3600000, step: 'PT5M' },
-      '24h': { offset: 86400000, step: 'PT2H' },
-      '3d': { offset: 259200000, step: 'PT6H' },
-      '1w': { offset: 604800000, step: 'PT14H' }
-    }[timespan]
 
     if (start > end) {
       return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
     }
 
-    if (timespanInterval) {
-      timespanStart = new Date().getTime() - timespanInterval.offset
-      timespanEnd = new Date().getTime()
-    }
+    const intervalInMs =
+      Math.ceil(
+        (new Date(end).getTime() - new Date(start).getTime()) / Number(intervalsCount ?? NaN) / 1000
+      ) * 1000
 
-    const interval = timespanInterval?.step ?? calculateInterval(new Date(start), new Date(end))
+    const interval = intervalsCount
+      ? iso8601duration(intervalInMs)
+      : calculateInterval(new Date(start), new Date(end))
 
     const stats = await this.validatorsDAO.getValidatorRewardStatsByProTxHash(
       hash,
-      new Date(timespanStart ?? start),
-      new Date(timespanEnd ?? end),
-      interval
+      new Date(start),
+      new Date(end),
+      interval,
+      isNaN(intervalInMs) ? Intervals[interval] : intervalInMs
     )
 
     response.send(stats)

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -235,17 +235,17 @@ module.exports = class ValidatorsDAO {
       .map(({ timestamp, data }) => new SeriesData(timestamp, data))
   }
 
-  getValidatorRewardStatsByProTxHash = async (proTxHash, start, end, interval) => {
-    const startSql = `'${start.toISOString()}'::timestamptz`
+  getValidatorRewardStatsByProTxHash = async (proTxHash, start, end, interval, intervalInMs) => {
+    const startSql = `'${new Date(start.getTime()).toISOString()}'::timestamptz`
 
     const endSql = `'${end.toISOString()}'::timestamptz`
 
     const ranges = this.knex
       .from(this.knex.raw(`generate_series(${startSql}, ${endSql}, '${interval}'::interval) date_to`))
-      .select('date_to', this.knex.raw('LAG(date_to, 1) over (order by date_to asc) date_from'))
+      .select('date_to', this.knex.raw(`LAG(date_to, 1, '${start.toISOString()}'::timestamptz) over (order by date_to asc) date_from`))
 
     const rows = await this.knex.with('ranges', ranges)
-      .select(this.knex.raw(`COALESCE(date_from, date_to - interval '${interval}'::interval) date_from`), 'date_to')
+      .select('date_from')
       .select(
         this.knex('blocks')
           .whereRaw('blocks.timestamp > date_from and blocks.timestamp <= date_to')

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -122,7 +122,11 @@ describe('Transaction routes', () => {
             alias: identityAlias.alias,
             contested: false,
             status: 'ok',
-            timestamp: transaction.block.timestamp.toISOString().replace('Z', '+00:00')
+            timestamp: (
+              transaction.block.timestamp.toISOString().slice(-2, -1) === '0'
+                ? `${transaction.block.timestamp.toISOString().slice(0, -2)}Z`
+                : transaction.block.timestamp.toISOString()
+            ).replace('Z', '+00:00')
           }]
         }
       }
@@ -153,7 +157,11 @@ describe('Transaction routes', () => {
             alias: identityAlias.alias,
             contested: false,
             status: 'ok',
-            timestamp: transaction.block.timestamp.toISOString().replace('Z', '+00:00')
+            timestamp: (
+              transaction.block.timestamp.toISOString().slice(-2, -1) === '0'
+                ? `${transaction.block.timestamp.toISOString().slice(0, -2)}Z`
+                : transaction.block.timestamp.toISOString()
+            ).replace('Z', '+00:00')
           }]
         }
       }
@@ -511,7 +519,7 @@ describe('Transaction routes', () => {
         const txs = transactions.filter(transaction =>
           new Date(transaction.block.timestamp).getTime() <= prevPeriod &&
           new Date(transaction.block.timestamp).getTime() >= nextPeriod
-        )
+        ).sort((a, b) => a.block.timestamp - b.block.timestamp)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -770,7 +770,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height ? gas : null,
+            gas: txs[0]?.block?.height ? gas : 0,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -806,7 +806,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height ? gas : null,
+            gas: txs[0]?.block?.height ? gas : 0,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -842,7 +842,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height ? gas : null,
+            gas: txs[0]?.block?.height ? gas : 0,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -878,7 +878,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height ? gas : null,
+            gas: txs[0]?.block?.height ? gas : 0,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }
@@ -916,7 +916,7 @@ describe('Transaction routes', () => {
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            gas: txs[0]?.block?.height ? gas : null,
+            gas: txs[0]?.block?.height ? gas : 0,
             blockHeight: txs[0]?.block?.height ?? null,
             blockHash: txs[0]?.block?.hash ?? null
           }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -16,8 +16,8 @@ Reference:
 * [Validators](#validators)
 * [Validator by ProTxHash](#validator-by-protxhash)
 * [Validator by Masternode Identifier](#validator-by-masternode-identifier)
-* [Validator Blocks Statistic](#validator-stats-by-protxhash)
 * [Validator Rewards Statistic](#validator-rewards-stats-by-protxhash)
+* [Validator Blocks Statistic](#validator-stats-by-protxhash)
 * [Transaction by hash](#transaction-by-hash)
 * [Transactions](#transactions)
 * [Data Contract By Identifier](#data-contract-by-identifier)
@@ -525,12 +525,12 @@ GET /validator/identity/8tsWRSwsTM5AXv4ViCF9gu39kzjbtfFDM6rCyL2RcFzd
 ### Validator rewards stats by ProTxHash
 Return a series data for the reward from proposed blocks by validator chart with
 
-* `start` lower interval threshold in ISO string ( _optional_ )
-* `end` upper interval threshold in ISO string ( _optional_ )
-
+* `start` lower interval threshold in ISO string
+* `end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
 
 ```
-GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/reward/stats?start=2024-01-01T00:00:00&end=2025-01-01T00:00:00
+GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/rewards/stats?start=2024-01-01T00:00:00&end=2025-01-01T00:00:00
 [
     {
         timestamp: "2024-06-23T13:51:44.154Z",
@@ -544,8 +544,8 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/
 ### Validator stats by ProTxHash
 Return a series data for the amount of proposed blocks by validator chart with
 
-* `start` lower interval threshold in ISO string ( _optional_ )
-* `end` upper interval threshold in ISO string ( _optional_ )
+* `start` lower interval threshold in ISO string
+* `end` upper interval threshold in ISO string
 * `intervalsCount` intervals count in response ( _optional_ )
 
 ```
@@ -1407,8 +1407,8 @@ ___
 ### Transactions history
 Return a series data for the amount of transactions chart
 
-* `start` lower interval threshold in ISO string ( _optional_ )
-* `end` upper interval threshold in ISO string ( _optional_ )
+* `start` lower interval threshold in ISO string
+* `end` upper interval threshold in ISO string
 * `intervalsCount` intervals count in response ( _optional_ )
 
 ```
@@ -1442,8 +1442,8 @@ ___
 ### Transactions Gas history
 Return a series data for the used gas of transactions chart
 
-* `start` lower interval threshold in ISO string ( _optional_ )
-* `end` upper interval threshold in ISO string ( _optional_ )
+* `start` lower interval threshold in ISO string
+* `end` upper interval threshold in ISO string
 * `intervalsCount` intervals count in response ( _optional_ )
 
 ```


### PR DESCRIPTION
# Issue
While we testing api, we found slow query for graphs, which requires 3 sec+ for 100 points.
Also was founded some mistakes in api documentation, deprecated code and we need implementation for `intervalsCount` in `getValidatorRewardStatsByProTxHash`

# Things done
* Optimization queries for transactions statistic. Old version use same subquery 4 times, now we have 1 subquery
* Update `README.md` and removing incorrect data
* Added implementation for `intervalsCount` int `getValidatorRewardStatsByProTxHash`
* Removed deprecated params from statistic
* Fix for txs timestamp in tests