### PR TITLE
Search route improvements

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1420,7 +1420,7 @@ GET /search?query=xyz
 GET /search?query=36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm
 
 {
-  "identity": {
+  "identities": [{
     "identifier": "36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm",
     "alias": "xyz.dash",
     "status": {
@@ -1428,7 +1428,7 @@ GET /search?query=36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm
       "status": "ok",
       "contested": true
     }
-  }
+  }]
 }
 ```
 Response codes:

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -141,7 +141,7 @@ class MainController {
       const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
 
       if (identity) {
-        result = { ...result, identity }
+        result = { ...result, identities: [identity] }
       }
 
       // search validator by MasterNode identity
@@ -157,7 +157,7 @@ class MainController {
       const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(query)
 
       if (dataContract) {
-        result = { ...result, dataContract }
+        result = { ...result, dataContracts: [dataContract] }
       }
 
       // search documents
@@ -172,14 +172,22 @@ class MainController {
     const identities = await this.identitiesDAO.getIdentitiesByDPNSName(query)
 
     if (identities) {
-      result = { ...result, identities }
+      if (result.identities) {
+        result.identities.push(identities)
+      } else {
+        result = { ...result, identities }
+      }
     }
 
     // by data-contract name
     const dataContracts = await this.dataContractsDAO.getDataContractByName(query)
 
     if (dataContracts) {
-      result = { ...result, dataContracts }
+      if (result.dataContracts) {
+        result.dataContracts.push(dataContracts)
+      } else {
+        result = { ...result, dataContracts }
+      }
     }
 
     if (Object.keys(result).length === 0) {

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -181,8 +181,10 @@ module.exports = class IdentitiesDAO {
 
   getIdentitiesByDPNSName = async (dpns) => {
     const rows = await this.knex('identity_aliases')
-      .select('identity_identifier', 'alias')
+      .select('identity_identifier', 'alias', 'timestamp')
       .whereILike('alias', `${dpns}%`)
+      .leftJoin('state_transitions', 'state_transition_hash', 'hash')
+      .leftJoin('blocks', 'blocks.hash', 'block_hash')
 
     if (rows.length === 0) {
       return null
@@ -194,7 +196,7 @@ module.exports = class IdentitiesDAO {
       return {
         identifier: row.identity_identifier,
         alias: row.alias,
-        status: getAliasStateByVote(aliasInfo, { alias: row.alias }, row.identity_identifier)
+        status: getAliasStateByVote(aliasInfo, { ...row }, row.identity_identifier)
       }
     }))
   }

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -342,7 +342,7 @@ describe('Identities routes', () => {
           alias,
           contested: false,
           status: 'ok',
-          timestamp: null
+          timestamp: block.timestamp.toISOString(),
         }
       }
 
@@ -365,7 +365,7 @@ describe('Identities routes', () => {
           alias,
           contested: false,
           status: 'ok',
-          timestamp: null
+          timestamp: block.timestamp.toISOString(),
         }
       }
 

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -342,7 +342,7 @@ describe('Identities routes', () => {
           alias,
           contested: false,
           status: 'ok',
-          timestamp: block.timestamp.toISOString(),
+          timestamp: block.timestamp.toISOString()
         }
       }
 
@@ -365,7 +365,7 @@ describe('Identities routes', () => {
           alias,
           contested: false,
           status: 'ok',
-          timestamp: block.timestamp.toISOString(),
+          timestamp: block.timestamp.toISOString()
         }
       }
 

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -411,7 +411,7 @@ describe('Other routes', () => {
           alias: identityAlias.alias,
           contested: false,
           status: 'ok',
-          timestamp: block.timestamp.toISOString(),
+          timestamp: block.timestamp.toISOString()
         }
       }]
 

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -333,7 +333,7 @@ describe('Other routes', () => {
         }
       }
 
-      assert.deepEqual({ dataContract: expectedDataContract }, body)
+      assert.deepEqual({ dataContracts: [expectedDataContract] }, body)
     })
 
     it('should search by data contract name', async () => {
@@ -411,7 +411,7 @@ describe('Other routes', () => {
           alias: identityAlias.alias,
           contested: false,
           status: 'ok',
-          timestamp: null
+          timestamp: block.timestamp.toISOString(),
         }
       }]
 
@@ -453,7 +453,7 @@ describe('Other routes', () => {
         totalWithdrawals: 0
       }
 
-      assert.deepEqual({ identity: expectedIdentity }, body)
+      assert.deepEqual({ identities: [expectedIdentity] }, body)
     })
   })
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1387,7 +1387,7 @@ GET /search?query=xyz
 GET /search?query=36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm
 
 {
-  "identity": {
+  "identities": [{
     "identifier": "36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm",
     "alias": "xyz.dash",
     "status": {
@@ -1395,7 +1395,7 @@ GET /search?query=36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm
       "status": "ok",
       "contested": true
     }
-  }
+  }]
 }
 ```
 Response codes:


### PR DESCRIPTION
# Issue
At this moment we returns for search by alias array of identities or data contracts and one object on search by identifier, but that incorrect
# Things done
* Renamed properties for search one object and pushed it into array
* Added check for push new data to this array in next queries
* Added timestamp support to query for search by dpns in DAO