### PR TITLE
Api power for masternode votes

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1349,7 +1349,7 @@ GET /masternodes/votes?timestamp_start=2024-09-18T01:10:57.833Z&timestamp_end=20
         "dash",
         "test001"
       ],
-      "powerMultiplier": 1
+      "power": 1
     }
   ],
   "pagination": {
@@ -1532,7 +1532,7 @@ GET /contestedResource/WyJkYXNoIiwieHl6Il0=/votes?choice=1&page=1&limit=10&order
         "dash",
         "xyz"
       ],
-      "powerMultiplier": 1
+      "power": 1
     }
   ],
   "pagination": {

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1349,7 +1349,7 @@ GET /masternodes/votes?timestamp_start=2024-09-18T01:10:57.833Z&timestamp_end=20
         "dash",
         "test001"
       ],
-      "powerMultiplier": null
+      "powerMultiplier": 1
     }
   ],
   "pagination": {

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1532,7 +1532,7 @@ GET /contestedResource/WyJkYXNoIiwieHl6Il0=/votes?choice=1&page=1&limit=10&order
         "dash",
         "xyz"
       ],
-      "powerMultiplier": null
+      "powerMultiplier": 1
     }
   ],
   "pagination": {

--- a/packages/api/src/dao/ContestedResourcesDAO.js
+++ b/packages/api/src/dao/ContestedResourcesDAO.js
@@ -79,6 +79,7 @@ module.exports = class ContestedDAO {
         'prefunded_voting_balance', 'gas_used as vote_gas_used', 'document_timestamp',
         'masternode_votes.choice as choice', 'document_state_transition_hash',
         'masternode_votes.state_transition_hash as masternode_vote_tx',
+        'masternode_votes.power as masternode_power',
         'masternode_votes.towards_identity_identifier as towards_identity', 'contested_documents_sub.index_name as index_name',
         'contested_documents_sub.owner as owner', 'document_identifier', 'document_timestamp as timestamp',
         'contested_documents_sub.document_type_name as document_type_name'
@@ -291,7 +292,7 @@ module.exports = class ContestedDAO {
     const subquery = this.knex('masternode_votes')
       .select('masternode_votes.id as id', 'pro_tx_hash', 'masternode_votes.state_transition_hash as state_transition_hash', 'voter_identity_id', 'choice',
         'towards_identity_identifier', 'data_contract_id', 'document_type_name', 'index_name', 'index_values',
-        'data_contracts.identifier as data_contract_identifier', 'blocks.timestamp as timestamp', 'aliases')
+        'data_contracts.identifier as data_contract_identifier', 'blocks.timestamp as timestamp', 'aliases', 'power')
       .select(this.knex.raw(`rank() over (order by masternode_votes.id ${order}) rank`))
       .whereRaw(query, bindings)
       .leftJoin('data_contracts', 'data_contract_id', 'data_contracts.id')
@@ -302,7 +303,7 @@ module.exports = class ContestedDAO {
 
     const rows = await this.knex(subquery)
       .select('pro_tx_hash', 'subquery.state_transition_hash as state_transition_hash', 'choice',
-        'subquery.timestamp as timestamp', 'towards_identity_identifier', 'voter_identity_id',
+        'subquery.timestamp as timestamp', 'towards_identity_identifier', 'voter_identity_id', 'power',
         'data_contract_identifier', 'document_type_name', 'index_name', 'index_values', 'aliases')
       .select(this.knex(subquery).count('*').as('total_count'))
       .whereBetween('rank', [fromRank, toRank])

--- a/packages/api/src/dao/MasternodeVotesDAO.js
+++ b/packages/api/src/dao/MasternodeVotesDAO.js
@@ -40,7 +40,12 @@ module.exports = class MasternodeVotesDAO {
         ]
       : ['true']
 
-    // TODO: Implement Power filter
+    const powerFilter = power
+      ? [
+          'power = ?',
+          [power]
+        ]
+      : ['true']
 
     const aliasesSubquery = this.knex('identity_aliases')
       .select('identity_identifier', this.knex.raw('array_agg(alias) as aliases'))
@@ -50,12 +55,13 @@ module.exports = class MasternodeVotesDAO {
     const subquery = this.knex('masternode_votes')
       .select('masternode_votes.id as id', 'pro_tx_hash', 'masternode_votes.state_transition_hash as state_transition_hash', 'voter_identity_id', 'choice',
         'towards_identity_identifier', 'data_contract_id', 'document_type_name', 'index_name', 'index_values',
-        'data_contracts.identifier as data_contract_identifier', 'blocks.timestamp as timestamp', 'aliases')
+        'data_contracts.identifier as data_contract_identifier', 'blocks.timestamp as timestamp', 'aliases', 'power')
       .select(this.knex.raw(`rank() over (order by masternode_votes.id ${order}) rank`))
       .whereRaw(...timestampFilter)
       .whereRaw(...voterIdentityFilter)
       .whereRaw(...towardsIdentityFilter)
       .whereRaw(...choiceFilter)
+      .whereRaw(...powerFilter)
       .leftJoin('data_contracts', 'data_contract_id', 'data_contracts.id')
       .leftJoin('state_transitions', 'masternode_votes.state_transition_hash', 'state_transitions.hash')
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
@@ -65,7 +71,7 @@ module.exports = class MasternodeVotesDAO {
     const rows = await this.knex(subquery)
       .select('pro_tx_hash', 'subquery.state_transition_hash as state_transition_hash', 'choice',
         'subquery.timestamp as timestamp', 'towards_identity_identifier', 'voter_identity_id',
-        'data_contract_identifier', 'document_type_name', 'index_name', 'index_values', 'aliases')
+        'data_contract_identifier', 'document_type_name', 'index_name', 'index_values', 'aliases', 'power')
       .select(this.knex(subquery).count('*').as('total_count'))
       .whereBetween('rank', [fromRank, toRank])
       .orderBy('subquery.id', order)
@@ -89,7 +95,7 @@ module.exports = class MasternodeVotesDAO {
     const [row] = await this.knex('masternode_votes')
       .select('pro_tx_hash', 'masternode_votes.state_transition_hash as state_transition_hash', 'voter_identity_id', 'choice',
         'blocks.timestamp as timestamp', 'towards_identity_identifier', 'document_type_name',
-        'data_contracts.identifier as data_contract_identifier', 'index_name', 'index_values')
+        'data_contracts.identifier as data_contract_identifier', 'index_name', 'index_values', 'power')
       .where('masternode_votes.state_transition_hash', '=', hash)
       .leftJoin('state_transitions', 'state_transition_hash', 'state_transitions.hash')
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')

--- a/packages/api/src/models/Vote.js
+++ b/packages/api/src/models/Vote.js
@@ -28,7 +28,7 @@ module.exports = class Vote {
   }
 
   /* eslint-disable camelcase */
-  static fromRow ({ pro_tx_hash, state_transition_hash, voter_identity_id, choice, timestamp, towards_identity_identifier, data_contract_identifier, document_type_name, index_name, index_values, aliases }) {
-    return new Vote(pro_tx_hash, state_transition_hash, voter_identity_id?.trim(), choice, timestamp, towards_identity_identifier?.trim(), aliases, data_contract_identifier, document_type_name?.trim(), index_name?.trim(), index_values)
+  static fromRow ({ pro_tx_hash, state_transition_hash, voter_identity_id, choice, timestamp, towards_identity_identifier, data_contract_identifier, document_type_name, index_name, index_values, aliases, power }) {
+    return new Vote(pro_tx_hash, state_transition_hash, voter_identity_id?.trim(), choice, timestamp, towards_identity_identifier?.trim(), aliases, data_contract_identifier, document_type_name?.trim(), index_name?.trim(), index_values, power)
   }
 }

--- a/packages/api/src/models/Vote.js
+++ b/packages/api/src/models/Vote.js
@@ -10,9 +10,9 @@ module.exports = class Vote {
   documentTypeName
   indexName
   indexValues
-  powerMultiplier
+  power
 
-  constructor (proTxHash, txHash, voterIdentifier, choice, timestamp, towardsIdentity, identityAliases, dataContractIdentifier, documentTypeName, indexName, indexValues, powerMultiplier) {
+  constructor (proTxHash, txHash, voterIdentifier, choice, timestamp, towardsIdentity, identityAliases, dataContractIdentifier, documentTypeName, indexName, indexValues, power) {
     this.proTxHash = proTxHash ?? null
     this.txHash = txHash ?? null
     this.voterIdentifier = voterIdentifier ?? null
@@ -24,7 +24,7 @@ module.exports = class Vote {
     this.documentTypeName = documentTypeName ?? null
     this.indexName = indexName ?? null
     this.indexValues = indexValues ?? null
-    this.powerMultiplier = powerMultiplier ?? null
+    this.power = power ?? null
   }
 
   /* eslint-disable camelcase */

--- a/packages/api/src/schemas.js
+++ b/packages/api/src/schemas.js
@@ -117,8 +117,7 @@ const schemaTypes = [
       },
       power: {
         type: ['number', 'null'],
-        minimum: 0,
-        maximum: 1
+        enum: [1, 4]
       }
     }
   },

--- a/packages/api/test/integration/contested.spec.js
+++ b/packages/api/test/integration/contested.spec.js
@@ -282,7 +282,7 @@ describe('Contested documents routes', () => {
           indexName: masternodeVote.index_name,
           indexValues: JSON.parse(masternodeVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: masternodeVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -315,7 +315,7 @@ describe('Contested documents routes', () => {
           indexName: masternodeVote.index_name,
           indexValues: JSON.parse(masternodeVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: masternodeVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)

--- a/packages/api/test/integration/contested.spec.js
+++ b/packages/api/test/integration/contested.spec.js
@@ -282,7 +282,7 @@ describe('Contested documents routes', () => {
           indexName: masternodeVote.index_name,
           indexValues: JSON.parse(masternodeVote.index_values),
           identityAliases: [],
-          powerMultiplier: masternodeVote.power
+          power: masternodeVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -315,7 +315,7 @@ describe('Contested documents routes', () => {
           indexName: masternodeVote.index_name,
           indexValues: JSON.parse(masternodeVote.index_values),
           identityAliases: [],
-          powerMultiplier: masternodeVote.power
+          power: masternodeVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)

--- a/packages/api/test/integration/votes.spec.js
+++ b/packages/api/test/integration/votes.spec.js
@@ -110,7 +110,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -141,7 +141,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -172,7 +172,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -203,7 +203,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -234,7 +234,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -266,7 +266,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -299,7 +299,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -331,7 +331,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -363,7 +363,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: mnVote.power
+          power: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)

--- a/packages/api/test/integration/votes.spec.js
+++ b/packages/api/test/integration/votes.spec.js
@@ -47,7 +47,8 @@ describe('Masternode routes', () => {
         data_contract_id: dataContract.id,
         voter_id: i % 2 === 0 ? voterIdentity.identifier : identity.identifier,
         choice: i % 3 === 0 ? 0 : 2,
-        index_values: JSON.stringify(i % 2 === 0 ? ['dash', 'xyz'] : [])
+        index_values: JSON.stringify(i % 2 === 0 ? ['dash', 'xyz'] : []),
+        power: i % 2 === 0 ? 1 : 4
       })
 
       if (i === 0) {
@@ -57,7 +58,8 @@ describe('Masternode routes', () => {
           data_contract_id: dataContract.id,
           voter_id: voterIdentity.identifier,
           choice: i % 3 === 0 ? 0 : 2,
-          towards_identity_identifier: identity.identifier
+          towards_identity_identifier: identity.identifier,
+          power: i % 2 === 0 ? 1 : 4
         })
 
         masternodeVotes.push({
@@ -108,7 +110,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -139,7 +141,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -170,7 +172,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -201,7 +203,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -232,7 +234,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -264,7 +266,40 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: mnVote.power
+        }))
+
+      assert.deepStrictEqual(body.resultSet, expectedVotes)
+    })
+
+    it('should allow filter by timestamp and power', async () => {
+      const { body } = await client.get(`/masternodes/votes?timestamp_start=${new Date(0).toISOString()}&timestamp_end=${new Date(4200000).toISOString()}&power=4`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.resultSet.length, 7)
+      assert.equal(body.pagination.limit, 10)
+      assert.equal(body.pagination.total, 7)
+      assert.equal(body.pagination.page, 1)
+
+      const expectedVotes = masternodeVotes
+        .filter(vote => vote.mnVote.power === 4)
+        .filter(vote => new Date(vote.block.timestamp).getTime() < 4500000)
+        .sort((a, b) => a.mnVote.id - b.mnVote.id)
+        .slice(0, 10)
+        .map(({ block, voterIdentity, transaction, mnVote }) => ({
+          proTxHash: mnVote.pro_tx_hash,
+          txHash: mnVote.state_transition_hash,
+          voterIdentifier: mnVote.voter_identity_id,
+          choice: mnVote.choice,
+          timestamp: block.timestamp,
+          towardsIdentity: mnVote.towards_identity_identifier,
+          dataContractIdentifier: dataContract.identifier,
+          documentTypeName: mnVote.document_type_name,
+          indexName: mnVote.index_name,
+          indexValues: JSON.parse(mnVote.index_values),
+          identityAliases: [],
+          powerMultiplier: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -296,7 +331,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)
@@ -328,7 +363,7 @@ describe('Masternode routes', () => {
           indexName: mnVote.index_name,
           indexValues: JSON.parse(mnVote.index_values),
           identityAliases: [],
-          powerMultiplier: null
+          powerMultiplier: mnVote.power
         }))
 
       assert.deepStrictEqual(body.resultSet, expectedVotes)

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1316,7 +1316,7 @@ GET /masternodes/votes?timestamp_start=2024-09-18T01:10:57.833Z&timestamp_end=20
         "dash",
         "test001"
       ],
-      "powerMultiplier": null
+      "powerMultiplier": 1
     }
   ],
   "pagination": {

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1316,7 +1316,7 @@ GET /masternodes/votes?timestamp_start=2024-09-18T01:10:57.833Z&timestamp_end=20
         "dash",
         "test001"
       ],
-      "powerMultiplier": 1
+      "power": 1
     }
   ],
   "pagination": {
@@ -1499,7 +1499,7 @@ GET /contestedResource/WyJkYXNoIiwieHl6Il0=/votes?choice=1&page=1&limit=10&order
         "dash",
         "xyz"
       ],
-      "powerMultiplier": 1
+      "power": 1
     }
   ],
   "pagination": {

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1499,7 +1499,7 @@ GET /contestedResource/WyJkYXNoIiwieHl6Il0=/votes?choice=1&page=1&limit=10&order
         "dash",
         "xyz"
       ],
-      "powerMultiplier": null
+      "powerMultiplier": 1
     }
   ],
   "pagination": {


### PR DESCRIPTION
# Issue
After all my PR's we have support of `power` in indexer and we can implement it on backend
# Things done
- Added power filter to query
- Added power to response
- Added power to contested resources queries
- Updated tests
- Updated README.md