### PR TITLE
Broadcast transaction and identity nonce queries

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -77,6 +77,9 @@ Reference:
 * [Masternode Votes](#masternode-votes)
 * [Search](#search)
 * [Decode Raw Transaction](#decode-raw-transaction)
+* [Identity Nonce](#identity-nonce)
+* [Identity Contract Nonce](#identity-contract-nonce)
+* [Broadcast Transaction](#broadcast-transaction)
 
 ### Status
 Returns basic stats and epoch info
@@ -2204,6 +2207,57 @@ IDENTITY_CREATE with instantLock
     "choice": "Abstain",
     "proTxHash": 'ad4e38fc81da72d61b14238ee6e5b91915554e24d725718800692d3a863c910b',
     "raw": "08005b246080ba64350685fe302d3d790f5bb238cb619920d46230c844f079944a233bb2df460e72e3d59e7fe1c082ab3a5bd9445dd0dd5c4894a6d9f0d9ed9404b5000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c021204646173681203793031010c00412019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d"
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+503: Service Temporarily Unavailable
+```
+___
+### Identity Nonce
+Return Identity Nonce
+```
+GET /identity/HTfJKDuW8omFfFrSQuNTkgW39WpncdwFUrL91VJyJXUS/nonce
+{
+    "identityNonce": "1"
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+503: Service Temporarily Unavailable
+```
+___
+### Identity Contract Nonce
+Return Identity Contract Nonce
+```
+GET /identity/HTfJKDuW8omFfFrSQuNTkgW39WpncdwFUrL91VJyJXUS/contract/6hVQW16jyvZyGSQk2YVty4ND6bgFXozizYWnPt753uW5/nonce
+{
+    "identityContractNonce": "2"
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+503: Service Temporarily Unavailable
+```
+___
+### Broadcast Transaction
+Send Transaction for Broadcast
+```
+POST /transaction/broadcast
+BODY:
+{
+    "base64": "AgDpAd/Bcqls4/fTNNbAtp3zsByG0w/wOnwk9RaDj5Q0DQEAAAAetrSpdOHzvWhmll5EyXQFOW6JEoHRY2Alb0wBP6ic9AcEbm90ZYpK8hfzQOnEyVhXSWzzO2jrbHEqxtIKHreFTRSv2f/PxVTtZXkupT+mJytiIWsAU0U1Ke1abN0JJvNNU1182eoCBmF1dGhvchIGb3dsMzUyB21lc3NhZ2USBHRlc3QAAAAA"
+}
+
+RESPONSE:
+{
+  "message": "broadcasted"
 }
 ```
 Response codes:

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -13,7 +13,7 @@
   },
   "dependencies": {
     "@dashevo/wasm-dpp": "github:owl352/wasm-dpp#test",
-    "@dashevo/dapi-client": "github:owl352/dapi-client",
+    "@dashevo/dapi-client": "github:owl352/dapi-client#experimental",
     "@dashevo/dashd-rpc": "github:owl352/dashd-rpc",
     "@fastify/cors": "^8.3.0",
     "@scure/base": "^1.1.5",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,14 +12,14 @@
     "lint": "standard ."
   },
   "dependencies": {
-    "@dashevo/wasm-dpp": "github:owl352/wasm-dpp",
+    "@dashevo/wasm-dpp": "github:owl352/wasm-dpp#test",
     "@dashevo/dapi-client": "github:owl352/dapi-client",
     "@dashevo/dashd-rpc": "github:owl352/dashd-rpc",
     "@fastify/cors": "^8.3.0",
     "@scure/base": "^1.1.5",
     "bs58": "^6.0.0",
     "cbor": "^9.0.2",
-    "dash": "4.7.0",
+    "dash": "github:owl352/js-dash-sdk",
     "dotenv": "^16.3.1",
     "fastify": "^4.21.0",
     "fastify-metrics": "^11.0.0",

--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -117,6 +117,11 @@ class DAPI {
     })
   }
 
+  async getIdentityNonce (identifier){
+    const {identityNonce} = await this.dapi.platform.getIdentityNonce(Identifier.from(identifier))
+    return identityNonce
+  }
+
   async getStatus () {
     return this.dapi.platform.getStatus()
   }

--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -120,6 +120,10 @@ class DAPI {
   async getStatus () {
     return this.dapi.platform.getStatus()
   }
+
+  async broadcastTransition (base64) {
+    return this.dapi.platform.broadcastStateTransition(base64)
+  }
 }
 
 module.exports = DAPI

--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -118,8 +118,8 @@ class DAPI {
     })
   }
 
-  async getIdentityNonce (identifier){
-    const {identityNonce} = await this.dapi.platform.getIdentityNonce(Identifier.from(identifier))
+  async getIdentityNonce (identifier) {
+    const { identityNonce } = await this.dapi.platform.getIdentityNonce(Identifier.from(identifier))
     return identityNonce
   }
 

--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -123,6 +123,11 @@ class DAPI {
     return identityNonce
   }
 
+  async getIdentityContractNonce (identifier, dataContractId) {
+    const { identityContractNonce } = await this.dapi.platform.getIdentityContractNonce(Identifier.from(identifier), Identifier.from(dataContractId))
+    return identityContractNonce
+  }
+
   async getStatus () {
     return this.dapi.platform.getStatus()
   }

--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -100,6 +100,7 @@ class DAPI {
       return {
         keyId: serialized.getId(),
         type: serialized.getType(),
+        raw: Buffer.from(key).toString('hex'),
         data: Buffer.from(serialized.getData()).toString('hex'),
         purpose: serialized.getPurpose(),
         securityLevel: serialized.getSecurityLevel(),

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -130,6 +130,14 @@ class IdentitiesController {
 
     response.send(new PaginatedResultSet(resultSet, null, null, null))
   }
+
+  getIdentityNonce = async (request, response) => {
+    const { identifier } = request.params
+
+    const nonce = await this.dapi.getIdentityNonce(identifier)
+
+    response.send({nonce})
+  }
 }
 
 module.exports = IdentitiesController

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -136,7 +136,7 @@ class IdentitiesController {
 
     const nonce = await this.dapi.getIdentityNonce(identifier)
 
-    response.send({ nonce })
+    response.send({ nonce: String(nonce) })
   }
 }
 

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -136,7 +136,15 @@ class IdentitiesController {
 
     const nonce = await this.dapi.getIdentityNonce(identifier)
 
-    response.send({ nonce: String(nonce) })
+    response.send({ identityNonce: String(nonce) })
+  }
+
+  getIdentityContractNonce = async (request, response) => {
+    const { identifier, data_contract_id: dataContractId } = request.params
+
+    const nonce = await this.dapi.getIdentityContractNonce(identifier, dataContractId)
+
+    response.send({ identityContractNonce: String(nonce) })
   }
 }
 

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -136,7 +136,7 @@ class IdentitiesController {
 
     const nonce = await this.dapi.getIdentityNonce(identifier)
 
-    response.send({nonce})
+    response.send({ nonce })
   }
 }
 

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -135,7 +135,11 @@ class TransactionsController {
   broadcastTransaction = async (request, response) => {
     const { base64 } = request.body
 
-    await this.dapi.broadcastTransition(base64)
+    try {
+      await this.dapi.broadcastTransition(base64)
+    } catch (e) {
+      return response.status(400).send({ error: e.toString() })
+    }
 
     response.send('broadcasted')
   }

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -141,7 +141,7 @@ class TransactionsController {
       return response.status(400).send({ error: e.toString() })
     }
 
-    response.send('broadcasted')
+    response.send({message: 'broadcasted'})
   }
 }
 

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -149,6 +149,14 @@ class TransactionsController {
 
     response.send({ documentBatchTransition: transaction })
   }
+
+  broadcastTransaction = async (request, response) => {
+    const {base64} = request.body
+
+    await this.dapi.broadcastTransition(base64)
+
+    response.send('broadcasted')
+  }
 }
 
 module.exports = TransactionsController

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -151,7 +151,7 @@ class TransactionsController {
   }
 
   broadcastTransaction = async (request, response) => {
-    const {base64} = request.body
+    const { base64 } = request.body
 
     await this.dapi.broadcastTransition(base64)
 

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -132,24 +132,6 @@ class TransactionsController {
     reply.send(decoded)
   }
 
-  createDocumentBatchTransition = async (request, response) => {
-    const { dataContractId, documentTypeName, data, owner, batchType, nonce } = request.body
-
-    if (!batchType) {
-      return response.status(400).send({ message: 'batchType cannot be empty' })
-    }
-
-    const dataContract = await this.dataContractsDAO.getDataContractByIdentifier(dataContractId)
-
-    if (!dataContract) {
-      return response.status(404).send({ message: 'data contract not found' })
-    }
-
-    const transaction = await utils.createDocumentBatchTransition(this.client, dataContract, owner, documentTypeName, data, batchType, nonce)
-
-    response.send({ documentBatchTransition: transaction })
-  }
-
   broadcastTransaction = async (request, response) => {
     const { base64 } = request.body
 

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -133,7 +133,7 @@ class TransactionsController {
   }
 
   createDocumentBatchTransition = async (request, response) => {
-    const { dataContractId, documentTypeName, data, owner, batchType } = request.body
+    const { dataContractId, documentTypeName, data, owner, batchType, nonce } = request.body
 
     if (!batchType) {
       return response.status(400).send({ message: 'batchType cannot be empty' })
@@ -145,7 +145,7 @@ class TransactionsController {
       return response.status(404).send({ message: 'data contract not found' })
     }
 
-    const transaction = await utils.createDocumentBatchTransition(this.client, dataContract, owner, documentTypeName, data, batchType)
+    const transaction = await utils.createDocumentBatchTransition(this.client, dataContract, owner, documentTypeName, data, batchType, nonce)
 
     response.send({ documentBatchTransition: transaction })
   }

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -141,7 +141,7 @@ class TransactionsController {
       return response.status(400).send({ error: e.toString() })
     }
 
-    response.send({message: 'broadcasted'})
+    response.send({ message: 'broadcasted' })
   }
 }
 

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -470,8 +470,23 @@ module.exports = ({
               enum: ['create', 'replace', 'delete']
             },
             nonce: {
-              type: 'number'
+              type: 'string',
+              pattern: "[0-9]"
             }
+          }
+        }
+      },
+    },
+    {
+      path: '/transaction/broadcast',
+      method: 'POST',
+      handler: transactionsController.broadcastTransaction,
+      schema: {
+        body: {
+          type: 'object',
+          required: ['base64'],
+          properties: {
+            base64: { type: 'string' }
           }
         }
       }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -444,6 +444,33 @@ module.exports = ({
       schema: {
         querystring: { $ref: 'paginationOptions#' }
       }
+    },
+    {
+      path: '/transaction/create',
+      method: 'POST',
+      handler: transactionsController.createDocumentBatchTransition,
+      schema: {
+        body: {
+          type: 'object',
+          properties: {
+            dataContractId: { $ref: 'identifier#' },
+            owner: { $ref: 'identifier#' },
+            documentTypeName: {
+              type: 'string',
+              minLength: 1,
+              maxLength: 100
+            },
+            data: {
+              type: 'object'
+            },
+            batchType: {
+              type: 'string',
+              // at this moment available only create
+              enum: ['create', 'replace', 'delete']
+            }
+          }
+        }
+      }
     }
   ]
 

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -503,6 +503,20 @@ module.exports = ({
           }
         }
       }
+    },
+    {
+      path: '/identity/:identifier/contract/:data_contract_id/nonce',
+      method: 'GET',
+      handler: identitiesController.getIdentityContractNonce,
+      schema: {
+        querystring: {
+          type: 'object',
+          properties: {
+            identifier: { $ref: 'identifier#' },
+            data_contract_id: { $ref: 'identifier#' }
+          }
+        }
+      }
     }
   ]
 

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -451,6 +451,7 @@ module.exports = ({
       handler: transactionsController.createDocumentBatchTransition,
       schema: {
         body: {
+          required: ['dataContractId', 'owner', 'documentTypeName', 'data', 'batchType', 'nonce'],
           type: 'object',
           properties: {
             dataContractId: { $ref: 'identifier#' },
@@ -467,6 +468,9 @@ module.exports = ({
               type: 'string',
               // at this moment available only create
               enum: ['create', 'replace', 'delete']
+            },
+            nonce: {
+              type: 'number'
             }
           }
         }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -490,6 +490,19 @@ module.exports = ({
           }
         }
       }
+    },
+    {
+      path: '/identity/:identifier/nonce',
+      method: 'GET',
+      handler: identitiesController.getIdentityNonce,
+      schema: {
+        querystring: {
+          type: 'object',
+          properties: {
+            identifier: { $ref: 'identifier#' }
+          }
+        }
+      }
     }
   ]
 

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -471,11 +471,11 @@ module.exports = ({
             },
             nonce: {
               type: 'string',
-              pattern: "[0-9]"
+              pattern: '[0-9]'
             }
           }
         }
-      },
+      }
     },
     {
       path: '/transaction/broadcast',

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -446,38 +446,6 @@ module.exports = ({
       }
     },
     {
-      path: '/transaction/create',
-      method: 'POST',
-      handler: transactionsController.createDocumentBatchTransition,
-      schema: {
-        body: {
-          required: ['dataContractId', 'owner', 'documentTypeName', 'data', 'batchType', 'nonce'],
-          type: 'object',
-          properties: {
-            dataContractId: { $ref: 'identifier#' },
-            owner: { $ref: 'identifier#' },
-            documentTypeName: {
-              type: 'string',
-              minLength: 1,
-              maxLength: 100
-            },
-            data: {
-              type: 'object'
-            },
-            batchType: {
-              type: 'string',
-              // at this moment available only create
-              enum: ['create', 'replace', 'delete']
-            },
-            nonce: {
-              type: 'string',
-              pattern: '[0-9]'
-            }
-          }
-        }
-      }
-    },
-    {
       path: '/transaction/broadcast',
       method: 'POST',
       handler: transactionsController.broadcastTransaction,

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -32,7 +32,7 @@ const hash = (data) => {
   return crypto.createHash('sha1').update(data).digest('hex')
 }
 
-const createDocumentBatchTransition = async (client, dataContractObject, owner, documentTypeName, data, batchType) => {
+const createDocumentBatchTransition = async (client, dataContractObject, owner, documentTypeName, data, batchType, nonce) => {
   const dpp = client.platform.dpp
 
   const dataContract = dpp.dataContract.create(Identifier.from(dataContractObject.owner.identifier), BigInt(0), JSON.parse(dataContractObject.schema))
@@ -51,7 +51,7 @@ const createDocumentBatchTransition = async (client, dataContractObject, owner, 
 
   const tx = dpp.document.createStateTransition(batch, {
     [owner]: {
-      [dataContract.getId().toString()]: 0
+      [dataContract.getId().toString()]: nonce
     }
   })
 

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -165,7 +165,7 @@ const decodeStateTransition = async (client, base64) => {
         type: assetLockProof instanceof InstantAssetLockProof ? 'instantSend' : 'chainLock',
         instantLock: assetLockProof instanceof InstantAssetLockProof ? assetLockProof.getInstantLock().toString('base64') : null,
         fundingAmount: decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis
-          ?String(decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis)
+          ? String(decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis)
           : null,
         fundingCoreTx: Buffer.from(assetLockProof.getOutPoint().slice(0, 32).toReversed()).toString('hex'),
         vout: assetLockProof.getOutPoint().readInt8(32)
@@ -214,7 +214,7 @@ const decodeStateTransition = async (client, base64) => {
         type: assetLockProof instanceof InstantAssetLockProof ? 'instantSend' : 'chainLock',
         fundingAmount: decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis
           ? String(decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis)
-          :null,
+          : null,
         fundingCoreTx: Buffer.from(assetLockProof.getOutPoint().slice(0, 32).toReversed()).toString('hex'),
         vout: assetLockProof.getOutPoint().readInt8(32)
       }

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -82,7 +82,7 @@ const decodeStateTransition = async (client, base64) => {
 
       decoded.version = stateTransition.getDataContract().getVersion()
       decoded.userFeeIncrease = stateTransition.toObject().userFeeIncrease
-      decoded.identityNonce = Number(stateTransition.getIdentityNonce())
+      decoded.identityNonce = String(stateTransition.getIdentityNonce())
       decoded.dataContractId = stateTransition.getDataContract().getId().toString()
       decoded.ownerId = stateTransition.getOwnerId().toString()
       decoded.schema = stateTransition.getDataContract().getDocumentSchemas()
@@ -97,10 +97,10 @@ const decodeStateTransition = async (client, base64) => {
         const out = {
           id: documentTransition.getId().toString(),
           dataContractId: documentTransition.getDataContractId().toString(),
-          revision: documentTransition.getRevision(),
+          revision: String(documentTransition.getRevision()),
           type: documentTransition.getType(),
           action: documentTransition.getAction(),
-          nonce: Number(documentTransition.getIdentityContractNonce())
+          nonce: String(documentTransition.getIdentityContractNonce())
         }
 
         switch (documentTransition.getAction()) {
@@ -242,7 +242,7 @@ const decodeStateTransition = async (client, base64) => {
       decoded.userFeeIncrease = stateTransition.toObject().userFeeIncrease
       decoded.ownerId = stateTransition.getDataContract().getOwnerId().toString()
       decoded.dataContractId = stateTransition.getDataContract().getId().toString()
-      decoded.dataContractNonce = Number(stateTransition.getDataContract().getIdentityNonce())
+      decoded.dataContractNonce = String(stateTransition.getDataContract().getIdentityNonce())
       decoded.schema = stateTransition.getDataContract().getDocumentSchemas()
       decoded.version = stateTransition.getDataContract().getVersion()
       decoded.dataContractOwner = stateTransition.getDataContract().getOwnerId().toString()
@@ -251,7 +251,7 @@ const decodeStateTransition = async (client, base64) => {
       break
     }
     case StateTransitionEnum.IDENTITY_UPDATE: {
-      decoded.identityContractNonce = Number(stateTransition.getIdentityContractNonce())
+      decoded.identityContractNonce = String(stateTransition.getIdentityContractNonce())
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
       decoded.identityId = stateTransition.getOwnerId().toString()
       decoded.revision = stateTransition.getRevision()
@@ -286,7 +286,7 @@ const decodeStateTransition = async (client, base64) => {
       break
     }
     case StateTransitionEnum.IDENTITY_CREDIT_TRANSFER: {
-      decoded.nonce = Number(stateTransition.getNonce())
+      decoded.nonce = String(stateTransition.getNonce())
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
       decoded.senderId = stateTransition.getIdentityId().toString()
       decoded.recipientId = stateTransition.getRecipientId().toString()
@@ -314,7 +314,7 @@ const decodeStateTransition = async (client, base64) => {
       decoded.signaturePublicKeyId = stateTransition.toObject().signaturePublicKeyId
       decoded.pooling = PoolingEnum[stateTransition.getPooling()]
       decoded.raw = stateTransition.toBuffer().toString('hex')
-      decoded.nonce = Number(stateTransition.getNonce())
+      decoded.nonce = String(stateTransition.getNonce())
 
       break
     }
@@ -330,7 +330,7 @@ const decodeStateTransition = async (client, base64) => {
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
       decoded.raw = stateTransition.toBuffer().toString('hex')
       decoded.proTxHash = stateTransition.getProTxHash().toString('hex')
-      decoded.nonce = Number(stateTransition.getIdentityContractNonce())
+      decoded.nonce = String(stateTransition.getIdentityContractNonce())
 
       break
     }

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -164,7 +164,9 @@ const decodeStateTransition = async (client, base64) => {
         coreChainLockedHeight: assetLockProof instanceof ChainAssetLockProof ? assetLockProof.getCoreChainLockedHeight() : null,
         type: assetLockProof instanceof InstantAssetLockProof ? 'instantSend' : 'chainLock',
         instantLock: assetLockProof instanceof InstantAssetLockProof ? assetLockProof.getInstantLock().toString('base64') : null,
-        fundingAmount: decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis ?? null,
+        fundingAmount: decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis
+          ?String(decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis)
+          : null,
         fundingCoreTx: Buffer.from(assetLockProof.getOutPoint().slice(0, 32).toReversed()).toString('hex'),
         vout: assetLockProof.getOutPoint().readInt8(32)
       }
@@ -210,13 +212,15 @@ const decodeStateTransition = async (client, base64) => {
       decoded.assetLockProof = {
         coreChainLockedHeight: assetLockProof instanceof ChainAssetLockProof ? assetLockProof.getCoreChainLockedHeight() : null,
         type: assetLockProof instanceof InstantAssetLockProof ? 'instantSend' : 'chainLock',
-        fundingAmount: decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis ?? null,
+        fundingAmount: decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis
+          ? String(decodedTransaction?.outputs[assetLockProof.getOutPoint().readInt8(32)].satoshis)
+          :null,
         fundingCoreTx: Buffer.from(assetLockProof.getOutPoint().slice(0, 32).toReversed()).toString('hex'),
         vout: assetLockProof.getOutPoint().readInt8(32)
       }
 
       decoded.identityId = stateTransition.getIdentityId().toString()
-      decoded.amount = output.satoshis * 1000
+      decoded.amount = String(output.satoshis * 1000)
       decoded.signature = stateTransition.getSignature()?.toString('hex') ?? null
       decoded.raw = stateTransition.toBuffer().toString('hex')
 
@@ -254,7 +258,7 @@ const decodeStateTransition = async (client, base64) => {
       decoded.identityContractNonce = String(stateTransition.getIdentityContractNonce())
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
       decoded.identityId = stateTransition.getOwnerId().toString()
-      decoded.revision = stateTransition.getRevision()
+      decoded.revision = String(stateTransition.getRevision())
 
       decoded.publicKeysToAdd = stateTransition.getPublicKeysToAdd()
         .map(key => {
@@ -290,7 +294,7 @@ const decodeStateTransition = async (client, base64) => {
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
       decoded.senderId = stateTransition.getIdentityId().toString()
       decoded.recipientId = stateTransition.getRecipientId().toString()
-      decoded.amount = stateTransition.getAmount()
+      decoded.amount = String(stateTransition.getAmount())
       decoded.signaturePublicKeyId = stateTransition.toObject().signaturePublicKeyId
       decoded.signature = stateTransition.getSignature()?.toString('hex') ?? null
       decoded.raw = stateTransition.toBuffer().toString('hex')
@@ -307,7 +311,7 @@ const decodeStateTransition = async (client, base64) => {
 
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
       decoded.senderId = stateTransition.getIdentityId().toString()
-      decoded.amount = parseInt(stateTransition.getAmount())
+      decoded.amount = String(stateTransition.getAmount())
       decoded.outputScript = stateTransition.getOutputScript()?.toString('hex') ?? null
       decoded.coreFeePerByte = stateTransition.getCoreFeePerByte()
       decoded.signature = stateTransition.getSignature()?.toString('hex')

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -51,7 +51,7 @@ const createDocumentBatchTransition = async (client, dataContractObject, owner, 
 
   const tx = dpp.document.createStateTransition(batch, {
     [owner]: {
-      [dataContract.getId().toString()]: nonce
+      [dataContract.getId().toString()]: BigInt(nonce).toString()
     }
   })
 

--- a/packages/api/test/integration/documents.spec.js
+++ b/packages/api/test/integration/documents.spec.js
@@ -171,7 +171,7 @@ describe('Documents routes', () => {
           aliases: []
         },
         system: document.document.is_system,
-        nonce: 2,
+        nonce: '2',
         gasUsed: null,
         totalGasUsed: 0,
         transitionType: 0
@@ -203,7 +203,7 @@ describe('Documents routes', () => {
           aliases: []
         },
         txHash: document.transaction.hash,
-        nonce: 2,
+        nonce: '2',
         gasUsed: null,
         totalGasUsed: 0,
         transitionType: 0

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -391,7 +391,7 @@ describe('Other routes', () => {
         },
         gasUsed: null,
         totalGasUsed: 0,
-        nonce: 2
+        nonce: '2'
       }
 
       assert.deepEqual({ document: expectedDataContract }, body)

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -40,7 +40,7 @@ describe('Utils', () => {
         },
         userFeeIncrease: 0,
         version: 1,
-        identityNonce: 10,
+        identityNonce: '10',
         dataContractId: 'GbGD5YbS9GVh7FSZjz3uUJpbrXo9ctbdKycfTqqg3Cmn',
         ownerId: '7dwjL5frrkM69pv3BsKSQb4ELrMYmDeE11KNoDSefG6c',
         schema: {
@@ -82,12 +82,12 @@ describe('Utils', () => {
           {
             id: '7TsrNHXDy14fYoRcoYjZHH14K4riMGU2VeHMwopG82DL',
             dataContractId: 'FhKAsUnPbqe7K4TZxgRdtPUrfSvNCtYV8iPsvjX7ZG58',
-            revision: 1,
+            revision: '1',
             prefundedVotingBalance: null,
             type: 'note',
             entropy: 'f09a3ceacaa2f12b9879ba223d5b8c66c3106efe58edc511556f31ee9676412b',
             action: 0,
-            nonce: 2,
+            nonce: '2',
             data: {
               message: 'Tutorial CI Test @ Thu, 08 Aug 2024 20:25:03 GMT'
             }
@@ -109,7 +109,7 @@ describe('Utils', () => {
         assetLockProof: {
           coreChainLockedHeight: null,
           type: 'instantSend',
-          fundingAmount: 30000000,
+          fundingAmount: '30000000',
           vout: 0,
           fundingCoreTx: 'fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d',
           instantLock: 'AQEKM9t1ICNzvddKryjM4enKn0Y5amBn3o6DwDoC4uk5SAAAAAAdraxrxe5CKYujiUmN9V1mgT5gQ3Bz2TzaGCW+TN2J/JQP49yOk0uJ6el6ls9CmNo++yPYoX1Sx1lWEZTTAAAAhXiuCBXgzawuboxMAXDiXQpJCCPi417VE4mdcYPgTa0/Hd+RCHLAR6H+MXhqKazlGddI7AdWxxLZ94ZvQu+qIpe7G9XRRjQWeYwroIyc6MqQF5mKpvV0AUMYUNMXjCsq'
@@ -164,12 +164,12 @@ describe('Utils', () => {
         assetLockProof: {
           coreChainLockedHeight: null,
           type: 'instantSend',
-          fundingAmount: 300000,
+          fundingAmount: '300000',
           vout: 0,
           fundingCoreTx: '7734f498c5b59f64f73070e0a5ec4fa113065da00358223cf888c3c27317ea64'
         },
         identityId: '4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF',
-        amount: 300000000,
+        amount: '300000000',
         signature: '810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710',
         raw: '040000c60101ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d5660000000064ea1773c2c388f83c225803a05d0613a14feca5e07030f7649fb5c598f43477940fe3dc8e934b89e9e97a96cf4298da3efb23d8a17d52c759561194d3000000a5e81597e94558618bf1464801188ecbc09c7a12e73489225c63684259f075f87aa3d47ea9bbbe1f9c314086ddc35a6d18b30ff4fe579855779f9268b8bf5c79760c7d8c56d34163931f016c2e3036852dd33a6b643dd59dc8c54199f34e3d2def0300080001ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d566000000006a4730440220339d4d894eb2ff9c193bd8c33cdb3030a8be18ddbf30d983e8286c08c6c4c7d90220181741d9eed3814ec077030c26c0b9fff63b9ef10e1e6ca1c87069b261b0127a0121034951bbd5d0d500942426507d4b84e6d88406300ed82009a8db087f493017786affffffff02e093040000000000026a0078aa0a00000000001976a914706db5d1e8fb5f925c6db64104f4b77f0c8b73d488ac00000000240101e0930400000000001976a91474a509b4f3b80ce818465dc0f9f66e2103d9178b88ac003012c19b98ec0033addb36cd64b7f510670f2a351a4304b5f6994144286efdac411f810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710'
       })
@@ -196,7 +196,7 @@ describe('Utils', () => {
         userFeeIncrease: 0,
         ownerId: '7dwjL5frrkM69pv3BsKSQb4ELrMYmDeE11KNoDSefG6c',
         dataContractId: '8BzeH7dmyLHNzcCtG6DGowAkWyRgWEq15y88Zz2zBxVg',
-        dataContractNonce: 0,
+        dataContractNonce: '0',
         schema: {
           labler: {
             type: 'object',
@@ -232,10 +232,10 @@ describe('Utils', () => {
 
       assert.deepEqual(decoded, {
         type: 5,
-        identityContractNonce: 2,
+        identityContractNonce: '2',
         userFeeIncrease: 0,
         identityId: 'AGQc1dwAc46Js6fvSBSqV2Zi7fCq2YvoAwEb1SmYtXuM',
-        revision: 1,
+        revision: '1',
         publicKeysToAdd: [
           {
             contractBounds: {
@@ -280,11 +280,11 @@ describe('Utils', () => {
 
       assert.deepEqual(decoded, {
         type: 7,
-        nonce: 3,
+        nonce: '3',
         userFeeIncrease: 2,
         senderId: '4CpFVPyU95ZxNeDnRWfkpjUa9J72i3nZ4YPsTnpdUudu',
         recipientId: 'GxdRSLivPDeACYU8Z6JSNvtrRPX7QG715JoumnctbwWN',
-        amount: 9998363,
+        amount: '9998363',
         signaturePublicKeyId: 65,
         signature: 'ca8aaa0ee3861da3579129ada28d1f2bdcbd847dd2dc1ddc9897fba3ba8c5060',
         raw: '07002f99e00e7f82a904c3fbf60ae6b5329ef77444436d022fb0aeb068c35bc7b0c4ed1f6e1c441217d504cf4e5e2b4754890563cd4410dda131cfd2973f03acffdffc0098901b03024120ca8aaa0ee3861da3579129ada28d1f2bdcbd847dd2dc1ddc9897fba3ba8c5060'
@@ -299,8 +299,8 @@ describe('Utils', () => {
         outputAddress: 'yZF5JqEgS9xT1xSkhhUQACdLLDbqSixL8i',
         userFeeIncrease: 2,
         senderId: 'FvqzjDyub72Hk51pcmJvd1JUACuor7vA3aJawiVG7Z17',
-        amount: 1000000,
-        nonce: 1,
+        amount: '1000000',
+        nonce: '1',
         outputScript: '76a9148dc5fd6be194390035cca6293a357bac8e3c35c588ac',
         coreFeePerByte: 2,
         signature: '8422df782b5e51b8a53ae46fe9b7a9280df4de575f031e58ed527e7a17c1e9',
@@ -331,7 +331,7 @@ describe('Utils', () => {
         raw: '0800bc77a5a2cec455c79fb92fb683dbd87a2a92b663c9a46d0c50d11889b4aeb121126fac34e15653f82356cffd3d37c5cd84c1f634d4043340dbae781d93d6b87e000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c02120464617368120874657374303130300033daa5a3e330b61e5a4416ab224f0a45ef4e4cab1357b5f4a86fae9314717a561000411f6c69fa9201b57bb7e7c24b392de9056cce5a66bcf2154d57631419e9c68efa8e4d1ca11e81c35de31dd52321d0fbb25f6ff17f5ff69a9cf47fce54746ee72644',
         proTxHash: 'bc77a5a2cec455c79fb92fb683dbd87a2a92b663c9a46d0c50d11889b4aeb121',
         userFeeIncrease: 0,
-        nonce: 16
+        nonce: '16'
       })
     })
   })

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -44,6 +44,9 @@ Reference:
 * [Masternode Votes](#masternode-votes)
 * [Search](#search)
 * [Decode Raw Transaction](#decode-raw-transaction)
+* [Identity Nonce](#identity-nonce)
+* [Identity Contract Nonce](#identity-contract-nonce)
+* [Broadcast Transaction](#broadcast-transaction)
 
 ### Status
 Returns basic stats and epoch info
@@ -2171,6 +2174,57 @@ IDENTITY_CREATE with instantLock
     "choice": "Abstain",
     "proTxHash": 'ad4e38fc81da72d61b14238ee6e5b91915554e24d725718800692d3a863c910b',
     "raw": "08005b246080ba64350685fe302d3d790f5bb238cb619920d46230c844f079944a233bb2df460e72e3d59e7fe1c082ab3a5bd9445dd0dd5c4894a6d9f0d9ed9404b5000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c021204646173681203793031010c00412019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d"
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+503: Service Temporarily Unavailable
+```
+___
+### Identity Nonce
+Return Identity Nonce
+```
+GET /identity/HTfJKDuW8omFfFrSQuNTkgW39WpncdwFUrL91VJyJXUS/nonce
+{
+    "identityNonce": "1"
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+503: Service Temporarily Unavailable
+```
+___
+### Identity Contract Nonce
+Return Identity Contract Nonce
+```
+GET /identity/HTfJKDuW8omFfFrSQuNTkgW39WpncdwFUrL91VJyJXUS/contract/6hVQW16jyvZyGSQk2YVty4ND6bgFXozizYWnPt753uW5/nonce
+{
+    "identityContractNonce": "2"
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+503: Service Temporarily Unavailable
+```
+___
+### Broadcast Transaction
+Send Transaction for Broadcast
+```
+POST /transaction/broadcast
+BODY:
+{
+    "base64": "AgDpAd/Bcqls4/fTNNbAtp3zsByG0w/wOnwk9RaDj5Q0DQEAAAAetrSpdOHzvWhmll5EyXQFOW6JEoHRY2Alb0wBP6ic9AcEbm90ZYpK8hfzQOnEyVhXSWzzO2jrbHEqxtIKHreFTRSv2f/PxVTtZXkupT+mJytiIWsAU0U1Ke1abN0JJvNNU1182eoCBmF1dGhvchIGb3dsMzUyB21lc3NhZ2USBHRlc3QAAAAA"
+}
+
+RESPONSE:
+{
+  "message": "broadcasted"
 }
 ```
 Response codes:


### PR DESCRIPTION
# Issue
We need some tools for constructing client side transactions and broadcasting them via PE
# Things done
* added in test mode new branch for fork [wasm-dpp](https://github.com/owl352/wasm-dpp)
* new braches for [dapi-grpc](https://github.com/owl352/dapi-grpc) and [dapi-client](https://github.com/owl352/dapi-client)
* updated `js-dash-sdk`
* Implemented in dapi `broadcastTransition`
* Implemented `getIdentityNonce` and `getIdentityContractNonce` in `IdentityController`
* Implemented `broadcastTransaction` in `TransactionController`