### PR TITLE
Implement BigInt conversions after #505 PR

### DIFF
--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -62,7 +62,7 @@ class MainController {
         }
       },
       tenderdash: {
-        version: status?.version?.tenderdash ?? null,
+        version: status?.version?.tenderdashVersion ?? null,
         block: {
           height: tdStatus?.highestBlock?.height ?? null,
           hash: tdStatus?.highestBlock?.hash ?? null,

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -46,7 +46,7 @@ class MainController {
     response.send({
       epoch,
       transactionsCount: stats?.transactionsCount,
-      totalCredits,
+      totalCredits: String(totalCredits),
       totalCollectedFeesDay,
       transfersCount: stats?.transfersCount,
       dataContractsCount: stats?.dataContractsCount,
@@ -62,7 +62,7 @@ class MainController {
         }
       },
       tenderdash: {
-        version: status?.version?.software.tenderdash ?? null,
+        version: status?.version?.tenderdash ?? null,
         block: {
           height: tdStatus?.highestBlock?.height ?? null,
           hash: tdStatus?.highestBlock?.hash ?? null,
@@ -75,18 +75,18 @@ class MainController {
       },
       versions: {
         software: {
-          dapi: status?.version?.software.dapi ?? null,
-          drive: status?.version?.software.drive ?? null,
-          tenderdash: status?.version?.software.tenderdash ?? null
+          dapi: status?.version?.dapiVersion ?? null,
+          drive: status?.version?.driveVersion ?? null,
+          tenderdash: status?.version?.tenderdashVersion ?? null
         },
         protocol: {
           tenderdash: {
-            p2p: status?.version?.protocol.tenderdash?.p2p ?? null,
-            block: status?.version?.protocol.tenderdash?.block ?? null
+            p2p: status?.version?.tenderdashP2pProtocol ?? null,
+            block: status?.version?.tenderdashBlockProtocol ?? null
           },
           drive: {
-            latest: status?.version?.protocol.drive?.latest ?? null,
-            current: status?.version?.protocol.drive?.current ?? null
+            latest: status?.version?.driveLatestProtocol ?? null,
+            current: status?.version?.driveCurrentProtocol ?? null
           }
         }
       }

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -161,10 +161,12 @@ module.exports = class IdentitiesDAO {
       fundingCoreTx = assetLockProof?.fundingCoreTx
     }
 
+    const balance = await this.dapi.getIdentityBalance(identity.identifier)
+
     return Identity.fromObject({
       ...identity,
       aliases,
-      balance: await this.dapi.getIdentityBalance(identity.identifier),
+      balance: String(balance),
       publicKeys: publicKeys?.map(key => ({
         keyId: key.keyId,
         type: key.type,

--- a/packages/api/src/models/Epoch.js
+++ b/packages/api/src/models/Epoch.js
@@ -21,11 +21,11 @@ module.exports = class Epoch {
     let endTime
 
     if (nextEpoch) {
-      endTime = nextEpoch.startTime
+      endTime = Number(nextEpoch.startTime)
     } else if (startTime) {
-      endTime = startTime + EPOCH_CHANGE_TIME
+      endTime = Number(startTime) + EPOCH_CHANGE_TIME
     }
 
-    return new Epoch(number, firstBlockHeight, firstCoreBlockHeight, startTime, feeMultiplier, endTime)
+    return new Epoch(number, String(firstBlockHeight), firstCoreBlockHeight, Number(startTime), feeMultiplier, endTime)
   }
 }

--- a/packages/api/test/integration/epochs.spec.js
+++ b/packages/api/test/integration/epochs.spec.js
@@ -122,7 +122,7 @@ describe('Epoch routes', () => {
       const expectedBlock = {
         epoch: {
           number: 0,
-          firstBlockHeight: 0,
+          firstBlockHeight: '0',
           firstCoreBlockHeight: 1,
           startTime: 0,
           feeMultiplier: 1,

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -225,7 +225,7 @@ describe('Identities routes', () => {
         identifier: identity.identifier,
         owner: identity.identifier,
         revision: identity.revision,
-        balance: 0,
+        balance: '0',
         timestamp: block.timestamp.toISOString(),
         txHash: identity.txHash,
         totalTxs: 0,

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -469,21 +469,13 @@ describe('Other routes', () => {
       }
       const mockDapiStatus = {
         version: {
-          software: {
-            dapi: '1.5.1',
-            drive: '1.6.2',
-            tenderdash: '1.4.0'
-          },
-          protocol: {
-            tenderdash: {
-              p2p: 10,
-              block: 14
-            },
-            drive: {
-              latest: 6,
-              current: 6
-            }
-          }
+          dapiVersion: '1.5.1',
+          driveVersion: '1.6.2',
+          tenderdashVersion: '1.4.0',
+          tenderdashP2pProtocol: 10,
+          tenderdashBlockProtocol: 14,
+          driveLatestProtocol: 6,
+          driveCurrentProtocol: 6
         }
       }
 
@@ -541,7 +533,7 @@ describe('Other routes', () => {
           }
         },
         tenderdash: {
-          version: mockDapiStatus.version.software.tenderdash ?? null,
+          version: mockDapiStatus.version.tenderdashVersion ?? null,
           block: {
             height: mockTDStatus?.highestBlock?.height,
             hash: mockTDStatus?.highestBlock?.hash,
@@ -550,18 +542,18 @@ describe('Other routes', () => {
         },
         versions: {
           software: {
-            dapi: mockDapiStatus.version.software.dapi ?? null,
-            drive: mockDapiStatus.version.software.drive ?? null,
-            tenderdash: mockDapiStatus.version.software.tenderdash ?? null
+            dapi: mockDapiStatus.version.dapiVersion ?? null,
+            drive: mockDapiStatus.version.driveVersion ?? null,
+            tenderdash: mockDapiStatus.version.tenderdashVersion ?? null
           },
           protocol: {
             tenderdash: {
-              p2p: mockDapiStatus.version.protocol.tenderdash.p2p ?? null,
-              block: mockDapiStatus.version.protocol.tenderdash.block ?? null
+              p2p: mockDapiStatus.version.tenderdashP2pProtocol ?? null,
+              block: mockDapiStatus.version.tenderdashBlockProtocol ?? null
             },
             drive: {
-              latest: mockDapiStatus.version.protocol.drive.latest ?? null,
-              current: mockDapiStatus.version.protocol.drive.current ?? null
+              latest: mockDapiStatus.version.driveLatestProtocol ?? null,
+              current: mockDapiStatus.version.driveCurrentProtocol ?? null
             }
           }
         }

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -426,7 +426,7 @@ describe('Other routes', () => {
       const expectedIdentity = {
         identifier: identity.identifier,
         revision: 0,
-        balance: 0,
+        balance: '0',
         timestamp: block.timestamp.toISOString(),
         txHash: identityTransaction.hash,
         totalTxs: 51,

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -492,7 +492,7 @@ describe('Other routes', () => {
       mock.method(DAPI.prototype, 'getStatus', async () => mockDapiStatus)
       mock.method(DAPI.prototype, 'getEpochsInfo', async () => [{
         number: 0,
-        firstBlockHeight: 0,
+        firstBlockHeight: '0',
         firstCoreBlockHeight: 0,
         startTime: 0,
         feeMultiplier: 0,
@@ -514,7 +514,7 @@ describe('Other routes', () => {
       const expectedStats = {
         epoch: {
           number: 0,
-          firstBlockHeight: 0,
+          firstBlockHeight: '0',
           firstCoreBlockHeight: 0,
           startTime: 0,
           feeMultiplier: 0,
@@ -522,7 +522,7 @@ describe('Other routes', () => {
         },
         identitiesCount: 1,
         transactionsCount: 51,
-        totalCredits: 0,
+        totalCredits: '0',
         totalCollectedFeesDay: 240000,
         transfersCount: 0,
         dataContractsCount: 1,


### PR DESCRIPTION
# Issue
We forget to update Epoch Model for work with BigInt
Also we found troubles with tenderdash response for status, because structure of response was changed

# Things done
* Added convertations for fields in `Epoch` model
* Updated tanderdash response processing in MainController 
* Added cast to string in Idenityt for balance
* Updated [dapi-grpc](https://github.com/owl352/dapi-grpc/tree/experimental)