### PR TITLE
Fixes for search response and new fields for search response

### DIFF
--- a/packages/api/src/DAPI.js
+++ b/packages/api/src/DAPI.js
@@ -1,6 +1,5 @@
-const { Identifier } = require('dash').PlatformProtocol
-
 const { IdentityPublicKey } = require('@dashevo/wasm-dpp/dist/wasm/wasm_dpp')
+const { Identifier } = require('@dashevo/wasm-dpp')
 
 class DAPI {
   dapi

--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -17,7 +17,7 @@ class MainController {
     this.documentsDAO = new DocumentsDAO(knex, dapi, client)
     this.transactionsDAO = new TransactionsDAO(knex, dapi)
     this.identitiesDAO = new IdentitiesDAO(knex, dapi, client)
-    this.validatorsDAO = new ValidatorsDAO(knex)
+    this.validatorsDAO = new ValidatorsDAO(knex, dapi)
     this.dapi = dapi
   }
 
@@ -124,14 +124,14 @@ class MainController {
       const transaction = await this.transactionsDAO.getTransactionByHash(query)
 
       if (transaction) {
-        result = { ...result, transaction }
+        result = { ...result, transactions: [transaction] }
       }
 
       // search validators by hash
-      const validator = await this.validatorsDAO.getValidatorByProTxHash(query, null, epoch)
+      const validator = await this.validatorsDAO.getValidatorByProTxHash(query, epoch)
 
       if (validator) {
-        result = { ...result, validator }
+        result = { ...result, validators: [validator] }
       }
     }
 
@@ -147,10 +147,10 @@ class MainController {
       // search validator by MasterNode identity
       const proTxHash = Buffer.from(base58.decode(query)).toString('hex')
 
-      const validator = await this.validatorsDAO.getValidatorByProTxHash(proTxHash, null, epoch)
+      const validator = await this.validatorsDAO.getValidatorByProTxHash(proTxHash, epoch)
 
       if (validator) {
-        result = { ...result, validator }
+        result = { ...result, validators: [validator] }
       }
 
       // search data contract by id
@@ -164,7 +164,7 @@ class MainController {
       const document = await this.documentsDAO.getDocumentByIdentifier(query)
 
       if (document) {
-        result = { ...result, document }
+        result = { ...result, documents: [document] }
       }
     }
 

--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -10,7 +10,7 @@ const Intervals = require('../enums/IntervalsEnum')
 
 class ValidatorsController {
   constructor (knex, dapi) {
-    this.validatorsDAO = new ValidatorsDAO(knex)
+    this.validatorsDAO = new ValidatorsDAO(knex, dapi)
     this.dapi = dapi
   }
 
@@ -20,10 +20,7 @@ class ValidatorsController {
     const [currentEpoch] = await this.dapi.getEpochsInfo(1)
     const epochInfo = Epoch.fromObject(currentEpoch)
 
-    const identifier = base58.encode(Buffer.from(hash, 'hex'))
-    const identityBalance = await this.dapi.getIdentityBalance(identifier)
-
-    const validator = await this.validatorsDAO.getValidatorByProTxHash(hash, identifier, epochInfo)
+    const validator = await this.validatorsDAO.getValidatorByProTxHash(hash, epochInfo)
 
     if (!validator) {
       return response.status(404).send({ message: 'not found' })
@@ -72,8 +69,6 @@ class ValidatorsController {
           ...validator,
           isActive,
           proTxInfo: ProTxInfo.fromObject(proTxInfo),
-          identifier,
-          identityBalance: String(identityBalance),
           epochInfo,
           endpoints
         }
@@ -122,7 +117,7 @@ class ValidatorsController {
               isActive: activeValidators.some(activeValidator =>
                 activeValidator.pro_tx_hash === validator.proTxHash),
               proTxInfo: ProTxInfo.fromObject(validator.proTxInfo),
-              identifier,
+              identity: identifier,
               identityBalance: String(identityBalance),
               epochInfo
             }

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -28,7 +28,7 @@ module.exports = class Validator {
     withdrawalsCount,
     lastWithdrawal,
     lastWithdrawalTime,
-    identifier,
+    identity,
     identityBalance,
     epochInfo,
     endpoints
@@ -38,7 +38,7 @@ module.exports = class Validator {
     this.proposedBlocksAmount = proposedBlocksAmount ?? null
     this.lastProposedBlockHeader = lastProposedBlockHeader ?? null
     this.proTxInfo = proTxInfo ?? null
-    this.identity = identifier ?? null
+    this.identity = identity ?? null
     this.identityBalance = identityBalance ?? null
     this.epochInfo = epochInfo ?? null
     this.totalReward = totalReward ?? null
@@ -102,7 +102,7 @@ module.exports = class Validator {
     withdrawalsCount,
     lastWithdrawal,
     lastWithdrawalTime,
-    identifier,
+    identity,
     identityBalance,
     epochInfo,
     endpoints
@@ -118,7 +118,7 @@ module.exports = class Validator {
       withdrawalsCount,
       lastWithdrawal,
       lastWithdrawalTime,
-      identifier,
+      identity,
       identityBalance,
       epochInfo,
       endpoints

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -266,7 +266,7 @@ describe('Other routes', () => {
         }
       }
 
-      assert.deepEqual({ transaction: expectedTransaction }, body)
+      assert.deepEqual({ transactions: [expectedTransaction] }, body)
     })
 
     it('should search block by height', async () => {
@@ -394,7 +394,7 @@ describe('Other routes', () => {
         nonce: '2'
       }
 
-      assert.deepEqual({ document: expectedDataContract }, body)
+      assert.deepEqual({ documents: [expectedDataContract] }, body)
     })
 
     it('should search by identity DPNS', async () => {


### PR DESCRIPTION
# Issue
We need to refactor search response, to send all categories like arrays, not one object
Also for new design we need to add `identity` and `identityBalance` for validators in search
# Things done
- Changed response strucure for transaction, document and validator
- Implemented `identity` and `identityBalance` on dao layer