### PR TITLE
Update api urls in docs

### DIFF
--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -4,7 +4,9 @@ Platform Explorer HTTP API allow you to query and see platform blockchain data p
 
 API is still under ongoing development, so refer to this page or repo documentation for the most up-to-date latest specification.
 
-Production (testnet) live URL is [https://platform-explorer.pshenmic.dev](https://platform-explorer.pshenmic.dev)
+Production (mainnet) live URL is [https://platform-explorer.pshenmic.dev](https://platform-explorer.pshenmic.dev)
+
+Testnet live URL is [https://testnet.platform-explorer.pshenmic.dev](https://testnet.platform-explorer.pshenmic.dev)
 
 Reference:
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -5,7 +5,7 @@ Platform Explorer HTTP API allow you to query and see platform blockchain data p
 API is still under ongoing development, so refer to this page or repo documentation for the most up-to-date latest specification.
 
 Production (mainnet) live URL is [https://platform-explorer.pshenmic.dev](https://platform-explorer.pshenmic.dev)
-
+ 
 Testnet live URL is [https://testnet.platform-explorer.pshenmic.dev](https://testnet.platform-explorer.pshenmic.dev)
 
 Reference:

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -5,7 +5,7 @@ Platform Explorer HTTP API allow you to query and see platform blockchain data p
 API is still under ongoing development, so refer to this page or repo documentation for the most up-to-date latest specification.
 
 Production (mainnet) live URL is [https://platform-explorer.pshenmic.dev](https://platform-explorer.pshenmic.dev)
- 
+
 Testnet live URL is [https://testnet.platform-explorer.pshenmic.dev](https://testnet.platform-explorer.pshenmic.dev)
 
 Reference:


### PR DESCRIPTION
# Issue
Currently in the API documentation we only have the mainnet URL, although we also have the testnet API URL. This causes confusion among users. So we need to clarify this information.

# Things done
Added information about testnet URL