### PR TITLE
Vertical alignment of PublicKeysListItem

### DIFF
--- a/packages/frontend/src/components/publicKeys/PublicKeysListItem.scss
+++ b/packages/frontend/src/components/publicKeys/PublicKeysListItem.scss
@@ -8,7 +8,7 @@
 
   &__Content {
     @include pk.Columns();
-    align-items: baseline;
+    align-items: center;
 
     &--Inline {
       display: inline !important;


### PR DESCRIPTION
# Issue
The basic alignment of PublicKeysListItem doesn't seem good

![image](https://github.com/user-attachments/assets/74f171b4-831d-4b2c-bee1-e232bfdd8a38)


# Things done
Changed vertical alignment of PublicKeysListItem to center.