### PR TITLE
Remove identity contract nonce from document page

### DIFF
--- a/packages/frontend/src/components/documents/DocumentTotalCard.js
+++ b/packages/frontend/src/components/documents/DocumentTotalCard.js
@@ -146,14 +146,6 @@ function DocumentTotalCard ({ document, rate, className }) {
 
         <InfoLine
           className={'DocumentTotalCard__InfoLine'}
-          title={'Identity Contract Nonce'}
-          value={document.data?.nonce}
-          loading={document.loading}
-          error={document.error || document.data?.nonce === undefined}
-        />
-
-        <InfoLine
-          className={'DocumentTotalCard__InfoLine'}
           title={'Deleted'}
           value={<Badge colorScheme={document.data?.deleted ? 'red' : 'green'}>{document.data?.deleted ? 'True' : 'False'}</Badge>}
           loading={document.loading}


### PR DESCRIPTION
# Issue
There is no need to display the identity contract nonce field on the document page.

# Things done
Removed Identity Contract Nonce field from document page