### PR TITLE
Transactions `totalCount` fix and filter by timestamp

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -650,6 +650,8 @@ Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appe
 * `transaction_type` number of tx type. Can be set multiple times
 * `gas_min` number of min `gas_used`
 * `gas_max` number of max `gas_used`
+* `timestamp_start` must be used with `timestamp_end`
+* `timestamp_end` must be used with `timestamp_start`
 
 ```
 GET /transactions?=1&limit=10&order=asc&owner=6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs&transaction_type=0&transaction_type=1&status=ALL&gas_min=0&gas_max=9999999

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -29,28 +29,35 @@ class TransactionsController {
       page = 1, limit = 10,
       order = 'asc', owner,
       status = 'ALL',
-      // eslint-disable-next-line camelcase
-      gas_min, gas_max, transaction_type
+      gas_min: gasMin, gas_max: gasMax,
+      transaction_type: transactionType,
+      timestamp_start: timestampStart,
+      timestamp_end: timestampEnd
     } = request.query
 
     if (order !== 'asc' && order !== 'desc') {
       return response.status(400).send({ message: `invalid ordering value ${order}. only 'asc' or 'desc' is valid values` })
     }
 
-    // eslint-disable-next-line camelcase
-    if (transaction_type?.length === 0 && transaction_type) {
+    if (transactionType?.length === 0 && transactionType) {
       return response.status(400).send({ message: 'invalid filters values' })
+    }
+
+    if (!timestampStart !== !timestampEnd) {
+      return response.status(400).send({ message: 'you must use timestamp_start and timestamp_end' })
     }
 
     const transactions = await this.transactionsDAO.getTransactions(
       Number(page ?? 1),
       Number(limit ?? 10),
       order,
-      transaction_type,
+      transactionType,
       owner,
       status,
-      gas_min,
-      gas_max
+      gasMin,
+      gasMax,
+      timestampStart,
+      timestampEnd
     )
 
     response.send(transactions)

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -52,12 +52,15 @@ module.exports = class TransactionsDAO {
     return Transaction.fromRow({ ...row, aliases })
   }
 
-  getTransactions = async (page, limit, order, transactionsTypes, owner, status, min, max) => {
+  getTransactions = async (page, limit, order, transactionsTypes, owner, status, min, max, timestampStart, timestampEnd) => {
     const fromRank = ((page - 1) * limit) + 1
     const toRank = fromRank + limit - 1
 
     let filtersQuery = ''
     const filtersBindings = []
+
+    let timestampsQuery = ''
+    const timestampBindings = []
 
     if (transactionsTypes) {
       // Currently knex cannot digest an array of numbers correctly
@@ -85,36 +88,59 @@ module.exports = class TransactionsDAO {
       filtersQuery = filtersQuery !== '' ? filtersQuery + ' and gas_used <= ?' : 'gas_used <= ?'
     }
 
+    if (timestampStart && timestampEnd) {
+      timestampsQuery = 'blocks.timestamp between ? and ?'
+      timestampBindings.push(timestampStart, timestampEnd)
+    }
+
     const aliasesSubquery = this.knex('identity_aliases')
       .select('identity_identifier', this.knex.raw('array_agg(alias) as aliases'))
       .groupBy('identity_identifier')
       .as('aliases')
 
     const filtersSubquery = this.knex('state_transitions')
-      .select(this.knex('state_transitions').count('hash').as('total_count'), 'state_transitions.hash as tx_hash',
-        'state_transitions.data as data', 'state_transitions.type as type', 'state_transitions.index as index',
+      .select('state_transitions.hash as tx_hash', 'state_transitions.data as data',
+        'state_transitions.type as type', 'state_transitions.index as index',
         'state_transitions.gas_used as gas_used', 'state_transitions.status as status', 'state_transitions.error as error',
         'state_transitions.block_hash as block_hash', 'state_transitions.id as id', 'state_transitions.owner as owner')
       .whereRaw(filtersQuery, filtersBindings)
-      .as('state_transitions')
+      .as('filters_subquery')
 
     const subquery = this.knex(filtersSubquery)
-      .select('tx_hash', 'total_count',
+      .select('tx_hash', 'aliases',
         'data', 'type', 'index',
         'gas_used', 'status', 'error',
         'block_hash', 'id', 'owner',
-        'identity_identifier', 'aliases'
+        'identity_identifier',
+        'blocks.height as block_height',
+        'blocks.timestamp as timestamp'
       )
-      .select(this.knex.raw(`rank() over (order by state_transitions.id ${order}) rank`))
-      .leftJoin(aliasesSubquery, 'aliases.identity_identifier', 'state_transitions.owner')
-      .as('state_transitions')
-
-    const rows = await this.knex(subquery)
-      .select('total_count', 'data', 'type', 'index', 'rank', 'block_hash', 'state_transitions.tx_hash as tx_hash',
-        'gas_used', 'status', 'error', 'blocks.height as block_height', 'blocks.timestamp as timestamp', 'owner', 'aliases')
+      .whereRaw(timestampsQuery, timestampBindings)
+      .leftJoin(aliasesSubquery, 'aliases.identity_identifier', 'filters_subquery.owner')
       .leftJoin('blocks', 'blocks.hash', 'block_hash')
+      // .as('state_transitions')
+
+    const calculatingSubquery = this.knex
+      .with('subquery', subquery)
+      .select('tx_hash', 'aliases',
+        'data', 'type', 'index',
+        'gas_used', 'status', 'error',
+        'block_hash', 'id', 'owner',
+        'identity_identifier',
+        'block_height', 'timestamp'
+      )
+      .select(this.knex.raw(`rank() over (order by subquery.id ${order}) rank`))
+      .select(this.knex('subquery').count('*').as('total_count'))
+      .from('subquery')
+      .as('calculated_subquery')
+
+    const rows = await this.knex(calculatingSubquery)
+      .select(
+        'data', 'type', 'index', 'owner', 'aliases',
+        'rank', 'block_hash', 'tx_hash', 'total_count',
+        'gas_used', 'status', 'error', 'timestamp', 'block_height')
       .whereBetween('rank', [fromRank, toRank])
-      .orderBy('state_transitions.id', order)
+      .orderBy('calculated_subquery.id', order)
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -617,7 +617,8 @@ Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appe
 * `transaction_type` number of tx type. Can be set multiple times
 * `gas_min` number of min `gas_used`
 * `gas_max` number of max `gas_used`
-
+* `timestamp_start` must be used with `timestamp_end`
+* `timestamp_end` must be used with `timestamp_start`
 ```
 GET /transactions?=1&limit=10&order=asc&owner=6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs&transaction_type=0&transaction_type=1&status=ALL&gas_min=0&gas_max=9999999
 


### PR DESCRIPTION
# Issue
We found bug in calculating `totalCount` for Transactions (`totalCount` calculates always as `totalCount` of all txs)
Also we need new filter for transactions, which allows to get transactions by timestamp

# Things done
- Fixed bug with `totalCount`
- Added 2 properties to querystring `timestmap_start` and `timestamp_end`
- Updated tests
- Updated `README.md`