### PR TITLE
Rename `identityNonce` in document to `contractNonce` 

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -877,7 +877,7 @@ GET /document/FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ?document_type_name=pr
   "typeName": "preorder",
   "gasUsed": null,
   "totalGasUsed": 15999780,
-  "identityNonce": null,
+  "identityContractNonce": null,
   "owner": {
     "identifier": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
     "aliases": [
@@ -942,7 +942,7 @@ GET /document/5Quf1y4GrqygGLLUwNHntxHBCguvUiVaMv2kWh7HNFAd/revisions
       "prefundedVotingBalance": null,
       "documentTypeName": null,
       "transitionType": 0,
-      "identityNonce": "2",
+      "identityContractNonce": "2",
       "gasUsed": 15048420,
       "totalGasUsed": null,
       "owner": {

--- a/packages/api/src/dao/DocumentsDAO.js
+++ b/packages/api/src/dao/DocumentsDAO.js
@@ -241,7 +241,7 @@ module.exports = class DocumentsDAO {
         ...document,
         entropy: transitionWithEntropy?.entropy,
         prefundedVotingBalance: transitionWithEntropy?.prefundedVotingBalance,
-        identityNonce: transitionWithEntropy?.identityNonce
+        identityContractNonce: transitionWithEntropy?.identityContractNonce
       })
     }))
 

--- a/packages/api/src/models/Document.js
+++ b/packages/api/src/models/Document.js
@@ -11,11 +11,11 @@ module.exports = class Document {
   prefundedVotingBalance
   documentTypeName
   transitionType
-  identityNonce
+  identityContractNonce
   gasUsed
   totalGasUsed
 
-  constructor (identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, isSystem, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, totalGasUsed, entropy, identityNonce) {
+  constructor (identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, isSystem, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, totalGasUsed, entropy, identityContractNonce) {
     this.identifier = identifier ? identifier.trim() : null
     this.owner = owner ?? null
     this.dataContractIdentifier = dataContractIdentifier ? dataContractIdentifier.trim() : null
@@ -31,7 +31,7 @@ module.exports = class Document {
     this.transitionType = transitionType ?? null
     this.entropy = entropy ?? null
     this.prefundedVotingBalance = prefundedVotingBalance ?? null
-    this.identityNonce = identityNonce ?? null
+    this.identityContractNonce = identityContractNonce ?? null
     this.gasUsed = gasUsed ?? null
     this.totalGasUsed = totalGasUsed ?? null
   }
@@ -41,7 +41,7 @@ module.exports = class Document {
     return new Document(identifier, owner, data_contract_identifier, deleted ? null : revision, tx_hash, deleted, data ? JSON.stringify(data) : null, timestamp, is_system, document_type_name, Number(transition_type), prefunded_voting_balance, Number(gas_used), Number(total_gas_used))
   }
 
-  static fromObject ({ identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, entropy, prefundedVotingBalance, identityNonce, gasUsed, totalGasUsed }) {
-    return new Document(identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, totalGasUsed, entropy, identityNonce)
+  static fromObject ({ identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, entropy, prefundedVotingBalance, identityContractNonce, gasUsed, totalGasUsed }) {
+    return new Document(identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, prefundedVotingBalance, gasUsed, totalGasUsed, entropy, identityContractNonce)
   }
 }

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -100,7 +100,7 @@ const decodeStateTransition = async (client, base64) => {
           revision: String(documentTransition.getRevision()),
           type: documentTransition.getType(),
           action: documentTransition.getAction(),
-          identityNonce: String(documentTransition.getIdentityContractNonce())
+          identityContractNonce: String(documentTransition.getIdentityContractNonce())
         }
 
         switch (documentTransition.getAction()) {

--- a/packages/api/test/integration/documents.spec.js
+++ b/packages/api/test/integration/documents.spec.js
@@ -171,7 +171,7 @@ describe('Documents routes', () => {
           aliases: []
         },
         system: document.document.is_system,
-        identityNonce: null,
+        identityContractNonce: null,
         gasUsed: null,
         totalGasUsed: 0,
         transitionType: 0
@@ -203,7 +203,7 @@ describe('Documents routes', () => {
           aliases: []
         },
         txHash: document.transaction.hash,
-        identityNonce: null,
+        identityContractNonce: null,
         gasUsed: null,
         totalGasUsed: 0,
         transitionType: 0
@@ -243,7 +243,7 @@ describe('Documents routes', () => {
         documentTypeName: null,
         entropy: null,
         identifier: document.document.identifier,
-        identityNonce: null,
+        identityContractNonce: null,
         prefundedVotingBalance: null,
         gasUsed: 0,
         totalGasUsed: null,
@@ -286,7 +286,7 @@ describe('Documents routes', () => {
           prefundedVotingBalance: null,
           gasUsed: null,
           totalGasUsed: null,
-          identityNonce: null
+          identityContractNonce: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -336,7 +336,7 @@ describe('Documents routes', () => {
           system: document.is_system,
           gasUsed: null,
           totalGasUsed: null,
-          identityNonce: null
+          identityContractNonce: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -373,7 +373,7 @@ describe('Documents routes', () => {
           prefundedVotingBalance: null,
           gasUsed: null,
           totalGasUsed: null,
-          identityNonce: null
+          identityContractNonce: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -423,7 +423,7 @@ describe('Documents routes', () => {
           prefundedVotingBalance: null,
           totalGasUsed: null,
           gasUsed: null,
-          identityNonce: null
+          identityContractNonce: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -468,7 +468,7 @@ describe('Documents routes', () => {
           prefundedVotingBalance: null,
           totalGasUsed: null,
           gasUsed: null,
-          identityNonce: null
+          identityContractNonce: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)
@@ -513,7 +513,7 @@ describe('Documents routes', () => {
           prefundedVotingBalance: null,
           totalGasUsed: null,
           gasUsed: null,
-          identityNonce: null
+          identityContractNonce: null
         }))
 
       assert.deepEqual(body.resultSet, expectedDocuments)

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -992,7 +992,7 @@ describe('Identities routes', () => {
         timestamp: _document.block.timestamp.toISOString(),
         system: false,
         transitionType: 0,
-        identityNonce: null,
+        identityContractNonce: null,
         gasUsed: null,
         totalGasUsed: null
       }))
@@ -1059,7 +1059,7 @@ describe('Identities routes', () => {
           system: false,
           transitionType: 0,
           gasUsed: null,
-          identityNonce: null,
+          identityContractNonce: null,
           totalGasUsed: null
         }))
 
@@ -1127,7 +1127,7 @@ describe('Identities routes', () => {
           prefundedVotingBalance: null,
           entropy: null,
           gasUsed: null,
-          identityNonce: null,
+          identityContractNonce: null,
           totalGasUsed: null
         }))
 
@@ -1193,7 +1193,7 @@ describe('Identities routes', () => {
           system: false,
           transitionType: 0,
           gasUsed: null,
-          identityNonce: null,
+          identityContractNonce: null,
           totalGasUsed: null
         }))
 
@@ -1259,7 +1259,7 @@ describe('Identities routes', () => {
           system: false,
           transitionType: 0,
           gasUsed: null,
-          identityNonce: null,
+          identityContractNonce: null,
           totalGasUsed: null
         }))
 

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -392,7 +392,7 @@ describe('Other routes', () => {
         },
         gasUsed: null,
         totalGasUsed: 0,
-        identityNonce: null
+        identityContractNonce: null
       }
 
       assert.deepEqual({ documents: [expectedDataContract] }, body)

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -87,7 +87,7 @@ describe('Utils', () => {
             type: 'note',
             entropy: 'f09a3ceacaa2f12b9879ba223d5b8c66c3106efe58edc511556f31ee9676412b',
             action: 0,
-            identityNonce: '2',
+            identityContractNonce: '2',
             data: {
               message: 'Tutorial CI Test @ Thu, 08 Aug 2024 20:25:03 GMT'
             }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -4,9 +4,7 @@ Platform Explorer HTTP API allow you to query and see platform blockchain data p
 
 API is still under ongoing development, so refer to this page or repo documentation for the most up-to-date latest specification.
 
-Production (mainnet) live URL is [https://platform-explorer.pshenmic.dev](https://platform-explorer.pshenmic.dev)
-
-Testnet live URL is [https://testnet.platform-explorer.pshenmic.dev](https://testnet.platform-explorer.pshenmic.dev)
+Production (testnet) live URL is [https://platform-explorer.pshenmic.dev](https://platform-explorer.pshenmic.dev)
 
 Reference:
 
@@ -621,6 +619,7 @@ Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appe
 * `gas_max` number of max `gas_used`
 * `timestamp_start` must be used with `timestamp_end`
 * `timestamp_end` must be used with `timestamp_start`
+
 ```
 GET /transactions?=1&limit=10&order=asc&owner=6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs&transaction_type=0&transaction_type=1&status=ALL&gas_min=0&gas_max=9999999
 
@@ -845,7 +844,7 @@ GET /document/FUJsiMpQZWGfdrWPEUhBRExMAQB9q6MNfFgRqCdz42UJ?document_type_name=pr
   "typeName": "preorder",
   "gasUsed": null,
   "totalGasUsed": 15999780,
-  "identityNonce": null,
+  "identityContractNonce": null,
   "owner": {
     "identifier": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
     "aliases": [
@@ -910,7 +909,7 @@ GET /document/5Quf1y4GrqygGLLUwNHntxHBCguvUiVaMv2kWh7HNFAd/revisions
       "prefundedVotingBalance": null,
       "documentTypeName": null,
       "transitionType": 0,
-      "identityNonce": "2",
+      "identityContractNonce": "2",
       "gasUsed": 15048420,
       "totalGasUsed": null,
       "owner": {


### PR DESCRIPTION
# Issue
Technically, nonce in documents must be `identityContractNonce`, but at this moment he named as `identityNonce`

# Things done
-  Field renamed
- Updated readme
- Updated tests