### PR TITLE
Rename identity contract nonce in Identity Updated transition

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1944,7 +1944,7 @@ POST /transaction/decode
             "revision": "1",
             "type": "note",
             "action": 0,
-            "identityNonce": "2",
+            "identityContractNonce": "2",
             "entropy": "f09a3ceacaa2f12b9879ba223d5b8c66c3106efe58edc511556f31ee9676412b",
             "data": {
                 "message": "Tutorial CI Test @ Thu, 08 Aug 2024 20:25:03 GMT"
@@ -2107,7 +2107,7 @@ IDENTITY_CREATE with instantLock
     "userFeeIncrease": 0,
     "ownerId": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
     "dataContractId": "AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18",
-    "dataContractNonce": 0,
+    "dataContractIdentityNonce": "0",
     "schema": {
         "note": {
             "type": "object",
@@ -2132,7 +2132,7 @@ IDENTITY_CREATE with instantLock
 ```
 {
   type: 5,
-  identityContractNonce: 3,
+  identityNonce: 3,
   userFeeIncrease: 0,
   identityId: '4NGALjtX2t3AXE3ZCqJiSmYuiWEY3ZPQNUBxNWWRrRSp',
   revision: 2,

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -246,7 +246,7 @@ const decodeStateTransition = async (client, base64) => {
       decoded.userFeeIncrease = stateTransition.toObject().userFeeIncrease
       decoded.ownerId = stateTransition.getDataContract().getOwnerId().toString()
       decoded.dataContractId = stateTransition.getDataContract().getId().toString()
-      decoded.dataContractNonce = String(stateTransition.getDataContract().getIdentityNonce())
+      decoded.dataContractIdentityNonce = String(stateTransition.getDataContract().getIdentityNonce())
       decoded.schema = stateTransition.getDataContract().getDocumentSchemas()
       decoded.version = stateTransition.getDataContract().getVersion()
       decoded.dataContractOwner = stateTransition.getDataContract().getOwnerId().toString()

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -255,7 +255,7 @@ const decodeStateTransition = async (client, base64) => {
       break
     }
     case StateTransitionEnum.IDENTITY_UPDATE: {
-      decoded.identityContractNonce = String(stateTransition.getIdentityContractNonce())
+      decoded.identityNonce = String(stateTransition.getIdentityContractNonce())
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
       decoded.identityId = stateTransition.getOwnerId().toString()
       decoded.revision = String(stateTransition.getRevision())

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -232,7 +232,7 @@ describe('Utils', () => {
 
       assert.deepEqual(decoded, {
         type: 5,
-        identityContractNonce: '2',
+        identityNonce: '2',
         userFeeIncrease: 0,
         identityId: 'AGQc1dwAc46Js6fvSBSqV2Zi7fCq2YvoAwEb1SmYtXuM',
         revision: '1',

--- a/packages/api/test/unit/utils.spec.js
+++ b/packages/api/test/unit/utils.spec.js
@@ -196,7 +196,7 @@ describe('Utils', () => {
         userFeeIncrease: 0,
         ownerId: '7dwjL5frrkM69pv3BsKSQb4ELrMYmDeE11KNoDSefG6c',
         dataContractId: '8BzeH7dmyLHNzcCtG6DGowAkWyRgWEq15y88Zz2zBxVg',
-        dataContractNonce: '0',
+        dataContractIdentityNonce: '0',
         schema: {
           labler: {
             type: 'object',

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1911,7 +1911,7 @@ POST /transaction/decode
             "revision": "1",
             "type": "note",
             "action": 0,
-            "identityNonce": "2",
+            "identityContractNonce": "2",
             "entropy": "f09a3ceacaa2f12b9879ba223d5b8c66c3106efe58edc511556f31ee9676412b",
             "data": {
                 "message": "Tutorial CI Test @ Thu, 08 Aug 2024 20:25:03 GMT"
@@ -2074,7 +2074,7 @@ IDENTITY_CREATE with instantLock
     "userFeeIncrease": 0,
     "ownerId": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
     "dataContractId": "AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18",
-    "dataContractNonce": 0,
+    "dataContractIdentityNonce": "0",
     "schema": {
         "note": {
             "type": "object",
@@ -2099,7 +2099,7 @@ IDENTITY_CREATE with instantLock
 ```
 {
   type: 5,
-  identityContractNonce: 3,
+  identityNonce: 3,
   userFeeIncrease: 0,
   identityId: '4NGALjtX2t3AXE3ZCqJiSmYuiWEY3ZPQNUBxNWWRrRSp',
   revision: 2,


### PR DESCRIPTION
# Issue
Incorrect named nonce field in Identity Update transitions after decode from base64
# Things done
- Renamed `identityContractNonce` in decode to `identityNonce`
- Renamed `dataContractNonce` in data contract update to `dataContractIdentityNonce`