### PR TITLE
Update validator field in block page

### DIFF
--- a/packages/frontend/src/components/blocks/BlockDigestCard.js
+++ b/packages/frontend/src/components/blocks/BlockDigestCard.js
@@ -87,8 +87,7 @@ function BlockDigestCard ({ block, rate, status }) {
           <ValueCard link={`/validator/${block.data?.header?.validator}`}>
             <Identifier
               avatar={true}
-              copyButton={true}
-              ellipsis={true}
+              ellipsis={false}
               styles={['highlight-both']}
             >
               {block.data?.header?.validator}

--- a/packages/frontend/src/components/blocks/BlockDigestCard.scss
+++ b/packages/frontend/src/components/blocks/BlockDigestCard.scss
@@ -77,6 +77,17 @@
   @media screen and (max-width: $breakpoint-sm) {
     &__InfoLine {
       flex-wrap: wrap;
+
+      &--Validator {
+        .InfoLine__Value {
+          width: 100%;
+
+          .Identifier {
+            width: 100%;
+            justify-content: space-between;
+          }
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
# Issue
There is no need to hide part of the validator hash on the block page. It is better to output it in several lines.

<img width="979" alt="Снимок экрана 2025-04-07 в 18 51 08" src="https://github.com/user-attachments/assets/77dc95ba-d426-40a0-bac7-112e52b2a0f9" />

# Things done
Updated validator value size and disabled ellipsis.