### PR TITLE
Update lists

### DIFF
--- a/packages/frontend/src/components/blocks/BlocksListItem.js
+++ b/packages/frontend/src/components/blocks/BlocksListItem.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import { Identifier, NotActive, TimeDelta, BigNumber } from '../data'
-import { Badge, Grid, GridItem, useBreakpointValue } from '@chakra-ui/react'
+import { Badge, Grid, GridItem } from '@chakra-ui/react'
 import { BlockIcon } from '../ui/icons'
 import { LinkContainer } from '../ui/containers'
 import { useRouter } from 'next/navigation'
@@ -9,7 +9,6 @@ import './BlocksListItem.scss'
 function BlocksListItem ({ block }) {
   const router = useRouter()
   const { header, txs } = block
-  const isMobile = useBreakpointValue({ base: true, lg: false })
 
   return (
     <Link href={`/block/${header?.hash}`} className={'BlocksListItem'}>
@@ -45,7 +44,6 @@ function BlocksListItem ({ block }) {
           >
             <Identifier
               styles={['highlight-both']}
-              ellipsis={isMobile}
               linesAdjustment={false}
               avatar={true}
             >

--- a/packages/frontend/src/components/blocks/BlocksListItem.scss
+++ b/packages/frontend/src/components/blocks/BlocksListItem.scss
@@ -31,7 +31,23 @@
 
     &--Validator {
       .Identifier__SymbolsContainer {
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
         line-height: 0.8rem;
+        max-height: 1.6rem;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: normal !important;
+      }
+    }
+
+    @container (max-width: 56em) {
+      &--Validator {
+        .Identifier__SymbolsContainer {
+          -webkit-line-clamp: 1;
+          max-height: 0.8rem;
+        }
       }
     }
   }

--- a/packages/frontend/src/components/blocks/_variables.scss
+++ b/packages/frontend/src/components/blocks/_variables.scss
@@ -9,16 +9,16 @@
     6rem // time
     5.3rem // height
     minmax(0, 30rem) // hash
-    6.25rem // proposed by
+    16.5rem // proposed by
     minmax(5rem, 8rem) // fees
     4.75rem; // tx count
 
-  @media screen and (min-width: 62em) {
+  @container (max-width: 56em) {
     grid-template-columns:
       6rem // time
       5.3rem // height
       minmax(0, 30rem) // hash
-      16.5rem // proposed by
+      6.25rem // proposed by
       minmax(5rem, 8rem) // fees
       4.75rem; // tx count
   }


### PR DESCRIPTION
# Issue
- The "Proposed by" column in the block list is displayed with 8 identifier lines when the list is displayed in half the page container size. There should be a maximum of two lines in lists. The responsive styles of the block list need to be fixed.

- Also it would also be convenient to see the full timestamp in the tooltip in the time column in lists.

# Things done
- Responsive styles of the "Proposed by" column in the block list fixed