### PR TITLE
Absolute timestamp in Block list

### DIFF
--- a/packages/frontend/src/app/validator/[hash]/Validator.js
+++ b/packages/frontend/src/app/validator/[hash]/Validator.js
@@ -449,7 +449,7 @@ function Validator ({ hash }) {
                   {!proposedBlocks.error
                     ? <div className={'ValidatorPage__List'}>
                         {!proposedBlocks.loading
-                          ? <BlocksList blocks={proposedBlocks?.data?.resultSet} headerStyles={'light'}/>
+                          ? <BlocksList blocks={proposedBlocks?.data?.resultSet} headerStyles={'light'} absoluteDate={true}/>
                           : <LoadingList itemsCount={pageSize}/>
                         }
                       </div>

--- a/packages/frontend/src/components/blocks/BlocksList.js
+++ b/packages/frontend/src/components/blocks/BlocksList.js
@@ -3,21 +3,16 @@ import { EmptyListMessage } from '../ui/lists'
 import { Grid, GridItem } from '@chakra-ui/react'
 import './BlocksList.scss'
 
-function BlocksList ({ blocks = [], columnsCount = 1, size = 'l', headerStyles = 'default' }) {
+function BlocksList ({ blocks = [], size = 'l', headerStyles = 'default', absoluteDate }) {
   const headerExtraClass = {
     default: '',
     light: 'BlocksList__ColumnTitles--Light'
   }
 
   return (
-    <div
-      className={'BlocksList'}
-      style={{
-        columnCount: blocks.length > 1 ? columnsCount : 1
-      }}
-    >
+    <div className={`BlocksList ${absoluteDate ? 'BlocksList--TimestampAbsolute' : ''}`}>
       <Grid className={`BlocksList__ColumnTitles ${headerExtraClass[headerStyles] || ''}`}>
-        <GridItem className={'BlocksList__ColumnTitle BlocksList__ColumnTitle--Time'}>
+        <GridItem className={'BlocksList__ColumnTitle BlocksList__ColumnTitle--Timestamp'}>
           Time
         </GridItem>
 
@@ -47,6 +42,7 @@ function BlocksList ({ blocks = [], columnsCount = 1, size = 'l', headerStyles =
           key={i}
           block={block}
           size={size}
+          absoluteDate={absoluteDate}
         />
       )}
 

--- a/packages/frontend/src/components/blocks/BlocksList.scss
+++ b/packages/frontend/src/components/blocks/BlocksList.scss
@@ -11,6 +11,10 @@
     @include blocks.Columns();
   }
 
+  &--TimestampAbsolute &__ColumnTitles {
+    @include blocks.Columns(true);
+  }
+
   &__ColumnTitle {
     @include blocks.Column();
 

--- a/packages/frontend/src/components/blocks/BlocksListItem.js
+++ b/packages/frontend/src/components/blocks/BlocksListItem.js
@@ -29,7 +29,7 @@ function BlocksListItem ({ block, absoluteDate }) {
                   timestamp={header.timestamp}
                   showRelativeTooltip={true}
                 />
-              : <TimeDelta showTimestampTooltip={false} endDate={new Date(header.timestamp)}/>
+              : <TimeDelta showTimestampTooltip={true} endDate={new Date(header.timestamp)}/>
             : <NotActive/>
           }
         </GridItem>

--- a/packages/frontend/src/components/blocks/BlocksListItem.js
+++ b/packages/frontend/src/components/blocks/BlocksListItem.js
@@ -1,21 +1,35 @@
 import Link from 'next/link'
-import { Identifier, NotActive, TimeDelta, BigNumber } from '../data'
+import { Identifier, NotActive, TimeDelta, BigNumber, DateBlock } from '../data'
 import { Badge, Grid, GridItem } from '@chakra-ui/react'
 import { BlockIcon } from '../ui/icons'
 import { LinkContainer } from '../ui/containers'
 import { useRouter } from 'next/navigation'
 import './BlocksListItem.scss'
 
-function BlocksListItem ({ block }) {
+function BlocksListItem ({ block, absoluteDate }) {
   const router = useRouter()
   const { header, txs } = block
 
   return (
-    <Link href={`/block/${header?.hash}`} className={'BlocksListItem'}>
+    <Link href={`/block/${header?.hash}`} className={`BlocksListItem ${
+        absoluteDate ? 'BlocksListItem--TimestampAbsolute' : ''
+      }`}
+    >
       <Grid className={'BlocksListItem__Content'}>
-        <GridItem className={'BlocksListItem__Column BlocksListItem__Column--Timestamp'}>
+        <GridItem
+          className={`BlocksListItem__Column BlocksListItem__Column--Timestamp ${
+            absoluteDate ? 'BlocksListItem__Column--TimestampAbsolute' : ''
+          }`}
+        >
           {header?.timestamp
-            ? <TimeDelta endDate={new Date(header.timestamp)}/>
+            ? absoluteDate
+              ? <DateBlock
+                  format={'dateOnly'}
+                  showTime={true}
+                  timestamp={header.timestamp}
+                  showRelativeTooltip={true}
+                />
+              : <TimeDelta showTimestampTooltip={false} endDate={new Date(header.timestamp)}/>
             : <NotActive/>
           }
         </GridItem>

--- a/packages/frontend/src/components/blocks/BlocksListItem.scss
+++ b/packages/frontend/src/components/blocks/BlocksListItem.scss
@@ -11,6 +11,10 @@
     align-items: center;
   }
 
+  &--TimestampAbsolute &__Content {
+    @include blocks.Columns(true);
+  }
+
   &__LinkContainer {
     max-width: 100%;
   }

--- a/packages/frontend/src/components/blocks/_variables.scss
+++ b/packages/frontend/src/components/blocks/_variables.scss
@@ -1,12 +1,14 @@
 @import '../../styles/variables.scss';
 
-@mixin Columns () {
+@mixin Columns ($absoluteTimespan: false) {
+  $timeSpanWidth: #{if($absoluteTimespan, '9rem', '6rem')};
+
   display: grid;
   gap: 16px;
   width: 100%;
 
   grid-template-columns:
-    6rem // time
+    $timeSpanWidth // time
     5.3rem // height
     minmax(0, 30rem) // hash
     16.5rem // proposed by
@@ -15,7 +17,7 @@
 
   @container (max-width: 56em) {
     grid-template-columns:
-      6rem // time
+      $timeSpanWidth // time
       5.3rem // height
       minmax(0, 30rem) // hash
       6.25rem // proposed by
@@ -23,9 +25,9 @@
       4.75rem; // tx count
   }
 
-  @container (max-width: 43em) {
+  @container (max-width: 46.5em) {
     grid-template-columns:
-      6rem // time
+      $timeSpanWidth // time
       5.3rem // height
       minmax(0, 30rem) // hash
       6.25rem // proposed by
@@ -34,7 +36,7 @@
 
   @container (max-width: 37.5em) {
     grid-template-columns:
-      6rem // time
+      $timeSpanWidth // time
       5.3rem // height
       minmax(0, 30rem) // hash
       4.75rem; // tx count
@@ -42,21 +44,21 @@
 
   @container (max-width: 30em) {
     grid-template-columns:
-      6rem // time
+      $timeSpanWidth // time
       5.3rem // height
       minmax(0, 30rem); // hash
   }
 
   @container (max-width: 24.5em) {
     grid-template-columns:
-      6rem // time
+      $timeSpanWidth // time
       minmax(0, 400px) // hash
       4.75rem; // tx count
   }
 
   @container (max-width: 23em) {
     grid-template-columns:
-      6rem // time
+      $timeSpanWidth // time
       minmax(0, 400px); // hash
   }
 }
@@ -70,7 +72,7 @@
     width: 5rem;
   }
 
-  @container (max-width: 43em) {
+  @container (max-width: 46.5em) {
     &--Fees {
       display: none;
     }

--- a/packages/frontend/src/components/data/DateBlock.js
+++ b/packages/frontend/src/components/data/DateBlock.js
@@ -2,9 +2,21 @@
 
 import { CalendarIcon } from '../ui/icons'
 import { TimeDelta } from './index'
+import { Tooltip } from '../ui/Tooltips'
 import './DateBlock.scss'
 
-function DateBlock ({ timestamp, format = 'all', showTime = false }) {
+const Wrapper = ({ children, tooltipContent, props }) => (
+  tooltipContent
+    ? <Tooltip
+        placement={'top'}
+        content={tooltipContent}
+      >
+        <div {...props}>{children}</div>
+      </Tooltip>
+    : <div {...props}>{children}</div>
+)
+
+function DateBlock ({ timestamp, format = 'all', showTime = false, showRelativeTooltip }) {
   const date = new Date(timestamp)
 
   if (String(date) === 'Invalid Date') return null
@@ -37,7 +49,13 @@ function DateBlock ({ timestamp, format = 'all', showTime = false }) {
   const formattedDate = date.toLocaleDateString('en-GB', options)
 
   return (
-    <div className={'DateBlock'}>
+    <Wrapper
+      className={'DateBlock'}
+      tooltipContent={showRelativeTooltip
+        ? <TimeDelta endDate={timestamp} showTimestampTooltip={false}/>
+        : null
+      }
+    >
       <div className={'DateBlock__InfoContainer'}>
         {formats[format].calendarIcon &&
           <CalendarIcon
@@ -58,7 +76,7 @@ function DateBlock ({ timestamp, format = 'all', showTime = false }) {
           </div>
         }
       </div>
-    </div>
+    </Wrapper>
   )
 }
 

--- a/packages/frontend/src/components/data/TimeDelta.js
+++ b/packages/frontend/src/components/data/TimeDelta.js
@@ -6,24 +6,24 @@ import { NotActive } from './index'
 import { Tooltip } from '../ui/Tooltips'
 import './TimeDelta.scss'
 
+const Wrapper = ({ children, tooltipDate, showTimestampTooltip, format }) => (
+  showTimestampTooltip && format !== 'detailed' && !isNaN(tooltipDate)
+    ? <Tooltip
+      placement={'top'}
+      content={
+        <span className={'TimeDelta__TooltipContent'}>
+          {tooltipDate?.toLocaleDateString()} {tooltipDate?.toLocaleTimeString()}
+        </span>
+      }
+    >
+      <span className={'TimeDelta'}>{children}</span>
+    </Tooltip>
+    : <>{children}</>
+)
+
 function TimeDelta ({ startDate, endDate, showTimestampTooltip = true, tooltipDate, format = 'default' }) {
   const [timeDelta, setTimeDelta] = useState(null)
   tooltipDate = new Date(tooltipDate || endDate)
-
-  const Wrapper = ({ children }) => (
-    showTimestampTooltip && format !== 'detailed' && !isNaN(tooltipDate)
-      ? <Tooltip
-          placement={'top'}
-          content={
-            <span className={'TimeDelta__TooltipContent'}>
-              {tooltipDate?.toLocaleDateString()} {tooltipDate?.toLocaleTimeString()}
-            </span>
-          }
-        >
-          <span className={'TimeDelta'}>{children}</span>
-        </Tooltip>
-      : <>{children}</>
-  )
 
   useEffect(() => {
     if (!endDate) {
@@ -56,7 +56,13 @@ function TimeDelta ({ startDate, endDate, showTimestampTooltip = true, tooltipDa
   }, [startDate, endDate, format])
 
   return timeDelta
-    ? <Wrapper>{timeDelta}</Wrapper>
+    ? <Wrapper
+        tooltipDate={tooltipDate}
+        showTimestampTooltip={showTimestampTooltip}
+        format={format}
+      >
+        {timeDelta}
+      </Wrapper>
     : <NotActive/>
 }
 

--- a/packages/frontend/src/components/identities/IdentitiesListItem.js
+++ b/packages/frontend/src/components/identities/IdentitiesListItem.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
 import ImageGenerator from '../imageGenerator'
-import { Identifier, Alias } from '../data'
+import { Identifier, Alias, DateBlock } from '../data'
 import './IdentitiesListItem.scss'
 
 function IdentitiesListItem ({ identity }) {
@@ -23,7 +23,6 @@ function IdentitiesListItem ({ identity }) {
               />
             : <Identifier
                 className={'IdentitiesListItem__Identifier'}
-                copyButton={true}
                 styles={['highlight-both']}
               >
                 {identifier}
@@ -35,7 +34,12 @@ function IdentitiesListItem ({ identity }) {
 
       {(typeof timestamp === 'string') &&
         <div className={'IdentitiesListItem__Timestamp'}>
-          {new Date(timestamp).toLocaleString()}
+          <DateBlock
+            format={'dateOnly'}
+            showTime={true}
+            timestamp={timestamp}
+            showRelativeTooltip={true}
+          />
         </div>
       }
     </Link>

--- a/packages/frontend/src/styles/mixins.scss
+++ b/packages/frontend/src/styles/mixins.scss
@@ -85,9 +85,12 @@
 
   &--Timestamp, &__Column--Timestamp {
     font-family: $font-mono;
-    font-size: 0.75rem;
     white-space: nowrap;
     color: #fff;
+
+    &, .DateBlock__Date {
+      font-size: 0.75rem;
+    }
   }
 }
 


### PR DESCRIPTION
# Issue
On the validator page in the list of blocks it is more convenient to look at the absolute time than the relative one.

# Things done
- Added absolute timestamp variant to BlocksList
- Applied absolute timestamp variant to BlocksList on the Validator page
- Added optional tooltip for relative time to DateBlock

**Also done in the process:**
- Updated render of Date in IdentitiesListItem
- Fixed tooltip twitching while seconds updates in TimeDelta
- Updated font size parameter in timestamp list column for DateBlock inside (in DefListItem mixin)