### PR TITLE
Fix aliases validation

### DIFF
--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -511,6 +511,7 @@ const getAliasInfo = async (aliasText, dapi) => {
 
   const normalizedLabel = convertToHomographSafeChars(label ?? '')
 
+
   if (/^[a-zA-Z01-]{3,19}$/.test(normalizedLabel)) {
     const domainBuffer = buildIndexBuffer(domain)
 

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -511,7 +511,7 @@ const getAliasInfo = async (aliasText, dapi) => {
 
   const normalizedLabel = convertToHomographSafeChars(label ?? '')
 
-  if (/^[a-zA-Z01]{3,19}$/.test(normalizedLabel)) {
+  if (/^[a-zA-Z01-]{3,19}$/.test(normalizedLabel)) {
     const domainBuffer = buildIndexBuffer(domain)
 
     const labelBuffer = buildIndexBuffer(normalizedLabel)

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -511,7 +511,6 @@ const getAliasInfo = async (aliasText, dapi) => {
 
   const normalizedLabel = convertToHomographSafeChars(label ?? '')
 
-
   if (/^[a-zA-Z01-]{3,19}$/.test(normalizedLabel)) {
     const domainBuffer = buildIndexBuffer(domain)
 


### PR DESCRIPTION
# Issue
At this moment we checks alias is contested or not by `/^[a-zA-Z01]{3,19}$/`, but correct is `/^[a-zA-Z01-]{3,19}$/`
# Things done
- Changed regex
