### PR TITLE
Fix prefunded voting balance field

### DIFF
--- a/packages/frontend/src/components/transactions/TransitionCard.js
+++ b/packages/frontend/src/components/transactions/TransitionCard.js
@@ -221,11 +221,11 @@ function TransitionCard ({ transition, owner, rate, className }) {
         />
       }
 
-      {transition?.prefundedBalance &&
+      {transition?.prefundedVotingBalance &&
         <InfoLine
           className={'TransitionCard__InfoLine TransitionCard__InfoLine--PrefundedBalance'}
           title={'Prefunded Voting Balance'}
-          value={<PrefundedBalance prefundedBalance={transition?.prefundedBalance} rate={rate}/>}
+          value={<PrefundedBalance prefundedBalance={transition?.prefundedVotingBalance} rate={rate}/>}
         />
       }
     </div>


### PR DESCRIPTION
# Issue
Prefunded balance is not displayed in the transition cards

# Things done
Fixed, field renamed from 