### PR TITLE
Fields naming fix in Epoch status 

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -176,19 +176,19 @@ HTTP /epoch/2492
   "totalCollectedFees": 1897008860,
   "bestValidator": "87075234AC47353B42BB97CE46330CB67CD4648C01F0B2393D7E729B0D678918",
   "topVotedResource": {
-    "resource": [
+    "resourceValue": [
       "dash",
       "asdthree0"
     ],
-    "yes": 7,
-    "abstain": 1,
-    "lock": 4
+    "totalCountTowardsIdentity": 7,
+    "totalCountAbstain": 1,
+    "totalCountLock": 4
   },
   "bestVoter": {
     "identifier": "4GfuwhaXL5YSerKKwJ19X2s5yXn8dC738tqfcvncqNgM",
-    "yes": 2,
-    "abstain": 1,
-    "lock": 2
+    "totalCountTowardsIdentity": 2,
+    "totalCountAbstain": 1,
+    "totalCountLock": 2
   },
   "totalVotesCount": 12,
   "totalVotesGasUsed": 120000000

--- a/packages/api/src/models/EpochData.js
+++ b/packages/api/src/models/EpochData.js
@@ -42,16 +42,16 @@ module.exports = class EpochData {
       Number(total_collected_fees ?? 0),
       best_validator,
       {
-        resource: top_voted_resource ?? null,
-        yes: Number(resource_votes_yes ?? 0),
-        abstain: Number(resource_votes_abstain ?? 0),
-        lock: Number(resource_votes_lock ?? 0)
+        resourceValue: top_voted_resource ?? null,
+        totalCountTowardsIdentity: Number(resource_votes_yes ?? 0),
+        totalCountAbstain: Number(resource_votes_abstain ?? 0),
+        totalCountLock: Number(resource_votes_lock ?? 0)
       },
       {
         identifier: voter_identity_id ?? null,
-        yes: Number(voter_yes ?? 0),
-        abstain: Number(voter_abstain ?? 0),
-        lock: Number(voter_lock ?? 0)
+        totalCountTowardsIdentity: Number(voter_yes ?? 0),
+        totalCountAbstain: Number(voter_abstain ?? 0),
+        totalCountLock: Number(voter_lock ?? 0)
       },
       Number(total_votes ?? 0),
       Number(total_votes_gas_used ?? 0)

--- a/packages/api/test/integration/epochs.spec.js
+++ b/packages/api/test/integration/epochs.spec.js
@@ -132,16 +132,16 @@ describe('Epoch routes', () => {
         totalCollectedFees: transactions.reduce((acc, tx) => acc + tx.gas_used, 0),
         bestValidator: validator.pro_tx_hash,
         bestVoter: {
-          abstain: 15,
-          yes: 15,
-          lock: 0,
+          totalCountAbstain: 15,
+          totalCountTowardsIdentity: 15,
+          totalCountLock: 0,
           identifier: masternodeVotes[masternodeVotes.length - 1][0].voter_identity_id
         },
         topVotedResource: {
-          abstain: 15,
-          yes: 15,
-          lock: 0,
-          resource: [30]
+          totalCountAbstain: 15,
+          totalCountTowardsIdentity: 15,
+          totalCountLock: 0,
+          resourceValue: [30]
         },
         totalVotesCount: 465,
         totalVotesGasUsed: masternodeVotesGas

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -143,19 +143,19 @@ HTTP /epoch/2492
   "totalCollectedFees": 1897008860,
   "bestValidator": "87075234AC47353B42BB97CE46330CB67CD4648C01F0B2393D7E729B0D678918",
   "topVotedResource": {
-    "resource": [
+    "resourceValue": [
       "dash",
       "asdthree0"
     ],
-    "yes": 7,
-    "abstain": 1,
-    "lock": 4
+    "totalCountTowardsIdentity": 7,
+    "totalCountAbstain": 1,
+    "totalCountLock": 4
   },
   "bestVoter": {
     "identifier": "4GfuwhaXL5YSerKKwJ19X2s5yXn8dC738tqfcvncqNgM",
-    "yes": 2,
-    "abstain": 1,
-    "lock": 2
+    "totalCountTowardsIdentity": 2,
+    "totalCountAbstain": 1,
+    "totalCountLock": 2
   },
   "totalVotesCount": 12,
   "totalVotesGasUsed": 120000000


### PR DESCRIPTION
# Issue
At this moment we have different naming for contested resources response and contested resources status in epoch response

# Things done
- Updated naming
- Updated tests
- `Updated README.md`