### PR TITLE
Withdrawals documents skip parameters

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1193,11 +1193,12 @@ Return all withdrawals for identity
 _Note: this request does not contain any pagination data in the response_
 
 * `limit` cannot be more then 100
-* `page` cannot be less then 1
+* `timestamp_start` ISO String
+* `start_at` base58 encoded withdrawal document identifier
 * returns 404 `not found` if identity don't have withdrawals
 * Pagination always `null`
 ```
-GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?limit=5
+GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?limit=5&start_at=95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs&timestamp_start=2024-10-10T02:37:39.187Z
 
 {
   "pagination": {
@@ -1209,9 +1210,9 @@ GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?limit=5
     {
       "document": "95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs",
       "sender": "A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb",
-      "status": "COMPLETE",
+      "status": 3,
       "amount": 200000,
-      "timestamp": 1729096625509,
+      "timestamp": "2024-10-10T02:37:39.187Z",
       "withdrawalAddress": "yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A",
       "hash": "113F86F4D1F48159B0D6690F3C5F8F33E39243086C041CF016454A66AD63F025"
     },

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -121,7 +121,7 @@ class IdentitiesController {
       status: document.getData().status,
       timestamp: document.getCreatedAt(),
       amount: document.getData().amount,
-      withdrawalAddress: outputScriptToAddress(Buffer.from(document.getData().outputScript, 'base64')),
+      withdrawalAddress: outputScriptToAddress(Buffer.from(document.getData().outputScript ?? [], 'base64')),
       hash: withdrawals.find(
         withdrawal =>
           withdrawal.timestamp.getTime() === document.getCreatedAt().getTime()

--- a/packages/api/src/schemas.js
+++ b/packages/api/src/schemas.js
@@ -118,6 +118,11 @@ const schemaTypes = [
       power: {
         type: ['number', 'null'],
         enum: [1, 4]
+      },
+      start_at: {
+        type: ['string', 'null'],
+        minLength: 43,
+        maxLength: 44
       }
     }
   },

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -65,7 +65,8 @@ const createDocumentBatchTransition = async (client, dataContractObject, owner, 
  */
 
 const outputScriptToAddress = (script) => {
-  return dashcorelib.Script(script).toAddress(NETWORK).toString()
+  const address = dashcorelib.Script(script).toAddress(NETWORK)
+  return address ? address.toString() : null
 }
 
 const decodeStateTransition = async (client, base64) => {

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -58,6 +58,16 @@ const createDocumentBatchTransition = async (client, dataContractObject, owner, 
   return tx.toBuffer().toString('base64')
 }
 
+/**
+ * allows to get address from output script
+ * @param {Buffer} script
+ * @returns {String}
+ */
+
+const outputScriptToAddress = (script) => {
+  return dashcorelib.Script(script).toAddress(NETWORK).toString()
+}
+
 const decodeStateTransition = async (client, base64) => {
   const stateTransition = await client.platform.dpp.stateTransition.createFromBuffer(Buffer.from(base64, 'base64'))
 
@@ -303,10 +313,7 @@ const decodeStateTransition = async (client, base64) => {
     }
     case StateTransitionEnum.IDENTITY_CREDIT_WITHDRAWAL: {
       decoded.outputAddress = stateTransition.getOutputScript()
-        ? dashcorelib
-          .Script(stateTransition.getOutputScript())
-          .toAddress(NETWORK)
-          .toString()
+        ? outputScriptToAddress(stateTransition.getOutputScript())
         : null
 
       decoded.userFeeIncrease = stateTransition.getUserFeeIncrease()
@@ -545,5 +552,6 @@ module.exports = {
   getAliasInfo,
   getAliasStateByVote,
   buildIndexBuffer,
-  createDocumentBatchTransition
+  createDocumentBatchTransition,
+  outputScriptToAddress
 }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1160,11 +1160,12 @@ Return all withdrawals for identity
 _Note: this request does not contain any pagination data in the response_
 
 * `limit` cannot be more then 100
-* `page` cannot be less then 1
+* `timestamp_start` ISO String
+* `start_at` base58 encoded withdrawal document identifier
 * returns 404 `not found` if identity don't have withdrawals
 * Pagination always `null`
 ```
-GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?limit=5
+GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?limit=5&start_at=95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs&timestamp_start=2024-10-10T02:37:39.187Z
 
 {
   "pagination": {
@@ -1176,9 +1177,9 @@ GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?limit=5
     {
       "document": "95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs",
       "sender": "A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb",
-      "status": "COMPLETE",
+      "status": 3,
       "amount": 200000,
-      "timestamp": 1729096625509,
+      "timestamp": "2024-10-10T02:37:39.187Z",
       "withdrawalAddress": "yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A",
       "hash": "113F86F4D1F48159B0D6690F3C5F8F33E39243086C041CF016454A66AD63F025"
     },


### PR DESCRIPTION
# Issue
At this moment, we can get withdrawals for identity with 1 parameter - limit, but we need to add mechanism for documents skip
# Things done
- Implemented new method in utils, which allows to get address from outout script
- Implemented updated query to dapi for `start_at` and `timestamp_start`
- Updated `README.md`
- Added new parametr `start_at`