### PR TITLE
Fix token receiver is optional

### DIFF
--- a/packages/indexer/src/processor/psql/dao/token.rs
+++ b/packages/indexer/src/processor/psql/dao/token.rs
@@ -89,7 +89,7 @@ impl PostgresDAO {
       &(token_position as i16),
       &st_hash,
       &data_contract_id,
-      &recipient.unwrap().to_string(Base58)
+      &recipient.map(|identifier| {identifier.to_string(Base58)})
     ]).await.unwrap();
 
     println!("Token transition from {}", &owner.to_string(Base58));


### PR DESCRIPTION
# Issue
There was a bug, where recipient of the TokenTransition was made nullable in the database, but by mistake an .unwrap() is used in query params.

# Things done
* Added map to string instead of .unwrap()