### PR TITLE
Fix token amount is optional

### DIFF
--- a/packages/indexer/src/processor/psql/dao/token.rs
+++ b/packages/indexer/src/processor/psql/dao/token.rs
@@ -84,7 +84,7 @@ impl PostgresDAO {
       &owner.to_string(Base58),
       &token_identifier.to_string(Base58),
       &(action as i16),
-      &(amount.unwrap() as i64),
+      &(amount.map(|token_amount| { token_amount as i64})),
       &public_note,
       &(token_position as i16),
       &st_hash,


### PR DESCRIPTION
# Issue 
Similar to https://github.com/pshenmic/platform-explorer/pull/583, token amount is not handled properly, using .unwrap() on an optional in SQL request params.

# Things done
* Added a .map() for optional