### PR TITLE
Fix validator statistics API methods

### DIFF
--- a/packages/frontend/src/util/Api.js
+++ b/packages/frontend/src/util/Api.js
@@ -202,11 +202,11 @@ const getValidatorByProTxHash = (proTxHash) => {
 }
 
 const getBlocksStatsByValidator = (proTxHash, start, end, intervalsCount) => {
-  return call(`validator/${proTxHash}/stats?start=${start}&end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
+  return call(`validator/${proTxHash}/stats?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
 }
 
 const getRewardsStatsByValidator = (proTxHash, start, end, intervalsCount) => {
-  return call(`validator/${proTxHash}/rewards/stats?start=${start}&end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
+  return call(`validator/${proTxHash}/rewards/stats?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
 }
 
 const getMasternodeVotes = (page = 1, limit = 10, order = 'asc', filters = {}) => {


### PR DESCRIPTION
# Issue
On the validator page, the charts display data only for the current day, regardless of the selected date range.

Since we need to push changes to mainnet urgently, but we can't merge all the changes from dev, this pull request is a repeat of the changes from [this](https://github.com/pshenmic/platform-explorer/pull/585) pull request.

# Things done
Fixed getBlocksStatsByValidator and getRewardsStatsByValidator methods api methods. Now the selected date range is displayed correctly