### PR TITLE
Improve filter logic

### DIFF
--- a/packages/frontend/src/app/blocks/Blocks.js
+++ b/packages/frontend/src/app/blocks/Blocks.js
@@ -21,7 +21,6 @@ import {
   useOutsideClick
 } from '@chakra-ui/react'
 import { BlocksFilter } from '../../components/blocks'
-import { useDebounce } from '../../hooks'
 import { SearchResultsList, GlobalSearchInput } from '../../components/search'
 import './Blocks.scss'
 
@@ -45,7 +44,6 @@ function Blocks ({ defaultPage = 1, defaultPageSize }) {
   const [currentPage, setCurrentPage] = useState(defaultPage ? defaultPage - 1 : 0)
   const pageCount = Math.ceil(total / pageSize) ? Math.ceil(total / pageSize) : 1
   const [filters, setFilters] = useState({})
-  const debouncedFilters = useDebounce(filters, 250)
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -78,7 +76,7 @@ function Blocks ({ defaultPage = 1, defaultPageSize }) {
         Math.max(1, currentPage + 1),
         Math.max(1, pageSize),
         'desc',
-        debouncedFilters
+        filters
       ).then(res => {
         setTotal(res.pagination.total)
         fetchHandlerSuccess(setBlocks, res)
@@ -89,7 +87,7 @@ function Blocks ({ defaultPage = 1, defaultPageSize }) {
     }
 
     fetchData()
-  }, [currentPage, pageSize, debouncedFilters])
+  }, [currentPage, pageSize, filters])
 
   useEffect(() => {
     const page = parseInt(searchParams.get('page')) || paginateConfig.defaultPage

--- a/packages/frontend/src/app/masternodeVotes/MasternodeVotes.js
+++ b/packages/frontend/src/app/masternodeVotes/MasternodeVotes.js
@@ -8,7 +8,6 @@ import { ErrorMessageBlock } from '../../components/Errors'
 import { fetchHandlerSuccess, fetchHandlerError } from '../../util'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Box, Container, Heading, useBreakpointValue } from '@chakra-ui/react'
-import { useDebounce } from '../../hooks'
 import { VotesList } from '../../components/contestedResources/votes'
 import { MasternodeVotesFilters } from '../../components/contestedResources'
 import './MasternodeVotes.scss'
@@ -28,7 +27,6 @@ function MasternodeVotes ({ defaultPage = 1, defaultPageSize }) {
   const [currentPage, setCurrentPage] = useState(defaultPage ? defaultPage - 1 : 0)
   const pageCount = Math.ceil(total / pageSize) ? Math.ceil(total / pageSize) : 1
   const [filters, setFilters] = useState({})
-  const debouncedFilters = useDebounce(filters, 250)
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
@@ -47,7 +45,7 @@ function MasternodeVotes ({ defaultPage = 1, defaultPageSize }) {
         Math.max(1, currentPage + 1),
         Math.max(1, pageSize),
         'desc',
-        debouncedFilters
+        filters
       ).then(res => {
         setTotal(res?.pagination?.total)
         fetchHandlerSuccess(setMasternodeVotes, res)
@@ -58,7 +56,7 @@ function MasternodeVotes ({ defaultPage = 1, defaultPageSize }) {
     }
 
     fetchData()
-  }, [currentPage, pageSize, debouncedFilters])
+  }, [currentPage, pageSize, filters])
 
   useEffect(() => {
     const page = parseInt(searchParams.get('page')) || paginateConfig.defaultPage

--- a/packages/frontend/src/app/transactions/Transactions.js
+++ b/packages/frontend/src/app/transactions/Transactions.js
@@ -10,7 +10,6 @@ import { LoadingList } from '../../components/loading'
 import { ErrorMessageBlock } from '../../components/Errors'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { Container, Heading, Box, useBreakpointValue } from '@chakra-ui/react'
-import { useDebounce } from '../../hooks'
 import './Transactions.scss'
 
 const paginateConfig = {
@@ -27,7 +26,6 @@ function Transactions ({ defaultPage = 1, defaultPageSize }) {
   const [total, setTotal] = useState(0)
   const [transactions, setTransactions] = useState({ data: [], loading: true, error: null })
   const [filters, setFilters] = useState({})
-  const debouncedFilters = useDebounce(filters, 250)
   const pageCount = Math.ceil(total / pageSize)
   const router = useRouter()
   const pathname = usePathname()
@@ -43,7 +41,7 @@ function Transactions ({ defaultPage = 1, defaultPageSize }) {
           Math.max(1, currentPage + 1),
           Math.max(1, pageSize),
           'desc',
-          debouncedFilters
+          filters
         )
 
         setTotal(response.pagination.total)
@@ -56,7 +54,7 @@ function Transactions ({ defaultPage = 1, defaultPageSize }) {
     }
 
     fetchTransactions()
-  }, [currentPage, pageSize, debouncedFilters])
+  }, [currentPage, pageSize, filters])
 
   useEffect(() => {
     const page = parseInt(searchParams.get('page')) || paginateConfig.defaultPage

--- a/packages/frontend/src/components/blocks/BlocksFilter.js
+++ b/packages/frontend/src/components/blocks/BlocksFilter.js
@@ -98,6 +98,7 @@ export default function BlocksFilter ({ initialFilters, onFilterChange, isMobile
       isMobile={isMobile}
       className={`BlocksFilter ${className || ''}`}
       buttonText={'Add filter'}
+      applyOnChange={false}
     />
   )
 }

--- a/packages/frontend/src/components/contestedResources/MasternodeVotesFilters.js
+++ b/packages/frontend/src/components/contestedResources/MasternodeVotesFilters.js
@@ -46,6 +46,7 @@ export default function MasternodeVotesFilters ({ initialFilters, onFilterChange
       isMobile={isMobile}
       className={`BlocksFilter ${className || ''}`}
       buttonText={'Add filter'}
+      applyOnChange={false}
     />
   )
 }

--- a/packages/frontend/src/components/filters/Filters.js
+++ b/packages/frontend/src/components/filters/Filters.js
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button, useDisclosure } from '@chakra-ui/react'
 import { useFilters } from '../../hooks'
 import { MultiSelectFilter, InputFilter, RangeFilter, FilterGroup, ActiveFilters, SearchFilter } from './'
@@ -17,7 +17,8 @@ export const Filters = ({
   onFilterChange,
   isMobile = false,
   buttonText = 'Add filter',
-  className = ''
+  className = '',
+  applyOnChange = false // If true, filters apply immediately on change. If false, filters apply only on menu close/submit
 }) => {
   const defaultFilters = Object.fromEntries(
     Object.keys(filtersConfig).map(key => [
@@ -26,20 +27,24 @@ export const Filters = ({
     ])
   )
 
+  // Menu filters - temporary state while user is selecting filters
   const {
-    filters,
-    setFilters,
+    filters: menuFilters,
+    setFilters: setMenuFilters,
     handleFilterChange: baseHandleFilterChange,
     handleMultipleValuesChange: baseHandleMultipleValuesChange
   } = useFilters(defaultFilters)
 
-  const previousFilters = useRef(filters)
+  // Applied filters - actual filters that are applied and shown in ActiveFilters
+  const [appliedFilters, setAppliedFilters] = useState(defaultFilters)
 
-  const applyFilters = useCallback(() => {
+  const previousAppliedFilters = useRef(appliedFilters)
+
+  const applyFilters = useCallback((filtersToApply = menuFilters) => {
     if (typeof onFilterChange !== 'function') return
 
     const processedFilters = (() => {
-      return Object.entries(filters).reduce((result, [key, value]) => {
+      return Object.entries(filtersToApply).reduce((result, [key, value]) => {
         const filterKeyConfig = filtersConfig[key]
 
         if (filterKeyConfig.type === 'multiselect' && (filterKeyConfig.isAllSelected(value) || value?.length === 0)) {
@@ -77,61 +82,95 @@ export const Filters = ({
       }, {})
     })()
 
-    if (JSON.stringify(previousFilters.current) === JSON.stringify(processedFilters)) {
+    // Update applied filters state
+    setAppliedFilters(filtersToApply)
+
+    if (JSON.stringify(previousAppliedFilters.current) === JSON.stringify(processedFilters)) {
       return
     }
 
-    previousFilters.current = processedFilters
+    previousAppliedFilters.current = processedFilters
     onFilterChange(processedFilters)
-  }, [filters, onFilterChange, filtersConfig])
+  }, [menuFilters, onFilterChange, filtersConfig])
 
-  useEffect(applyFilters, [applyFilters])
+  // Apply filters immediately only if applyOnChange is true
+  useEffect(() => {
+    if (applyOnChange) {
+      applyFilters()
+    }
+  }, [applyFilters, applyOnChange])
 
   const { isOpen: menuIsOpen, onOpen: menuOnOpen, onClose: menuOnClose } = useDisclosure()
 
+  // Sync menu filters with applied filters when menu opens
+  const handleMenuOpen = useCallback(() => {
+    setMenuFilters(appliedFilters)
+    menuOnOpen()
+  }, [appliedFilters, setMenuFilters, menuOnOpen])
+
+  const handleMenuClose = useCallback(() => {
+    // Apply filters when menu closes (if not applying on change)
+    if (!applyOnChange) {
+      applyFilters()
+    }
+    menuOnClose()
+  }, [applyFilters, applyOnChange, menuOnClose])
+
   const submitHandler = () => {
+    // Always apply filters when submit is pressed
     applyFilters()
     menuOnClose()
   }
 
-  /** Handle single filter change */
+  /** Handle single filter change in menu */
   const handleFilterChange = useCallback((filterName, value) => {
     const newFilters = baseHandleFilterChange(filterName, value)
-    setFilters(newFilters)
-  }, [baseHandleFilterChange, setFilters])
+    setMenuFilters(newFilters)
+  }, [baseHandleFilterChange, setMenuFilters])
 
-  /** Handle multiple values filter change */
+  /** Handle multiple values filter change in menu */
   const handleMultipleValuesChange = useCallback((fieldName, value) => {
     const newFilters = baseHandleMultipleValuesChange(fieldName, value)
-    setFilters(newFilters)
-  }, [baseHandleMultipleValuesChange, setFilters])
+    setMenuFilters(newFilters)
+  }, [baseHandleMultipleValuesChange, setMenuFilters])
 
   const handleToggleAll = useCallback((filterName, values) => {
     const newFilters = baseHandleFilterChange(filterName, values)
-    setFilters(newFilters)
-  }, [baseHandleFilterChange, setFilters])
+    setMenuFilters(newFilters)
+  }, [baseHandleFilterChange, setMenuFilters])
 
-  /** Clear a specific filter */
-  const clearFilter = useCallback((filterName) => {
-    const newFilters = {
-      ...filters,
+  /** Clear a specific applied filter */
+  const clearAppliedFilter = useCallback((filterName) => {
+    const newAppliedFilters = {
+      ...appliedFilters,
       [filterName]: filtersConfig[filterName].defaultValue
     }
-    setFilters(newFilters)
-  }, [filters, filtersConfig, setFilters])
 
-  const resetAllFilters = useCallback(() => {
+    // Update both applied and menu filters
+    setAppliedFilters(newAppliedFilters)
+    setMenuFilters(newAppliedFilters)
+
+    // Apply filters immediately
+    applyFilters(newAppliedFilters)
+  }, [appliedFilters, filtersConfig, setMenuFilters, applyFilters])
+
+  const resetAllAppliedFilters = useCallback(() => {
     const defaultFilters = Object.fromEntries(
       Object.keys(filtersConfig).map(key => [
         key,
         filtersConfig[key].defaultValue
       ])
     )
-    setFilters(defaultFilters)
+
+    // Update both applied and menu filters
+    setAppliedFilters(defaultFilters)
+    setMenuFilters(defaultFilters)
+
+    // Apply empty filters immediately
     if (typeof onFilterChange === 'function') {
       onFilterChange({})
     }
-  }, [filtersConfig, setFilters, onFilterChange])
+  }, [filtersConfig, setMenuFilters, onFilterChange])
 
   const menuData = Object.entries(filtersConfig).map(([key, config]) => {
     let content
@@ -142,7 +181,7 @@ export const Filters = ({
           <FilterGroup title={config.title}>
             <MultiSelectFilter
               items={config.options}
-              selectedValues={filters[key]}
+              selectedValues={menuFilters[key]}
               onItemClick={(value) => handleMultipleValuesChange(key, value)}
               onSelectAll={(values) => handleToggleAll(key, values)}
               showToggleAll={true}
@@ -156,7 +195,7 @@ export const Filters = ({
         content = (
           <FilterGroup title={config.title}>
             <RangeFilter
-              value={filters[key]}
+              value={menuFilters[key]}
               onChange={(value) => handleFilterChange(key, value)}
               type={'number'}
               minTitle={config.minTitle}
@@ -173,7 +212,7 @@ export const Filters = ({
         content = (
           <FilterGroup title={config.title}>
             <InputFilter
-              value={filters[key]}
+              value={menuFilters[key]}
               onChange={(value) => handleFilterChange(key, value)}
               placeholder={config.placeholder}
               showSubmitButton={true}
@@ -186,7 +225,7 @@ export const Filters = ({
         content = (
           <FilterGroup title={config?.title}>
             <SearchFilter
-              value={filters[key]}
+              value={menuFilters[key]}
               onChange={(value) => handleFilterChange(key, value)}
               placeholder={config?.placeholder}
               showSubmitButton={true}
@@ -200,7 +239,7 @@ export const Filters = ({
         content = (
           <FilterGroup title={config?.title}>
             <DateRangeFilter
-              value={filters[key]}
+              value={menuFilters[key]}
               onChange={(value) => handleFilterChange(key, value)}
               onSubmit={submitHandler}
             />
@@ -211,8 +250,9 @@ export const Filters = ({
         content = null
     }
 
-    const activeFilterValue = !filtersConfig[key].isAllSelected?.(filters[key]) && filters[key]
-      ? filtersConfig[key].formatValue?.(filters[key])
+    // Use applied filters for activeFilterValue (what shows in ActiveFilters)
+    const activeFilterValue = !filtersConfig[key].isAllSelected?.(appliedFilters[key]) && appliedFilters[key]
+      ? filtersConfig[key].formatValue?.(appliedFilters[key])
       : null
 
     return {
@@ -222,7 +262,7 @@ export const Filters = ({
       activeFilterValue,
       type: config.type,
       filterKey: key,
-      rawValue: filters[key],
+      rawValue: appliedFilters[key], // Use applied filters for ActiveFilters display
       options: config.options || null,
       mobileTagRenderer: config.mobileTagRenderer || null
     }
@@ -231,7 +271,7 @@ export const Filters = ({
   const TriggerButton = () => (
     <Button
       className={'Filters__Button Filters__Button--ToggleFilters '}
-      onClick={() => menuIsOpen ? menuOnClose() : menuOnOpen()}
+      onClick={() => menuIsOpen ? handleMenuClose() : handleMenuOpen()}
       variant={'brand'}
       size={'sm'}
     >
@@ -255,9 +295,9 @@ export const Filters = ({
                 placement={'bottom-start'}
                 trigger={TriggerButton()}
                 menuData={menuData}
-                onClose={menuOnClose}
+                onClose={handleMenuClose}
                 isOpen={menuIsOpen}
-                onOpen={menuOnOpen}
+                onOpen={handleMenuOpen}
               />
           }
 
@@ -266,7 +306,7 @@ export const Filters = ({
               className={'Filters__Button'}
               variant={'gray'}
               size={'sm'}
-              onClick={resetAllFilters}
+              onClick={resetAllAppliedFilters}
             >
               Clear ({activeFiltersCount})
             </Button>
@@ -274,8 +314,8 @@ export const Filters = ({
         </div>
 
         <ActiveFilters
-          filters={filters}
-          onClearFilter={clearFilter}
+          filters={appliedFilters}
+          onClearFilter={clearAppliedFilter}
           allValuesSelected={(key, value) => filtersConfig[key]?.isAllSelected?.(value) || false}
           formatValue={(key, value) => filtersConfig[key]?.formatValue(value)}
           getFilterLabel={(key) => filtersConfig[key]?.label || key}
@@ -285,14 +325,14 @@ export const Filters = ({
       {isMobile && (
         <BottomSheet
           isOpen={menuIsOpen}
-          onClose={menuOnClose}
-          onOpen={menuOnOpen}
+          onClose={handleMenuClose}
+          onOpen={handleMenuOpen}
           fullHeightOnly={true}
         >
           <MobileFilterMenu
             menuData={menuData}
             onSubmit={submitHandler}
-            onReset={resetAllFilters}
+            onReset={resetAllAppliedFilters}
           />
         </BottomSheet>
       )}

--- a/packages/frontend/src/components/filters/Filters.js
+++ b/packages/frontend/src/components/filters/Filters.js
@@ -27,7 +27,7 @@ export const Filters = ({
     ])
   )
 
-  // Menu filters - temporary state while user is selecting filters
+  /** Menu filters - temporary state while user is selecting filters */
   const {
     filters: menuFilters,
     setFilters: setMenuFilters,
@@ -35,7 +35,7 @@ export const Filters = ({
     handleMultipleValuesChange: baseHandleMultipleValuesChange
   } = useFilters(defaultFilters)
 
-  // Applied filters - actual filters that are applied and shown in ActiveFilters
+  /** Applied filters - actual filters that are applied and shown in ActiveFilters */
   const [appliedFilters, setAppliedFilters] = useState(defaultFilters)
 
   const previousAppliedFilters = useRef(appliedFilters)
@@ -82,7 +82,7 @@ export const Filters = ({
       }, {})
     })()
 
-    // Update applied filters state
+    /** Update applied filters state */
     setAppliedFilters(filtersToApply)
 
     if (JSON.stringify(previousAppliedFilters.current) === JSON.stringify(processedFilters)) {
@@ -93,7 +93,7 @@ export const Filters = ({
     onFilterChange(processedFilters)
   }, [menuFilters, onFilterChange, filtersConfig])
 
-  // Apply filters immediately only if applyOnChange is true
+  /** Apply filters immediately only if applyOnChange is true */
   useEffect(() => {
     if (applyOnChange) {
       applyFilters()
@@ -102,14 +102,14 @@ export const Filters = ({
 
   const { isOpen: menuIsOpen, onOpen: menuOnOpen, onClose: menuOnClose } = useDisclosure()
 
-  // Sync menu filters with applied filters when menu opens
+  /** Sync menu filters with applied filters when menu opens */
   const handleMenuOpen = useCallback(() => {
     setMenuFilters(appliedFilters)
     menuOnOpen()
   }, [appliedFilters, setMenuFilters, menuOnOpen])
 
   const handleMenuClose = useCallback(() => {
-    // Apply filters when menu closes (if not applying on change)
+    /** Apply filters when menu closes (if not applying on change) */
     if (!applyOnChange) {
       applyFilters()
     }
@@ -117,7 +117,7 @@ export const Filters = ({
   }, [applyFilters, applyOnChange, menuOnClose])
 
   const submitHandler = () => {
-    // Always apply filters when submit is pressed
+    /** Always apply filters when submit is pressed */
     applyFilters()
     menuOnClose()
   }
@@ -146,11 +146,11 @@ export const Filters = ({
       [filterName]: filtersConfig[filterName].defaultValue
     }
 
-    // Update both applied and menu filters
+    /** Update both applied and menu filters */
     setAppliedFilters(newAppliedFilters)
     setMenuFilters(newAppliedFilters)
 
-    // Apply filters immediately
+    /** Apply filters immediately */
     applyFilters(newAppliedFilters)
   }, [appliedFilters, filtersConfig, setMenuFilters, applyFilters])
 
@@ -162,11 +162,11 @@ export const Filters = ({
       ])
     )
 
-    // Update both applied and menu filters
+    /** Update both applied and menu filters */
     setAppliedFilters(defaultFilters)
     setMenuFilters(defaultFilters)
 
-    // Apply empty filters immediately
+    /** Apply empty filters immediately */
     if (typeof onFilterChange === 'function') {
       onFilterChange({})
     }
@@ -250,7 +250,7 @@ export const Filters = ({
         content = null
     }
 
-    // Use applied filters for activeFilterValue (what shows in ActiveFilters)
+    /** Use applied filters for activeFilterValue (what shows in ActiveFilters) */
     const activeFilterValue = !filtersConfig[key].isAllSelected?.(appliedFilters[key]) && appliedFilters[key]
       ? filtersConfig[key].formatValue?.(appliedFilters[key])
       : null

--- a/packages/frontend/src/components/transactions/TransactionsFilter.js
+++ b/packages/frontend/src/components/transactions/TransactionsFilter.js
@@ -139,6 +139,7 @@ export default function TransactionsFilter ({ initialFilters, onFilterChange, is
       isMobile={isMobile}
       className={`TransactionsFilter ${className || ''}`}
       buttonText={'Add filter'}
+      applyOnChange={false}
     />
   )
 }


### PR DESCRIPTION
# Issue
Currently, filters are applied immediately when filter parameters are changed. Because of this, API requests can be sent too often and overlap each other. It is necessary to make it so that the data request is sent not with each filter change, but when the filters are closed or the "ok" button is pressed in the filter parameters.

# Things done
Updated logic for applying filters. Now filters can be applied immediately upon state change in the menu and after filters have been fully applied.
Filters on the transaction and block pages have been updated to send queries after filters have been fully applied.
