### PR TITLE
Fix column title in search result list block title

### DIFF
--- a/packages/frontend/src/components/search/SearchResultsList.js
+++ b/packages/frontend/src/components/search/SearchResultsList.js
@@ -7,7 +7,7 @@ const COLUMN_TITLES = {
   [categoryMap.validators]: ['Identity', 'Balance'],
   [categoryMap.identities]: ['Status', 'Time'],
   [categoryMap.dataContracts]: ['Owner', 'Time'],
-  [categoryMap.blocks]: ['Epoch', 'Time'],
+  [categoryMap.blocks]: ['Height', 'Time'],
   [categoryMap.documents]: ['Identity', 'Time'],
   [categoryMap.transactions]: ['Status', 'Time']
 }


### PR DESCRIPTION
# Issue
The block list in the search results has an incorrect column name. You need to change the Epoch to Height

# Things done
fixed