### PR TITLE
Tokens rating `timestamp_start` and `timestamp_end`

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2544,21 +2544,47 @@ Return list of tokens identifier with order by transactions count
 * Valid `order` values are `asc` or `desc`
 * `limit` cannot be more then 100
 * `page` cannot be less then 1
+* `timestamp_start` and `timestamp_end` can be null and `timestamp_end` must be greater then `timestamp_start` if they are used. Default value is equal to the interval in the past 30 days
 ```
-GET tokens/rating?order=desc&limit=10&page=1
+GET tokens/rating?order=desc&limit=10&page=1&timestamp_start=2025-06-20T17:10:28.585Z&timestamp_end=2025-07-28T20:37:28.585Z
 {
     "resultSet": [
         {
             "tokenIdentifier": "8RsBCPSDUwWMnvLTDooh7ZcfZmnRb5tecsagsrdAFrrd",
-            "transitionCount": 15
-        },
-        {
-            "tokenIdentifier": "4xd9usiX6WCPE4h1AFPQBJ4Rje6TfZw8kiBzkSAzvmCL",
-            "transitionCount": 13
-        },
-        {
-            "tokenIdentifier": "5F4Q7PNmdxBP7ULbfUwKP6gNxdgZKygQaQ6m79LPQBd4",
-            "transitionCount": 5
+            "transitionCount": 15,
+            {
+                "localizations": {
+                    "en": {
+                        "pluralForm": "A1-keyword",
+                        "singularForm": "A1-keyword",
+                        "shouldCapitalize": true
+                    }
+                },
+                "tokenIdentifier": "FWuCZYmNo2qWfLcYsNUnu1LdqBWbzvWBUcGQHRFE2mVt",
+                "transitionCount": 1
+            },
+            {
+                "localizations": {
+                    "en": {
+                        "pluralForm": "A1-test-1",
+                        "singularForm": "A1-test-1",
+                        "shouldCapitalize": true
+                    }
+                },
+                "tokenIdentifier": "Eg49SNkMVgo84vGhj89bEK53X2mURGuVSERzteaT1brr",
+                "transitionCount": 1
+            },
+            {
+                "localizations": {
+                    "en": {
+                        "pluralForm": "aaa",
+                        "singularForm": "aaa",
+                        "shouldCapitalize": true
+                    }
+                },
+                "tokenIdentifier": "8Uv6WJEf7pyw17AtcJpGdURkU3wrmz86RkXxUdNNx575",
+                "transitionCount": 2
+            },
         },
         ...
     ],

--- a/packages/api/src/controllers/TokensController.js
+++ b/packages/api/src/controllers/TokensController.js
@@ -32,21 +32,47 @@ class TokensController {
   }
 
   getTokenTransitions = async (request, response) => {
+    const { identifier } = request.params
     const {
-      identifier
-    } = request.params
+      page = 1,
+      limit = 10,
+      order = 'asc'
+    } = request.query
 
-    const { page = 1, limit = 10, order = 'asc' } = request.query
-
-    const transitions = await this.tokensDAO.getTokenTransitions(identifier, Number(page ?? 0), Number(limit ?? 0), order)
+    const transitions = await this.tokensDAO.getTokenTransitions(
+      identifier,
+      Number(page ?? 0),
+      Number(limit ?? 0),
+      order
+    )
 
     response.send(transitions)
   }
 
   getTokensTrends = async (request, response) => {
-    const { page = 1, limit = 10, order = 'asc' } = request.query
+    const {
+      page = 1,
+      limit = 10,
+      order = 'asc',
+      timestamp_start: start = new Date().getTime() - 2592000000,
+      timestamp_end: end = new Date().getTime()
+    } = request.query
 
-    const rating = await this.tokensDAO.getTokensTrends(Number(page ?? 0), Number(limit ?? 0), order)
+    if (!start || !end) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
+
+    if (start > end) {
+      return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
+    }
+
+    const rating = await this.tokensDAO.getTokensTrends(
+      new Date(start),
+      new Date(end),
+      Number(page ?? 0),
+      Number(limit ?? 0),
+      order
+    )
 
     response.send(rating)
   }

--- a/packages/api/src/dao/TokensDAO.js
+++ b/packages/api/src/dao/TokensDAO.js
@@ -124,7 +124,6 @@ module.exports = class TokensDAO {
       .select(this.knex.raw('count(token_identifier) as transitions_count'))
       .whereBetween('timestamp', [startDate.toISOString(), endDate.toISOString()])
       .groupBy('token_identifier')
-      .orderBy('transitions_count', order)
       .leftJoin('state_transitions', 'state_transitions.hash', 'token_transitions.state_transition_hash')
       .leftJoin('blocks', 'state_transitions.block_height', 'blocks.height')
       .as('subquery')
@@ -134,6 +133,7 @@ module.exports = class TokensDAO {
       .select(this.knex.raw('count(*) OVER() as total_count'))
       .limit(limit)
       .offset(fromRank)
+      .orderBy('transitions_count', order)
       .leftJoin('tokens', 'tokens.identifier', 'token_identifier')
       .leftJoin('data_contracts', 'data_contracts.id', 'data_contract_id')
 

--- a/packages/api/src/dao/TokensDAO.js
+++ b/packages/api/src/dao/TokensDAO.js
@@ -2,6 +2,7 @@ const Token = require('../models/Token')
 const TokenTransition = require('../models/TokenTransition')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
 const TokenTransitionsEnum = require('../enums/TokenTransitionsEnum')
+const Localization = require('../models/Localization')
 
 module.exports = class TokensDAO {
   constructor (knex, dapi) {
@@ -115,28 +116,46 @@ module.exports = class TokensDAO {
     return new PaginatedResultSet(rows.map(TokenTransition.fromRow), page, limit, order)
   }
 
-  getTokensTrends = async (page, limit, order) => {
+  getTokensTrends = async (startDate, endDate, page, limit, order) => {
     const fromRank = (page - 1) * limit
 
     const subquery = this.knex('token_transitions')
       .select('token_identifier')
       .select(this.knex.raw('count(token_identifier) as transitions_count'))
+      .whereBetween('timestamp', [startDate.toISOString(), endDate.toISOString()])
       .groupBy('token_identifier')
       .orderBy('transitions_count', order)
+      .leftJoin('state_transitions', 'state_transitions.hash', 'token_transitions.state_transition_hash')
+      .leftJoin('blocks', 'state_transitions.block_height', 'blocks.height')
       .as('subquery')
 
     const rows = await this.knex(subquery)
-      .select('token_identifier', 'transitions_count')
+      .select('token_identifier', 'transitions_count', 'data_contracts.identifier as data_contract_identifier', 'tokens.position')
       .select(this.knex.raw('count(*) OVER() as total_count'))
       .limit(limit)
       .offset(fromRank)
+      .leftJoin('tokens', 'tokens.identifier', 'token_identifier')
+      .leftJoin('data_contracts', 'data_contracts.id', 'data_contract_id')
+
+    const resultSet = await Promise.all(rows.map(async (row) => {
+      const dataContract = await this.dapi.getDataContract(row.data_contract_identifier)
+
+      const token = dataContract.tokens[row.position]
+
+      const localizations = {}
+
+      for (const locale in token.conventions.localizations) {
+        localizations[locale] = Localization.fromObject(token.conventions.localizations[locale])
+      }
+
+      return {
+        localizations,
+        tokenIdentifier: row.token_identifier ?? null,
+        transitionCount: Number(row.transitions_count ?? null)
+      }
+    }))
 
     const [row] = rows
-
-    const resultSet = rows.map(row => ({
-      tokenIdentifier: row.token_identifier ?? null,
-      transitionCount: Number(row.transitions_count ?? null)
-    }))
 
     return new PaginatedResultSet(resultSet, page, limit, Number(row?.total_count ?? 0))
   }

--- a/packages/api/test/integration/tokens.spec.js
+++ b/packages/api/test/integration/tokens.spec.js
@@ -545,6 +545,12 @@ describe('Tokens', () => {
       for (let i = 0; i < 30; i++) {
         let tokenTransition
 
+        block = await fixtures.block(knex, {
+          timestamp: new Date(new Date().getTime()-3600000*(31-i)),
+          height: i+2
+        })
+
+
         const stateTransition = await fixtures.transaction(knex, {
           block_hash: block.hash,
           block_height: block.height,
@@ -578,7 +584,7 @@ describe('Tokens', () => {
           tokenTransitions.push(tokenTransition)
         }
 
-        tokens.push({ token, stateTransition, tokenTransitions })
+        tokens.push({ token, stateTransition, tokenTransitions, block })
       }
     })
 
@@ -687,6 +693,38 @@ describe('Tokens', () => {
           transitionCount: tokenTransitions.length
         }))
         .slice(14, 21)
+
+      assert.deepEqual(body.resultSet, expected)
+    })
+
+    it('Should allow to get default rating in order desc with custom limit and page size and time', async () => {
+      const start = new Date(new Date().getTime()-3600000*20)
+      const end = new Date()
+
+      const { body } = await client.get(`/tokens/rating?limit=4&page=2&order=desc&timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.pagination.page, 2)
+      assert.equal(body.pagination.limit, 4)
+      assert.equal(body.pagination.total, 18)
+      assert.equal(body.resultSet.length, 4)
+
+      const expected = tokens
+        .sort((a, b) => b.tokenTransitions.length - a.tokenTransitions.length)
+        .filter(({ block }) => block.timestamp.getTime() > start.getTime() && block.timestamp.getTime() < end.getTime())
+        .slice(4, 8)
+        .map(({ token, tokenTransitions }) => ({
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
+          tokenIdentifier: token.identifier,
+          transitionCount: tokenTransitions.length
+        }))
 
       assert.deepEqual(body.resultSet, expected)
     })

--- a/packages/api/test/integration/tokens.spec.js
+++ b/packages/api/test/integration/tokens.spec.js
@@ -546,10 +546,9 @@ describe('Tokens', () => {
         let tokenTransition
 
         block = await fixtures.block(knex, {
-          timestamp: new Date(new Date().getTime()-3600000*(31-i)),
-          height: i+2
+          timestamp: new Date(new Date().getTime() - 3600000 * (31 - i)),
+          height: i + 2
         })
-
 
         const stateTransition = await fixtures.transaction(knex, {
           block_hash: block.hash,
@@ -698,7 +697,7 @@ describe('Tokens', () => {
     })
 
     it('Should allow to get default rating in order desc with custom limit and page size and time', async () => {
-      const start = new Date(new Date().getTime()-3600000*20)
+      const start = new Date(new Date().getTime() - 3600000 * 20)
       const end = new Date()
 
       const { body } = await client.get(`/tokens/rating?limit=4&page=2&order=desc&timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}`)

--- a/packages/api/test/integration/tokens.spec.js
+++ b/packages/api/test/integration/tokens.spec.js
@@ -30,7 +30,14 @@ describe('Tokens', () => {
           baseSupply: 1000n,
           maxSupply: 1010n,
           conventions: {
-            decimals: 1000
+            decimals: 1000,
+            localizations: {
+              en: {
+                pluralForm: 'tests',
+                singularForm: 'test',
+                shouldCapitalize: true
+              }
+            }
           },
           manualMintingRules: {
             authorizedToMakeChange: {
@@ -313,11 +320,17 @@ describe('Tokens', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       const expectedToken = {
+        localizations: {
+          en: {
+            pluralForm: 'tests',
+            singularForm: 'test',
+            shouldCapitalize: true
+          }
+        },
         identifier: token.token.identifier,
         position: 29,
         timestamp: block.timestamp.toISOString(),
         description: null,
-        localizations: null,
         baseSupply: '1000',
         maxSupply: '1010',
         totalSupply: '1000',
@@ -350,11 +363,17 @@ describe('Tokens', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       const expectedToken = {
+        localizations: {
+          en: {
+            pluralForm: 'tests',
+            singularForm: 'test',
+            shouldCapitalize: true
+          }
+        },
         identifier: token.token.identifier,
         position: 29,
         timestamp: block.timestamp.toISOString(),
         description: null,
-        localizations: null,
         baseSupply: '1000',
         maxSupply: '1010',
         totalSupply: '1000',
@@ -575,6 +594,13 @@ describe('Tokens', () => {
 
       const expected = tokens
         .map(({ token, tokenTransitions }) => ({
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
           tokenIdentifier: token.identifier,
           transitionCount: tokenTransitions.length
         }))
@@ -595,6 +621,13 @@ describe('Tokens', () => {
 
       const expected = tokens
         .map(({ token, tokenTransitions }) => ({
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
           tokenIdentifier: token.identifier,
           transitionCount: tokenTransitions.length
         }))
@@ -615,6 +648,13 @@ describe('Tokens', () => {
 
       const expected = tokens
         .map(({ token, tokenTransitions }) => ({
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
           tokenIdentifier: token.identifier,
           transitionCount: tokenTransitions.length
         }))
@@ -636,6 +676,13 @@ describe('Tokens', () => {
       const expected = tokens
         .sort((a, b) => b.tokenTransitions.length - a.tokenTransitions.length)
         .map(({ token, tokenTransitions }) => ({
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
           tokenIdentifier: token.identifier,
           transitionCount: tokenTransitions.length
         }))

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -2511,21 +2511,47 @@ Return list of tokens identifier with order by transactions count
 * Valid `order` values are `asc` or `desc`
 * `limit` cannot be more then 100
 * `page` cannot be less then 1
+* `timestamp_start` and `timestamp_end` can be null and `timestamp_end` must be greater then `timestamp_start` if they are used. Default value is equal to the interval in the past 30 days
 ```
-GET tokens/rating?order=desc&limit=10&page=1
+GET tokens/rating?order=desc&limit=10&page=1&timestamp_start=2025-06-20T17:10:28.585Z&timestamp_end=2025-07-28T20:37:28.585Z
 {
     "resultSet": [
         {
             "tokenIdentifier": "8RsBCPSDUwWMnvLTDooh7ZcfZmnRb5tecsagsrdAFrrd",
-            "transitionCount": 15
-        },
-        {
-            "tokenIdentifier": "4xd9usiX6WCPE4h1AFPQBJ4Rje6TfZw8kiBzkSAzvmCL",
-            "transitionCount": 13
-        },
-        {
-            "tokenIdentifier": "5F4Q7PNmdxBP7ULbfUwKP6gNxdgZKygQaQ6m79LPQBd4",
-            "transitionCount": 5
+            "transitionCount": 15,
+            {
+                "localizations": {
+                    "en": {
+                        "pluralForm": "A1-keyword",
+                        "singularForm": "A1-keyword",
+                        "shouldCapitalize": true
+                    }
+                },
+                "tokenIdentifier": "FWuCZYmNo2qWfLcYsNUnu1LdqBWbzvWBUcGQHRFE2mVt",
+                "transitionCount": 1
+            },
+            {
+                "localizations": {
+                    "en": {
+                        "pluralForm": "A1-test-1",
+                        "singularForm": "A1-test-1",
+                        "shouldCapitalize": true
+                    }
+                },
+                "tokenIdentifier": "Eg49SNkMVgo84vGhj89bEK53X2mURGuVSERzteaT1brr",
+                "transitionCount": 1
+            },
+            {
+                "localizations": {
+                    "en": {
+                        "pluralForm": "aaa",
+                        "singularForm": "aaa",
+                        "shouldCapitalize": true
+                    }
+                },
+                "tokenIdentifier": "8Uv6WJEf7pyw17AtcJpGdURkU3wrmz86RkXxUdNNx575",
+                "transitionCount": 2
+            },
         },
         ...
     ],


### PR DESCRIPTION
# Issue
We need to add `timestamp_start` and `timestamp_end` to request for rating of tokens for more detailed trends.
Also we need to add localizations for this list

# Things done
- Updated query
- Added `timestamp_start` and `timestamp_end` to controller and DAO
- Updated tests
- Updated README.md