### PR TITLE
Update transactions types format on the frontend

### DIFF
--- a/packages/frontend/src/app/transaction/[hash]/TransactionData.js
+++ b/packages/frontend/src/app/transaction/[hash]/TransactionData.js
@@ -1,4 +1,3 @@
-import { StateTransitionEnum } from '../../../enums/state.transition.type'
 import { ValueCard } from '../../../components/cards'
 import { Identifier, InfoLine, CreditsBlock, VoteChoice, CodeBlock } from '../../../components/data'
 import { TransitionCard, PublicKeyCard, VoteIndexValues } from '../../../components/transactions'
@@ -63,7 +62,7 @@ function TransactionData ({ data, type, loading, rate }) {
 
   if (data === null) return <></>
 
-  if (type === StateTransitionEnum.MASTERNODE_VOTE) {
+  if (type === 'MASTERNODE_VOTE') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine'}
@@ -163,7 +162,7 @@ function TransactionData ({ data, type, loading, rate }) {
     </>)
   }
 
-  if (type === StateTransitionEnum.DATA_CONTRACT_CREATE) {
+  if (type === 'DATA_CONTRACT_CREATE') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine'}
@@ -237,7 +236,7 @@ function TransactionData ({ data, type, loading, rate }) {
     </>)
   }
 
-  if (type === StateTransitionEnum.BATCH) {
+  if (type === 'BATCH') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine TransactionPage__InfoLine--Transitions'}
@@ -258,7 +257,7 @@ function TransactionData ({ data, type, loading, rate }) {
     </>)
   }
 
-  if (type === StateTransitionEnum.IDENTITY_CREATE) {
+  if (type === 'IDENTITY_CREATE') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine'}
@@ -294,7 +293,7 @@ function TransactionData ({ data, type, loading, rate }) {
     </>)
   }
 
-  if (type === StateTransitionEnum.IDENTITY_TOP_UP) {
+  if (type === 'IDENTITY_TOP_UP') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine'}
@@ -328,7 +327,7 @@ function TransactionData ({ data, type, loading, rate }) {
     </>)
   }
 
-  if (type === StateTransitionEnum.DATA_CONTRACT_UPDATE) {
+  if (type === 'DATA_CONTRACT_UPDATE') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine'}
@@ -395,7 +394,7 @@ function TransactionData ({ data, type, loading, rate }) {
     </>)
   }
 
-  if (type === StateTransitionEnum.IDENTITY_UPDATE) {
+  if (type === 'IDENTITY_UPDATE') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine'}
@@ -459,7 +458,7 @@ function TransactionData ({ data, type, loading, rate }) {
     </>)
   }
 
-  if (type === StateTransitionEnum.IDENTITY_CREDIT_WITHDRAWAL) {
+  if (type === 'IDENTITY_CREDIT_WITHDRAWAL') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine'}
@@ -527,7 +526,7 @@ function TransactionData ({ data, type, loading, rate }) {
     </>)
   }
 
-  if (type === StateTransitionEnum.IDENTITY_CREDIT_TRANSFER) {
+  if (type === 'IDENTITY_CREDIT_TRANSFER') {
     return (<>
       <InfoLine
         className={'TransactionPage__InfoLine'}

--- a/packages/frontend/src/app/transaction/[hash]/TransactionPage.js
+++ b/packages/frontend/src/app/transaction/[hash]/TransactionPage.js
@@ -110,7 +110,7 @@ function Transaction ({ hash }) {
           <InfoLine
             className={'TransactionPage__InfoLine TransactionPage__InfoLine--Type'}
             title={'Type'}
-            value={<TypeBadge typeId={transaction.data?.type}/>}
+            value={<TypeBadge type={transaction.data?.type}/>}
             loading={transaction.loading}
             error={transaction.error}
           />

--- a/packages/frontend/src/components/transactions/TransactionsFilter.js
+++ b/packages/frontend/src/components/transactions/TransactionsFilter.js
@@ -5,47 +5,47 @@ import { Identifier } from '../data'
 
 const transactionOptions = [
   {
-    label: <TypeBadge typeId={StateTransitionEnum.DATA_CONTRACT_CREATE}/>,
+    label: <TypeBadge type={'DATA_CONTRACT_CREATE'}/>,
     title: TransactionTypesInfo.DATA_CONTRACT_CREATE.title,
     value: StateTransitionEnum.DATA_CONTRACT_CREATE
   },
   {
-    label: <TypeBadge typeId={StateTransitionEnum.BATCH}/>,
+    label: <TypeBadge type={'BATCH'}/>,
     title: TransactionTypesInfo.BATCH.title,
     value: StateTransitionEnum.BATCH
   },
   {
-    label: <TypeBadge typeId={StateTransitionEnum.IDENTITY_CREATE}/>,
+    label: <TypeBadge type={'IDENTITY_CREATE'}/>,
     title: TransactionTypesInfo.IDENTITY_CREATE.title,
     value: StateTransitionEnum.IDENTITY_CREATE
   },
   {
-    label: <TypeBadge typeId={StateTransitionEnum.IDENTITY_TOP_UP}/>,
+    label: <TypeBadge type={'IDENTITY_TOP_UP'}/>,
     title: TransactionTypesInfo.IDENTITY_TOP_UP.title,
     value: StateTransitionEnum.IDENTITY_TOP_UP
   },
   {
-    label: <TypeBadge typeId={StateTransitionEnum.DATA_CONTRACT_UPDATE}/>,
+    label: <TypeBadge type={'DATA_CONTRACT_UPDATE'}/>,
     title: TransactionTypesInfo.DATA_CONTRACT_UPDATE.title,
     value: StateTransitionEnum.DATA_CONTRACT_UPDATE
   },
   {
-    label: <TypeBadge typeId={StateTransitionEnum.IDENTITY_UPDATE}/>,
+    label: <TypeBadge type={'IDENTITY_UPDATE'}/>,
     title: TransactionTypesInfo.IDENTITY_UPDATE.title,
     value: StateTransitionEnum.IDENTITY_UPDATE
   },
   {
-    label: <TypeBadge typeId={StateTransitionEnum.IDENTITY_CREDIT_WITHDRAWAL}/>,
+    label: <TypeBadge type={'IDENTITY_CREDIT_WITHDRAWAL'}/>,
     title: TransactionTypesInfo.IDENTITY_CREDIT_WITHDRAWAL.title,
     value: StateTransitionEnum.IDENTITY_CREDIT_WITHDRAWAL
   },
   {
-    label: <TypeBadge typeId={StateTransitionEnum.IDENTITY_CREDIT_TRANSFER}/>,
+    label: <TypeBadge type={'IDENTITY_CREDIT_TRANSFER'}/>,
     title: TransactionTypesInfo.IDENTITY_CREDIT_TRANSFER.title,
     value: StateTransitionEnum.IDENTITY_CREDIT_TRANSFER
   },
   {
-    label: <TypeBadge typeId={StateTransitionEnum.MASTERNODE_VOTE}/>,
+    label: <TypeBadge type={'MASTERNODE_VOTE'}/>,
     title: TransactionTypesInfo.MASTERNODE_VOTE.title,
     value: StateTransitionEnum.MASTERNODE_VOTE
   }

--- a/packages/frontend/src/components/transactions/TransactionsFilter.js
+++ b/packages/frontend/src/components/transactions/TransactionsFilter.js
@@ -1,4 +1,4 @@
-import { StateTransitionEnum, TransactionTypesInfo } from '../../enums/state.transition.type'
+import { TransactionTypesInfo } from '../../enums/state.transition.type'
 import { TransactionStatusBadge, TypeBadge } from './index'
 import { Filters } from '../filters'
 import { Identifier } from '../data'
@@ -7,47 +7,47 @@ const transactionOptions = [
   {
     label: <TypeBadge type={'DATA_CONTRACT_CREATE'}/>,
     title: TransactionTypesInfo.DATA_CONTRACT_CREATE.title,
-    value: StateTransitionEnum.DATA_CONTRACT_CREATE
+    value: 'DATA_CONTRACT_CREATE'
   },
   {
     label: <TypeBadge type={'BATCH'}/>,
     title: TransactionTypesInfo.BATCH.title,
-    value: StateTransitionEnum.BATCH
+    value: 'BATCH'
   },
   {
     label: <TypeBadge type={'IDENTITY_CREATE'}/>,
     title: TransactionTypesInfo.IDENTITY_CREATE.title,
-    value: StateTransitionEnum.IDENTITY_CREATE
+    value: 'IDENTITY_CREATE'
   },
   {
     label: <TypeBadge type={'IDENTITY_TOP_UP'}/>,
     title: TransactionTypesInfo.IDENTITY_TOP_UP.title,
-    value: StateTransitionEnum.IDENTITY_TOP_UP
+    value: 'IDENTITY_TOP_UP'
   },
   {
     label: <TypeBadge type={'DATA_CONTRACT_UPDATE'}/>,
     title: TransactionTypesInfo.DATA_CONTRACT_UPDATE.title,
-    value: StateTransitionEnum.DATA_CONTRACT_UPDATE
+    value: 'DATA_CONTRACT_UPDATE'
   },
   {
     label: <TypeBadge type={'IDENTITY_UPDATE'}/>,
     title: TransactionTypesInfo.IDENTITY_UPDATE.title,
-    value: StateTransitionEnum.IDENTITY_UPDATE
+    value: 'IDENTITY_UPDATE'
   },
   {
     label: <TypeBadge type={'IDENTITY_CREDIT_WITHDRAWAL'}/>,
     title: TransactionTypesInfo.IDENTITY_CREDIT_WITHDRAWAL.title,
-    value: StateTransitionEnum.IDENTITY_CREDIT_WITHDRAWAL
+    value: 'IDENTITY_CREDIT_WITHDRAWAL'
   },
   {
     label: <TypeBadge type={'IDENTITY_CREDIT_TRANSFER'}/>,
     title: TransactionTypesInfo.IDENTITY_CREDIT_TRANSFER.title,
-    value: StateTransitionEnum.IDENTITY_CREDIT_TRANSFER
+    value: 'IDENTITY_CREDIT_TRANSFER'
   },
   {
     label: <TypeBadge type={'MASTERNODE_VOTE'}/>,
     title: TransactionTypesInfo.MASTERNODE_VOTE.title,
-    value: StateTransitionEnum.MASTERNODE_VOTE
+    value: 'MASTERNODE_VOTE'
   }
 ]
 

--- a/packages/frontend/src/components/transactions/TransactionsListItem.js
+++ b/packages/frontend/src/components/transactions/TransactionsListItem.js
@@ -88,7 +88,7 @@ function TransactionsListItem ({ transaction, rate }) {
           {transaction?.batchType
             ? <BatchTypeBadge className={'TransactionsListItem__TypeBadge'} batchType={transaction.batchType?.replace(/[\\""]/g, '')}/>
             : transaction?.type !== undefined
-              ? <TypeBadge className={'TransactionsListItem__TypeBadge'} typeId={transaction.type}/>
+              ? <TypeBadge className={'TransactionsListItem__TypeBadge'} type={transaction.type}/>
               : <NotActive/>
           }
         </GridItem>

--- a/packages/frontend/src/components/transactions/TypeBadge.js
+++ b/packages/frontend/src/components/transactions/TypeBadge.js
@@ -2,7 +2,7 @@ import { Badge } from '@chakra-ui/react'
 import { TransactionTypesInfo } from '../../enums/state.transition.type'
 import { Tooltip } from '../ui/Tooltips'
 
-function TypeBadge ({ typeId, type, ...props }) {
+function TypeBadge ({ type, ...props }) {
   return (
     <Tooltip
       title={TransactionTypesInfo?.[type]?.title}

--- a/packages/frontend/src/components/transactions/TypeBadge.js
+++ b/packages/frontend/src/components/transactions/TypeBadge.js
@@ -1,22 +1,19 @@
 import { Badge } from '@chakra-ui/react'
-import { getTransitionTypeKeyById } from '../../util/index'
 import { TransactionTypesInfo } from '../../enums/state.transition.type'
 import { Tooltip } from '../ui/Tooltips'
 
 function TypeBadge ({ typeId, type, ...props }) {
-  const TransitionTypeKey = typeof typeId === 'number' ? getTransitionTypeKeyById(typeId) : type
-
   return (
     <Tooltip
-      title={TransactionTypesInfo?.[TransitionTypeKey]?.title}
-      content={TransactionTypesInfo?.[TransitionTypeKey]?.description}
+      title={TransactionTypesInfo?.[type]?.title}
+      content={TransactionTypesInfo?.[type]?.description}
       placement={'top'}
     >
       <Badge
-        colorScheme={TransactionTypesInfo?.[TransitionTypeKey]?.colorScheme}
+        colorScheme={TransactionTypesInfo?.[type]?.colorScheme}
         {...props}
       >
-        {TransactionTypesInfo?.[TransitionTypeKey]?.title}
+        {TransactionTypesInfo?.[type]?.title}
       </Badge>
     </Tooltip>
   )

--- a/packages/frontend/src/components/transfers/TypeBadge.js
+++ b/packages/frontend/src/components/transfers/TypeBadge.js
@@ -1,10 +1,8 @@
 import { Badge } from '@chakra-ui/react'
 import { TransactionTypesInfo } from '../../enums/state.transition.type'
 import { Tooltip } from '../ui/Tooltips'
-import { getTransitionTypeKeyById } from '../../util'
 
 function TypeBadge ({ type, ...props }) {
-  const transitionType = getTransitionTypeKeyById(type)
   const TransferTypesTitle = {
     IDENTITY_TOP_UP: 'Credit Top Up',
     IDENTITY_CREDIT_WITHDRAWAL: 'Credit Withdrawal',
@@ -14,15 +12,15 @@ function TypeBadge ({ type, ...props }) {
 
   return (
     <Tooltip
-      title={TransferTypesTitle[transitionType]}
-      content={TransactionTypesInfo?.[transitionType]?.description}
+      title={TransferTypesTitle[type]}
+      content={TransactionTypesInfo?.[type]?.description}
       placement={'top'}
     >
       <Badge
-        colorScheme={TransactionTypesInfo?.[transitionType]?.colorScheme}
+        colorScheme={TransactionTypesInfo?.[type]?.colorScheme}
         {...props}
       >
-        {TransferTypesTitle[transitionType]}
+        {TransferTypesTitle[type]}
       </Badge>
     </Tooltip>
   )

--- a/packages/frontend/src/enums/state.transition.type.js
+++ b/packages/frontend/src/enums/state.transition.type.js
@@ -1,15 +1,3 @@
-export const StateTransitionEnum = {
-  DATA_CONTRACT_CREATE: 0,
-  BATCH: 1,
-  IDENTITY_CREATE: 2,
-  IDENTITY_TOP_UP: 3,
-  DATA_CONTRACT_UPDATE: 4,
-  IDENTITY_UPDATE: 5,
-  IDENTITY_CREDIT_WITHDRAWAL: 6,
-  IDENTITY_CREDIT_TRANSFER: 7,
-  MASTERNODE_VOTE: 8
-}
-
 export const TransactionTypesInfo = {
   DATA_CONTRACT_CREATE: {
     title: 'Data Contract Create',

--- a/packages/frontend/src/util/index.js
+++ b/packages/frontend/src/util/index.js
@@ -1,15 +1,6 @@
 import copyToClipboard from './copyToClipboard'
-import { StateTransitionEnum } from '../enums/state.transition.type'
 import currencyRound from './currencyRound'
 import { getDaysBetweenDates, getDynamicRange, getTimeDelta } from './datetime'
-
-function getTransitionTypeKeyById (id) {
-  const [stateTransitionType] = Object.entries(StateTransitionEnum)
-    .filter(([key]) => StateTransitionEnum[key] === id)
-    .map(([key]) => key)
-
-  return stateTransitionType
-}
 
 function fetchHandlerSuccess (setter, data) {
   setter(state => ({
@@ -101,7 +92,6 @@ export {
   currencyRound,
   copyToClipboard,
   getTimeDelta,
-  getTransitionTypeKeyById,
   creditsToDash,
   roundUsd,
   removeTrailingZeros,


### PR DESCRIPTION
# Issue
The transaction type format in the API has changed from a number to a string. We need to update it on the frontend.

# Things done
- Transaction type numeric format replaced with string
- Removed unused functions for type format conversion