### PR TITLE
Implement a tokens list on the data contract page

### DIFF
--- a/packages/frontend/src/app/dataContract/[identifier]/DataContract.js
+++ b/packages/frontend/src/app/dataContract/[identifier]/DataContract.js
@@ -13,6 +13,7 @@ import { DataContractDigestCard, DataContractTotalCard, GroupsList } from '../..
 import { Container, Tabs, TabList, TabPanels, Tab, TabPanel } from '@chakra-ui/react'
 import { useBreadcrumbs } from '../../../contexts/BreadcrumbsContext'
 import { TransactionsList } from '../../../components/transactions'
+import TokensList from '../../../components/tokens/TokensList'
 import './DataContract.scss'
 
 const pagintationConfig = {
@@ -26,6 +27,7 @@ const pagintationConfig = {
 const tabs = [
   'transactions',
   'documents',
+  'tokens',
   'schema',
   'groups'
 ]
@@ -127,6 +129,8 @@ function DataContract ({ identifier }) {
       .catch(err => fetchHandlerError(setTransactions, err))
   }, [identifier, transactions.props.currentPage])
 
+  console.log('dataContract', dataContract?.data?.tokens)
+
   return (
     <PageDataContainer
       className={'DataContract'}
@@ -140,15 +144,21 @@ function DataContract ({ identifier }) {
       <InfoContainer styles={['tabs']} id={'tabs'}>
         <Tabs onChange={(index) => setActiveTab(index)} index={activeTab}>
           <TabList>
-            <Tab>Transactions {transactions.data?.pagination?.total !== undefined
+            <Tab>Transactions {transactions.data?.pagination?.total != null
               ? <span className={`Tabs__TabItemsCount ${transactions.data?.pagination?.total === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
                   {transactions.data?.pagination?.total}
                 </span>
               : ''}
             </Tab>
-            <Tab>Documents {dataContract.data?.documentsCount !== undefined
+            <Tab>Documents {dataContract.data?.documentsCount != null
               ? <span className={`Tabs__TabItemsCount ${dataContract.data?.documentsCount === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
                   {dataContract.data?.documentsCount}
+                </span>
+              : ''}
+            </Tab>
+            <Tab>Tokens {dataContract.data?.tokens?.length != null
+              ? <span className={`Tabs__TabItemsCount ${dataContract.data?.tokens?.length === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
+                  {dataContract.data?.tokens?.length}
                 </span>
               : ''}
             </Tab>
@@ -176,14 +186,20 @@ function DataContract ({ identifier }) {
             <TabPanel position={'relative'}>
               {!documents.error
                 ? <DocumentsList
-                    documents={documents.data?.resultSet}
-                    loading={documents.loading}
-                    pagination={{
-                      onPageChange: pagination => paginationHandler(setDocuments, pagination.selected),
-                      pageCount: Math.ceil(documents.data?.pagination?.total / pageSize) || 1,
-                      forcePage: documents.props.currentPage
-                    }}
-                  />
+                  documents={documents.data?.resultSet}
+                  loading={documents.loading}
+                  pagination={{
+                    onPageChange: pagination => paginationHandler(setDocuments, pagination.selected),
+                    pageCount: Math.ceil(documents.data?.pagination?.total / pageSize) || 1,
+                    forcePage: documents.props.currentPage
+                  }}
+                />
+                : <Container h={20}><ErrorMessageBlock/></Container>
+              }
+            </TabPanel>
+            <TabPanel position={'relative'}>
+              {!documents.error
+                ? <TokensList tokens={dataContract.data?.tokens} loading={dataContract.loading}/>
                 : <Container h={20}><ErrorMessageBlock/></Container>
               }
             </TabPanel>
@@ -200,12 +216,12 @@ function DataContract ({ identifier }) {
             <TabPanel position={'relative'}>
               {!dataContract.error
                 ? <LoadingBlock h={'250px'} loading={dataContract.loading}>
-                    <GroupsList
-                      groups={dataContract.data?.groups || {}}
-                      expandedGroups={expandedGroups}
-                      onExpandedGroupsChange={handleExpandedGroupsChange}
-                    />
-                  </LoadingBlock>
+                  <GroupsList
+                    groups={dataContract.data?.groups || {}}
+                    expandedGroups={expandedGroups}
+                    onExpandedGroupsChange={handleExpandedGroupsChange}
+                  />
+                </LoadingBlock>
                 : <Container h={20}><ErrorMessageBlock/></Container>
               }
             </TabPanel>

--- a/packages/frontend/src/app/dataContract/[identifier]/DataContract.js
+++ b/packages/frontend/src/app/dataContract/[identifier]/DataContract.js
@@ -129,8 +129,6 @@ function DataContract ({ identifier }) {
       .catch(err => fetchHandlerError(setTransactions, err))
   }, [identifier, transactions.props.currentPage])
 
-  console.log('dataContract', dataContract?.data?.tokens)
-
   return (
     <PageDataContainer
       className={'DataContract'}

--- a/packages/frontend/src/components/tokens/TokensListItem.js
+++ b/packages/frontend/src/components/tokens/TokensListItem.js
@@ -4,7 +4,7 @@ import { Grid, GridItem } from '@chakra-ui/react'
 import { Supply } from './index'
 import { LinkContainer, ValueContainer } from '../ui/containers'
 import { useRouter } from 'next/navigation'
-import { currencyRound } from '../../util'
+import { currencyRound, findActiveAlias } from '../../util'
 import './TokensListItem.scss'
 
 function TokensListItem ({ token, variant = 'default' }) {
@@ -19,6 +19,8 @@ function TokensListItem ({ token, variant = 'default' }) {
   } = token
   const router = useRouter()
 
+  const ownerId = typeof owner === 'object' ? owner?.identifier : owner
+  const ownerName = typeof owner === 'object' ? findActiveAlias(owner?.aliases) : null
   const name = localizations?.en?.singularForm ||
     Object.values(localizations || {})[0]?.singularForm ||
     ''
@@ -71,17 +73,20 @@ function TokensListItem ({ token, variant = 'default' }) {
             onClick={e => {
               e.stopPropagation()
               e.preventDefault()
-              router.push(`/identity/${owner}`)
+              router.push(`/identity/${ownerId}`)
             }}
           >
-            <Identifier
-              className={'TokensListItem__OwnerIdentifier'}
-              ellipsis={true}
-              styles={['highlight-both']}
-              avatar={true}
-            >
-              {owner}
-            </Identifier>
+            {ownerName
+              ? <Alias avatarSource={ownerId} alias={ownerName?.alias}/>
+              : <Identifier
+                  className={'TokensListItem__OwnerIdentifier'}
+                  ellipsis={true}
+                  avatar={true}
+                  styles={['highlight-both']}
+                >
+                  {ownerId}
+                </Identifier>
+            }
           </LinkContainer>
         </GridItem>
 

--- a/packages/frontend/src/components/tokens/activity/ActivityList.js
+++ b/packages/frontend/src/components/tokens/activity/ActivityList.js
@@ -33,7 +33,7 @@ export default function ActivityList ({
             Hash
           </GridItem>
           <GridItem className={'ActivityList__ColumnTitle ActivityList__ColumnTitle--Creator'}>
-            Tx Creator
+            Owner
           </GridItem>
           <GridItem className={'ActivityList__ColumnTitle ActivityList__ColumnTitle--Recipient'}>
             Recipient

--- a/packages/frontend/src/components/tokens/activity/_variables.scss
+++ b/packages/frontend/src/components/tokens/activity/_variables.scss
@@ -4,12 +4,12 @@
   display: grid;
   gap: 1rem;
 
-  grid-template-columns: 
-    1fr // time
-    2fr // hash
-    2fr // creator
-    2fr // recipient
-    1fr // amount
+  grid-template-columns:
+    8rem // time
+    minmax(0, 2fr) // hash
+    minmax(0, 2fr) // creator
+    minmax(0, 2fr) // recipient
+    8rem // amount
     9rem; // type
 
   @container (max-width: 104rem) {


### PR DESCRIPTION
# Issue
We need to view the list of tokens of the data contract

# Things done
- Implemented tokens list on the data contract page
- Implemented object format of the owner field in the tokens list
- Updated conditions of items count in tabs on the data contract page