### PR TITLE
Index token interactions for transfers

### DIFF
--- a/packages/api/test/utils/fixtures.js
+++ b/packages/api/test/utils/fixtures.js
@@ -513,6 +513,10 @@ const fixtures = {
 
     await this.tokenHolder(knex, { holder: owner, token_id: token.id })
 
+    if (recipient) {
+      await this.tokenHolder(knex, { holder: recipient, token_id: token.id })
+    }
+
     return { ...row, id: result.id, transition }
   },
   cleanup: async (knex) => {


### PR DESCRIPTION
# Issue
At this moment if we try to transfer tokens to identity, we dosen't see token in token list for identity

# Things done
- Updated token transition handler in indexer, now we write recipients and issued_identity as holders also
- Optimization for identity transfers and transactions
- update fixtures