### PR TITLE
Fix transaction_type enum in routes schema

### DIFF
--- a/packages/api/src/schemas.js
+++ b/packages/api/src/schemas.js
@@ -67,6 +67,7 @@ const schemaTypes = [
                 'DATA_CONTRACT_UPDATE',
                 'IDENTITY_UPDATE',
                 'IDENTITY_CREDIT_WITHDRAWAL',
+                'IDENTITY_CREDIT_TRANSFER',
                 'MASTERNODE_VOTE'
               ]
             },


### PR DESCRIPTION
# Issue
At this moment we cannot filter transactions by IDENTITY_CREDIT_TRANSFER

# Things done
- Updated enum