### PR TITLE
Tokens Holders

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -86,6 +86,7 @@ Reference:
 * [Token Transitions](#token-transitions)
 * [Tokens Rating](#tokens-rating)
 * [Tokens By Identity](#tokens-by-identity)
+* [Token Holders](#token-holders)
 * [Broadcast Transaction](#broadcast-transaction)
 * [Quorum Info](#quorum-info)
 
@@ -2774,7 +2775,7 @@ GET /token/4xd9usiX6WCPE4h1AFPQBJ4Rje6TfZw8kiBzkSAzvmCL/transitions?limit=10&ord
     "pagination": {
         "page": 1,
         "limit": 10,
-        "total": "desc"
+        "total": 100
     }
 }
 ```
@@ -2860,7 +2861,7 @@ Return list of tokens which created by identity
 * `limit` cannot be more then 100
 * `page` cannot be less then 1
 ```
-GET identity/5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5B1/tokens?limit=10&page=1&order=asc
+GET /identity/5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5B1/tokens?limit=10&page=1&order=asc
 {
     "resultSet": [
         {
@@ -2922,6 +2923,61 @@ GET identity/5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5B1/tokens?limit=10&page=1
         "page": 1,
         "limit": 10,
         "total": 3
+    }
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+503: Service Temporarily Unavailable
+```
+___
+### Token Holders
+Return list of token holders
+
+* Valid `order` values are `asc` or `desc`
+* `limit` cannot be more then 100
+* `page` cannot be less then 1
+```
+GET /token/Bu2749WKcP5HFNm8v3k5kshRKDSVyfsJMqoWnXmK4q7h/holders?order=desc&limit=10&page=1
+{
+    "resultSet": [
+        {
+            "balance": "0",
+            "holder": {
+                "identifier": "HJDxtN6FJF3U3T9TMLWCqudfJ5VRkaUrxTsRp36djXAG",
+                "aliases": [
+                    {
+                        "alias": "wasm-sdk-test-identity-2.dash",
+                        "status": "ok",
+                        "timestamp": "2025-08-26T13:20:11.698Z",
+                        "documentId": "Girj8ujNxqzhHnnvEyKcKfvJxQh8CTG8N4GCY4oVXMS2",
+                        "contested": false
+                    }
+                ]
+            }
+        },
+        {
+            "balance": "135",
+            "holder": {
+                "identifier": "7XcruVSsGQVSgTcmPewaE4tXLutnW1F6PXxwMbo8GYQC",
+                "aliases": [
+                    {
+                        "alias": "wasm-sdk-test-identity.dash",
+                        "status": "ok",
+                        "timestamp": "2025-08-21T19:42:41.349Z",
+                        "documentId": "9odEjcSxU3MqBNXxX2GvVjqZtYk1HSZmK7NHVmVqp35T",
+                        "contested": false
+                    }
+                ]
+            }
+        }
+    ],
+    "pagination": {
+        "page": 1,
+        "limit": 10,
+        "total": 2
     }
 }
 ```

--- a/packages/api/src/controllers/TokensController.js
+++ b/packages/api/src/controllers/TokensController.js
@@ -94,6 +94,24 @@ class TokensController {
 
     response.send(tokens)
   }
+
+  getTokenHolders = async (request, response) => {
+    const { identifier } = request.params
+    const {
+      page = 1,
+      limit = 10,
+      order = 'asc'
+    } = request.query
+
+    const transitions = await this.tokensDAO.getTokenHolders(
+      identifier,
+      Number(page ?? 1),
+      Number(limit ?? 10),
+      order
+    )
+
+    response.send(transitions)
+  }
 }
 
 module.exports = TokensController

--- a/packages/api/src/dao/TokensDAO.js
+++ b/packages/api/src/dao/TokensDAO.js
@@ -114,17 +114,25 @@ module.exports = class TokensDAO {
   getTokenTransitions = async (identifier, page, limit, order) => {
     const fromRank = (page - 1) * limit
 
-    const rows = await this.knex('token_transitions')
+    const subquery = this.knex('token_transitions')
       .select(
-        'action', 'amount', 'state_transition_hash',
+        'action', 'amount', 'state_transition_hash', 'token_transitions.id',
         'recipient', 'timestamp', 'public_note', 'token_transitions.owner'
       )
+      .select(this.knex.raw('count(*) OVER () as total_count'))
       .where('token_identifier', identifier)
-      .offset(fromRank)
-      .limit(limit)
-      .orderBy('token_transitions.id', order)
       .leftJoin('state_transitions', 'state_transitions.hash', 'state_transition_hash')
       .leftJoin('blocks', 'block_hash', 'blocks.hash')
+      .as('subquery')
+
+    const rows = await this.knex(subquery)
+      .select(
+        'action', 'amount', 'state_transition_hash', 'total_count',
+        'recipient', 'timestamp', 'public_note', 'owner'
+      )
+      .offset(fromRank)
+      .limit(limit)
+      .orderBy('id', order)
 
     const resultSet = await Promise.all(rows.map(async (row) => {
       const [aliasDocument] = await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.owner.trim()]], 1)
@@ -145,7 +153,9 @@ module.exports = class TokensDAO {
       })
     }))
 
-    return new PaginatedResultSet(resultSet, page, limit, order)
+    const [row] = rows
+
+    return new PaginatedResultSet(resultSet, page, limit, Number(row?.total_count ?? 0))
   }
 
   getTokensTrends = async (startDate, endDate, page, limit, order) => {
@@ -256,7 +266,7 @@ module.exports = class TokensDAO {
 
     const tokensWithBalance = tokens.map(token => ({
       ...token,
-      balance: tokenBalances?.find(t => t.identifier === token.identifier)?.balance ?? null
+      balance: tokenBalances?.find(t => t.tokenId.base58() === token.identifier)?.balance ?? null
     }))
 
     const [row] = rows
@@ -294,6 +304,60 @@ module.exports = class TokensDAO {
     const [row] = rows
 
     const resultSet = await fetchTokenInfoByRows(rows, this.sdk)
+
+    return new PaginatedResultSet(resultSet, page, limit, Number(row?.total_count ?? 0))
+  }
+
+  getTokenHolders = async (identifier, page, limit, order) => {
+    const fromRank = (page - 1) * limit
+
+    const subquery = this.knex('token_holders')
+      .select('owner', 'tokens.identifier as token_identifier', 'token_holders.id')
+      .select(this.knex.raw('count(*) OVER() as total_count'))
+      .where('tokens.identifier', identifier)
+      .leftJoin('tokens', 'token_holders.token_id', 'tokens.id')
+      .as('subquery')
+
+    const rows = await this.knex(subquery)
+      .select('owner', 'token_identifier', 'total_count')
+      .offset(fromRank)
+      .limit(limit)
+      .orderBy('id', order)
+
+    const [row] = rows
+
+    if (!row) {
+      return new PaginatedResultSet([], page, limit, 0)
+    }
+
+    const owners = rows.map((row) => row.owner)
+
+    const balances = await this.sdk.tokens.getIdentitiesTokenBalances(owners, row.token_identifier)
+
+    const ownersWithBalance = balances.reduce((acc, balance) => {
+      return {
+        ...acc,
+        [balance.identityId.base58()]: balance.balance.toString()
+      }
+    }, {})
+
+    const resultSet = await Promise.all(rows.map(async (row) => {
+      const [aliasDocument] = await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.owner.trim()]], 1)
+
+      const aliases = []
+
+      if (aliasDocument) {
+        aliases.push(getAliasFromDocument(aliasDocument))
+      }
+
+      return {
+        balance: ownersWithBalance[row.owner.trim()] ?? null,
+        owner: {
+          identifier: row.owner?.trim(),
+          aliases: aliases ?? []
+        }
+      }
+    }))
 
     return new PaginatedResultSet(resultSet, page, limit, Number(row?.total_count ?? 0))
   }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -564,6 +564,20 @@ module.exports = ({
       }
     },
     {
+      path: '/token/:identifier/holders',
+      method: 'GET',
+      handler: tokensController.getTokenHolders,
+      schema: {
+        params: {
+          type: 'object',
+          properties: {
+            identifier: { $ref: 'identifier#' }
+          }
+        },
+        querystring: { $ref: 'paginationOptions#' }
+      }
+    },
+    {
       path: '/tokens/:name/info',
       method: 'GET',
       handler: tokensController.getTokensByName,

--- a/packages/api/test/utils/fixtures.js
+++ b/packages/api/test/utils/fixtures.js
@@ -389,9 +389,16 @@ const fixtures = {
       holder
     }
 
-    const [result] = await knex('token_holders').insert(row).returning('id')
+    const [alreadyExistHolder] = await knex('token_holders')
+      .where('holder', holder)
+      .andWhere('token_id', token_id)
+      .returning('id')
 
-    return { ...row, id: result.id }
+    if (!alreadyExistHolder) {
+      const [result] = await knex('token_holders').insert(row).returning('id')
+
+      return { ...row, id: result.id }
+    }
   },
   token: async function (knex, {
     position,

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -53,6 +53,7 @@ Reference:
 * [Token Transitions](#token-transitions)
 * [Tokens Rating](#tokens-rating)
 * [Tokens By Identity](#tokens-by-identity)
+* [Token Holders](#token-holders)
 * [Broadcast Transaction](#broadcast-transaction)
 * [Quorum Info](#quorum-info)
 
@@ -2741,7 +2742,7 @@ GET /token/4xd9usiX6WCPE4h1AFPQBJ4Rje6TfZw8kiBzkSAzvmCL/transitions?limit=10&ord
     "pagination": {
         "page": 1,
         "limit": 10,
-        "total": "desc"
+        "total": 100
     }
 }
 ```
@@ -2827,7 +2828,7 @@ Return list of tokens which created by identity
 * `limit` cannot be more then 100
 * `page` cannot be less then 1
 ```
-GET identity/5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5B1/tokens?limit=10&page=1&order=asc
+GET /identity/5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5B1/tokens?limit=10&page=1&order=asc
 {
     "resultSet": [
         {
@@ -2889,6 +2890,61 @@ GET identity/5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5B1/tokens?limit=10&page=1
         "page": 1,
         "limit": 10,
         "total": 3
+    }
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+503: Service Temporarily Unavailable
+```
+___
+### Token Holders
+Return list of token holders
+
+* Valid `order` values are `asc` or `desc`
+* `limit` cannot be more then 100
+* `page` cannot be less then 1
+```
+GET /token/Bu2749WKcP5HFNm8v3k5kshRKDSVyfsJMqoWnXmK4q7h/holders?order=desc&limit=10&page=1
+{
+    "resultSet": [
+        {
+            "balance": "0",
+            "holder": {
+                "identifier": "HJDxtN6FJF3U3T9TMLWCqudfJ5VRkaUrxTsRp36djXAG",
+                "aliases": [
+                    {
+                        "alias": "wasm-sdk-test-identity-2.dash",
+                        "status": "ok",
+                        "timestamp": "2025-08-26T13:20:11.698Z",
+                        "documentId": "Girj8ujNxqzhHnnvEyKcKfvJxQh8CTG8N4GCY4oVXMS2",
+                        "contested": false
+                    }
+                ]
+            }
+        },
+        {
+            "balance": "135",
+            "holder": {
+                "identifier": "7XcruVSsGQVSgTcmPewaE4tXLutnW1F6PXxwMbo8GYQC",
+                "aliases": [
+                    {
+                        "alias": "wasm-sdk-test-identity.dash",
+                        "status": "ok",
+                        "timestamp": "2025-08-21T19:42:41.349Z",
+                        "documentId": "9odEjcSxU3MqBNXxX2GvVjqZtYk1HSZmK7NHVmVqp35T",
+                        "contested": false
+                    }
+                ]
+            }
+        }
+    ],
+    "pagination": {
+        "page": 1,
+        "limit": 10,
+        "total": 2
     }
 }
 ```

--- a/packages/indexer/src/entities/validator.rs
+++ b/packages/indexer/src/entities/validator.rs
@@ -3,7 +3,7 @@ use tokio_postgres::Row;
 #[derive(Clone)]
 pub struct Validator {
     pub pro_tx_hash: String,
-    pub id: Option<i32>
+    pub id: Option<i32>,
 }
 
 impl From<Row> for Validator {
@@ -11,6 +11,9 @@ impl From<Row> for Validator {
         let pro_tx_hash: String = row.get(0);
         let id: i32 = row.get(1);
 
-        return Validator { pro_tx_hash, id: Some(id) };
+        return Validator {
+            pro_tx_hash,
+            id: Some(id),
+        };
     }
 }

--- a/packages/indexer/src/processor/psql/dao/blocks.rs
+++ b/packages/indexer/src/processor/psql/dao/blocks.rs
@@ -10,12 +10,18 @@ impl PostgresDAO {
         block_header: BlockHeader,
         sql_transaction: &Transaction<'_>,
     ) -> String {
-        
-        let validator = self.get_validator_by_pro_tx_hash(block_header.proposer_pro_tx_hash.clone(), sql_transaction)
+        let validator = self
+            .get_validator_by_pro_tx_hash(
+                block_header.proposer_pro_tx_hash.clone(),
+                sql_transaction,
+            )
             .await
-            .expect(&format!("Cannot find validator {}", block_header.proposer_pro_tx_hash))
+            .expect(&format!(
+                "Cannot find validator {}",
+                block_header.proposer_pro_tx_hash
+            ))
             .unwrap();
-        
+
         let stmt = sql_transaction
             .prepare_cached(
                 "INSERT INTO blocks(hash, height, \

--- a/packages/indexer/src/processor/psql/handlers/handle_tokens.rs
+++ b/packages/indexer/src/processor/psql/handlers/handle_tokens.rs
@@ -39,8 +39,7 @@ impl PSQLProcessor {
 
         match transition.clone() {
             TokenTransition::Mint(mint) => {
-                self
-                    .dao
+                self.dao
                     .token_transition(
                         transition.clone(),
                         Some(mint.amount()),
@@ -55,12 +54,15 @@ impl PSQLProcessor {
 
                 if mint.issued_to_identity_id().is_some() {
                     self.dao
-                        .token_holder(mint.issued_to_identity_id().unwrap(), transition.token_id(), &sql_transaction)
+                        .token_holder(
+                            mint.issued_to_identity_id().unwrap(),
+                            transition.token_id(),
+                            &sql_transaction,
+                        )
                         .await
                         .unwrap();
                 }
-                
-            },
+            }
             TokenTransition::Burn(burn) => self
                 .dao
                 .token_transition(
@@ -75,8 +77,7 @@ impl PSQLProcessor {
                 .await
                 .unwrap(),
             TokenTransition::Transfer(transfer) => {
-                self
-                    .dao
+                self.dao
                     .token_transition(
                         transition.clone(),
                         Some(transfer.amount()),
@@ -90,13 +91,16 @@ impl PSQLProcessor {
                     .unwrap();
 
                 self.dao
-                    .token_holder(transfer.recipient_id(), transition.token_id(), &sql_transaction)
+                    .token_holder(
+                        transfer.recipient_id(),
+                        transition.token_id(),
+                        &sql_transaction,
+                    )
                     .await
                     .unwrap();
-            },
+            }
             TokenTransition::Freeze(freeze) => {
-                self
-                    .dao
+                self.dao
                     .token_transition(
                         transition.clone(),
                         None,
@@ -110,13 +114,16 @@ impl PSQLProcessor {
                     .unwrap();
 
                 self.dao
-                    .token_holder(freeze.frozen_identity_id(), transition.token_id(), &sql_transaction)
+                    .token_holder(
+                        freeze.frozen_identity_id(),
+                        transition.token_id(),
+                        &sql_transaction,
+                    )
                     .await
                     .unwrap();
-            },
+            }
             TokenTransition::Unfreeze(unfreeze) => {
-                self
-                    .dao
+                self.dao
                     .token_transition(
                         transition.clone(),
                         None,
@@ -130,10 +137,14 @@ impl PSQLProcessor {
                     .unwrap();
 
                 self.dao
-                    .token_holder(unfreeze.frozen_identity_id(), transition.token_id(), &sql_transaction)
+                    .token_holder(
+                        unfreeze.frozen_identity_id(),
+                        transition.token_id(),
+                        &sql_transaction,
+                    )
                     .await
                     .unwrap();
-            },
+            }
             TokenTransition::DestroyFrozenFunds(destroy_frozen_funds) => self
                 .dao
                 .token_transition(


### PR DESCRIPTION
# Issue
We need to update alghoritm for indexing token holders and add token holders endpoint

# Things done
**The new algorithm still cannot index token holders who received coins through perpetual distribution => EvonodesByParticipation.**

- Updated `handle_token_configuration` in configuration for handling token distribution rules also
- Implemented Token Holders
- Fix for pagination info response for token transitions
- Updated README.md
- Improved fixtures, now they works as indexer (for tokens)
- Tests
- Lint rust code