### PR TITLE
Fix tokens count on the Identity page

### DIFF
--- a/packages/frontend/src/app/identity/[identifier]/Identity.js
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.js
@@ -160,11 +160,15 @@ function Identity ({ identifier }) {
               : ''}
             </Tab>
             <Tab>Credit Transfers {identity.data?.totalTransfers !== undefined
-              ? <span className={`Tabs__TabItemsCount ${identity.data?.totalTransfers === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>{identity.data?.totalTransfers}</span>
+              ? <span className={`Tabs__TabItemsCount ${identity.data?.totalTransfers === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
+                  {identity.data?.totalTransfers}
+                </span>
               : ''}
             </Tab>
             <Tab>Tokens {tokens.data?.pagination?.total !== undefined
-              ? <span className={`Tabs__TabItemsCount ${tokens.data?.pagination?.total === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>{tokens.data?.pagination?.total}</span>
+              ? <span className={`Tabs__TabItemsCount ${tokens.data?.pagination?.total === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
+                  {Math.max(tokens.data?.pagination?.total, 0)}
+                </span>
               : ''}
             </Tab>
           </TabList>


### PR DESCRIPTION
# Issue
The number of tokens on the identity page is shown as -1 instead of 0

<img width="384" height="169" alt="image" src="https://github.com/user-attachments/assets/c13b00b7-46a4-4451-974f-d02a7f5bde3f" />


# Things done
Fixed