### PR TITLE
Identities history points calculation update

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1291,24 +1291,18 @@ GET /identities/history?timestamp_start=2025-09-09T00:00:00.000Z&timestamp_end=2
         "timestamp": "2025-09-09T00:00:00.000Z",
         "data": {
             "registeredIdentities": 0,
-            "blockHeight": null,
-            "blockHash": null
         }
     },
     {
         "timestamp": "2025-09-09T08:00:00.000Z",
         "data": {
             "registeredIdentities": 26,
-            "blockHeight": 2,
-            "blockHash": "2BD91299D19649C8DA1EC963FF6304606C052F69CEEB98F72DE5E2E09C8B88E6"
         }
     },
     {
         "timestamp": "2025-09-09T16:00:00.000Z",
         "data": {
-            "registeredIdentities": 4,
-            "blockHeight": 28,
-            "blockHash": "E26D7A8B3497EB104924BB4D152A0BA62ECB3C46BF96F9A8440B6BF151069E5B"
+            "registeredIdentities": 30,
         }
     }
 ]

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -1986,6 +1986,12 @@ describe('Identities routes', () => {
       const block = await fixtures.block(knex, { timestamp: new Date(0) })
       const owner = await fixtures.identity(knex, { block_hash: block.hash, block_height: block.height })
 
+      identities.push({
+        block,
+        transaction: null,
+        identity: owner
+      })
+
       for (let i = 0; i < 30; i++) {
         const block = await fixtures.block(knex, {
           timestamp: new Date(new Date().getTime() - (27000000 - 900000 * i)),
@@ -2030,16 +2036,13 @@ describe('Identities routes', () => {
         const prevPeriod = firstTimestamp - 300000 * (i - 1)
 
         const registeredIdentities = identities.filter(identity =>
-          new Date(identity.block.timestamp).getTime() <= prevPeriod &&
-          new Date(identity.block.timestamp).getTime() >= nextPeriod
+          new Date(identity.block.timestamp).getTime() <= prevPeriod
         ).sort((a, b) => a.block.timestamp - b.block.timestamp)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            registeredIdentities: registeredIdentities.length,
-            blockHeight: registeredIdentities[0]?.block?.height ?? null,
-            blockHash: registeredIdentities[0]?.block?.hash ?? null
+            registeredIdentities: registeredIdentities.length
           }
         })
       }
@@ -2064,16 +2067,13 @@ describe('Identities routes', () => {
         const prevPeriod = firstTimestamp - 1440000 * (i - 1)
 
         const registeredIdentities = identities.filter(identity =>
-          new Date(identity.block.timestamp).getTime() <= prevPeriod &&
-          new Date(identity.block.timestamp).getTime() >= nextPeriod
+          new Date(identity.block.timestamp).getTime() <= prevPeriod
         ).sort((a, b) => a.block.timestamp - b.block.timestamp)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            registeredIdentities: registeredIdentities.length,
-            blockHeight: registeredIdentities[0]?.block?.height ?? null,
-            blockHash: registeredIdentities[0]?.block?.hash ?? null
+            registeredIdentities: registeredIdentities.length
           }
         })
       }
@@ -2098,16 +2098,13 @@ describe('Identities routes', () => {
         const prevPeriod = firstTimestamp - 17280000 * (i - 1)
 
         const registeredIdentities = identities.filter(identity =>
-          new Date(identity.block.timestamp).getTime() <= prevPeriod &&
-          new Date(identity.block.timestamp).getTime() >= nextPeriod
+          new Date(identity.block.timestamp).getTime() <= prevPeriod
         ).sort((a, b) => a.block.timestamp - b.block.timestamp)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            registeredIdentities: registeredIdentities.length,
-            blockHeight: registeredIdentities[0]?.block?.height ?? null,
-            blockHash: registeredIdentities[0]?.block?.hash ?? null
+            registeredIdentities: registeredIdentities.length
           }
         })
       }
@@ -2132,16 +2129,13 @@ describe('Identities routes', () => {
         const prevPeriod = firstTimestamp - 51840000 * (i - 1)
 
         const registeredIdentities = identities.filter(identity =>
-          new Date(identity.block.timestamp).getTime() <= prevPeriod &&
-          new Date(identity.block.timestamp).getTime() >= nextPeriod
+          new Date(identity.block.timestamp).getTime() <= prevPeriod
         ).sort((a, b) => a.block.timestamp - b.block.timestamp)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            registeredIdentities: registeredIdentities.length,
-            blockHeight: registeredIdentities[0]?.block?.height ?? null,
-            blockHash: registeredIdentities[0]?.block?.hash ?? null
+            registeredIdentities: registeredIdentities.length
           }
         })
       }
@@ -2166,16 +2160,13 @@ describe('Identities routes', () => {
         const prevPeriod = firstTimestamp - 120960000 * (i - 1)
 
         const registeredIdentities = identities.filter(identity =>
-          new Date(identity.block.timestamp).getTime() <= prevPeriod &&
-          new Date(identity.block.timestamp).getTime() >= nextPeriod
+          new Date(identity.block.timestamp).getTime() <= prevPeriod
         ).sort((a, b) => a.block.timestamp - b.block.timestamp)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            registeredIdentities: registeredIdentities.length,
-            blockHeight: registeredIdentities[0]?.block?.height ?? null,
-            blockHash: registeredIdentities[0]?.block?.hash ?? null
+            registeredIdentities: registeredIdentities.length
           }
         })
       }
@@ -2183,8 +2174,8 @@ describe('Identities routes', () => {
       assert.deepEqual(expectedSeriesData.reverse(), body)
     })
     it('should return series of 6 intervals timespan 3d', async () => {
-      const start = new Date(new Date().getTime())
-      const end = new Date(start.getTime() + 10800000)
+      const start = new Date(new Date().getTime() - 86400000)
+      const end = new Date()
 
       const { body } = await client.get(`/identities/history?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}&intervalsCount=6`)
         .expect(200)
@@ -2198,20 +2189,17 @@ describe('Identities routes', () => {
       const expectedSeriesData = []
 
       for (let i = 0; i < body.length; i++) {
-        const nextPeriod = firstTimestamp - Math.ceil((end - start) / 1000 / 6) * 1000 * i
-        const prevPeriod = firstTimestamp - 3600000 * (i - 1)
+        const nextPeriod = firstTimestamp - 14400000 * i
+        const prevPeriod = firstTimestamp - 14400000 * (i - 1)
 
         const registeredIdentities = identities.filter(identity =>
-          new Date(identity.block.timestamp).getTime() <= prevPeriod &&
-          new Date(identity.block.timestamp).getTime() >= nextPeriod
+          new Date(identity.block.timestamp).getTime() <= prevPeriod
         ).sort((a, b) => a.block.timestamp - b.block.timestamp)
 
         expectedSeriesData.push({
           timestamp: new Date(nextPeriod).toISOString(),
           data: {
-            registeredIdentities: registeredIdentities.length,
-            blockHeight: registeredIdentities[0]?.block?.height ?? null,
-            blockHash: registeredIdentities[0]?.block?.hash ?? null
+            registeredIdentities: registeredIdentities.length
           }
         })
       }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1258,24 +1258,18 @@ GET /identities/history?timestamp_start=2025-09-09T00:00:00.000Z&timestamp_end=2
         "timestamp": "2025-09-09T00:00:00.000Z",
         "data": {
             "registeredIdentities": 0,
-            "blockHeight": null,
-            "blockHash": null
         }
     },
     {
         "timestamp": "2025-09-09T08:00:00.000Z",
         "data": {
             "registeredIdentities": 26,
-            "blockHeight": 2,
-            "blockHash": "2BD91299D19649C8DA1EC963FF6304606C052F69CEEB98F72DE5E2E09C8B88E6"
         }
     },
     {
         "timestamp": "2025-09-09T16:00:00.000Z",
         "data": {
-            "registeredIdentities": 4,
-            "blockHeight": 28,
-            "blockHash": "E26D7A8B3497EB104924BB4D152A0BA62ECB3C46BF96F9A8440B6BF151069E5B"
+            "registeredIdentities": 30,
         }
     }
 ]


### PR DESCRIPTION
# Issue
At this moment we generate data by intervals, but every interval contains data only for registred in himelf identities

# Things done 
- Updated calculating alghoritm, now we sum identities count from past and current interval
- Updated tests
- Updated README.md