### PR TITLE
Increase public note limit to 2048

### DIFF
--- a/packages/indexer/migrations/V51__token_transitions.sql
+++ b/packages/indexer/migrations/V51__token_transitions.sql
@@ -4,7 +4,7 @@ CREATE TABLE token_transitions (
       owner varchar(64) NOT NULL,
       action SMALLINT NOT NULL,
       amount bigint,
-      public_note char(64),
+      public_note varchar(200),
       state_transition_hash char(64) NOT NULL references state_transitions(hash),
       token_contract_position SMALLINT NOT NULL,
       data_contract_id int NOT NULL references data_contracts(id),


### PR DESCRIPTION
# Issue
There is a mistake in database schema, with a max size of publicNote field of the token transition to 64, while the protocol allows it to be up to 2048.

This makes indexer to fail to process a valid transaction from the network.

# Things done

* Fixed existing migration