### PR TITLE
Fix responsive styles of lists

### DIFF
--- a/packages/frontend/src/components/blocks/BlocksListItem.scss
+++ b/packages/frontend/src/components/blocks/BlocksListItem.scss
@@ -21,8 +21,6 @@
 
   &__Column {
     @include blocks.Column();
-    display: flex;
-    align-items: center;
 
     &:last-child {
       text-align: right;

--- a/packages/frontend/src/components/blocks/_variables.scss
+++ b/packages/frontend/src/components/blocks/_variables.scss
@@ -74,6 +74,9 @@
 }
 
 @mixin Column () {
+  display: flex;
+  align-items: center;
+
   &:last-child {
     text-align: right;
   }

--- a/packages/frontend/src/components/cards/DashboardCards.scss
+++ b/packages/frontend/src/components/cards/DashboardCards.scss
@@ -49,7 +49,7 @@
 
     .Slider__Carousel {
       width: 110%;
-      margin: calc(-5% - 4px);
+      margin: 0 calc(-5% - 4px);
       overflow: visible;
     }
   }

--- a/packages/frontend/src/components/contestedResources/ContestedResourcesList.scss
+++ b/packages/frontend/src/components/contestedResources/ContestedResourcesList.scss
@@ -13,8 +13,6 @@
 
   &__ColumnTitle {
     @include cr.Column();
-    width: 100%;
-    display: block;
     word-break: normal;
     white-space: normal;
     overflow-wrap: break-word;

--- a/packages/frontend/src/components/contestedResources/contenders/_variables.scss
+++ b/packages/frontend/src/components/contestedResources/contenders/_variables.scss
@@ -6,7 +6,7 @@
 
   grid-template-columns:
     5rem // Date
-    minmax(5.875rem, 46rem) // Hash
+    minmax(5.875rem, 100rem) // Hash
     16.5rem // Identity
     16.5rem // Document
     8rem; // Votes

--- a/packages/frontend/src/components/contestedResources/votes/VotesList.scss
+++ b/packages/frontend/src/components/contestedResources/votes/VotesList.scss
@@ -22,8 +22,6 @@
 
   &__ColumnTitle {
     @include votes.Column();
-    width: 100%;
-    display: block;
     word-break: normal;
     white-space: normal;
     overflow-wrap: break-word;

--- a/packages/frontend/src/components/dataContracts/DataContractsList.scss
+++ b/packages/frontend/src/components/dataContracts/DataContractsList.scss
@@ -13,8 +13,6 @@
 
   &__ColumnTitle {
     @include dc.Column();
-    width: 100%;
-    display: block;
     word-break: normal;
     white-space: normal;
     overflow-wrap: break-word;

--- a/packages/frontend/src/components/documents/DocumentsList.scss
+++ b/packages/frontend/src/components/documents/DocumentsList.scss
@@ -13,8 +13,6 @@
 
   &__ColumnTitle {
     @include docs.Column();
-    width: 100%;
-    display: block;
     word-break: normal;
     white-space: normal;
     overflow-wrap: break-word;

--- a/packages/frontend/src/components/tokens/TokensList.scss
+++ b/packages/frontend/src/components/tokens/TokensList.scss
@@ -21,14 +21,6 @@
       justify-content: flex-start;
     }
 
-    &--Ticker {
-      justify-content: center;
-    }
-
-    &--Supply {
-      justify-content: center;
-    }
-
     &--Contract {
       justify-content: flex-start;
     }

--- a/packages/frontend/src/components/tokens/TokensList.scss
+++ b/packages/frontend/src/components/tokens/TokensList.scss
@@ -13,8 +13,6 @@
 
   &__ColumnTitle {
     @include tokens.Column();
-    width: 100%;
-    display: block;
     word-break: normal;
     white-space: normal;
     overflow-wrap: break-word;

--- a/packages/frontend/src/components/tokens/_variables.scss
+++ b/packages/frontend/src/components/tokens/_variables.scss
@@ -134,6 +134,7 @@
 @mixin Column () {
   display: flex;
   align-items: center;
+  width: 100%;
 
   &:last-child {
     justify-content: flex-end;

--- a/packages/frontend/src/components/transactions/TransactionsList.scss
+++ b/packages/frontend/src/components/transactions/TransactionsList.scss
@@ -13,8 +13,6 @@
 
   &__ColumnTitle {
     @include txs.Column();
-    width: 100%;
-    display: block;
     word-break: normal;
     white-space: normal;
     overflow-wrap: break-word;

--- a/packages/frontend/src/components/transfers/_variables.scss
+++ b/packages/frontend/src/components/transfers/_variables.scss
@@ -5,23 +5,23 @@
   display: grid;
   gap: 16px;
 
-  @container (min-width: 90em) {
-    grid-template-columns:
+  grid-template-columns:
     70px
     minmax(0, 400px)
     minmax(0, 500rem)
     minmax(185px, 185px)
     minmax(100px, 100px)
     128px;
-  }
 
-  grid-template-columns:
-    70px
-    minmax(0, 400px)
-    minmax(0, 400px)
-    minmax(185px, 185px)
-    minmax(100px, 100px)
-    128px;
+  @container (max-width: 90em) {
+    grid-template-columns:
+      70px
+      minmax(0, 400px)
+      minmax(0, 400px)
+      minmax(185px, 185px)
+      minmax(100px, 100px)
+      128px;
+  }
 
   @container (max-width: 50em) {
     grid-template-columns:


### PR DESCRIPTION
# Issue
- Incorrect offsets in DashboardCards 
- Hiding columns is not applied correctly in ```@container``` queries in list components

# Things done
Fixed offsets in DashboardCards component

Fixed responsive styles in:
- Transactions list
- Blocks list
- Identities list
- Documents list
- Data contracts list 
- Contested resources list
- Votes list
- Contenders list
- Transfers list