### PR TITLE
Fix sql vulnerability with `where like` and user input for query

### DIFF
--- a/packages/api/src/controllers/MainController.js
+++ b/packages/api/src/controllers/MainController.js
@@ -113,7 +113,7 @@ class MainController {
       }
     }
 
-    if (/^[0-9A-f]{64,64}$/.test(query)) {
+    if (/^[0-9A-Fa-f]{64,64}$/.test(query)) {
       // search block by hash
       const block = await this.blocksDAO.getBlockByHash(query)
 
@@ -137,7 +137,7 @@ class MainController {
     }
 
     // check for any Identifiers (identities, data contracts, documents)
-    if (/^[0-9A-z]{43,44}$/.test(query)) {
+    if (/^[0-9A-Za-z]{43,44}$/.test(query)) {
       // search identites
       const identity = await this.identitiesDAO.getIdentityByIdentifier(query)
 

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -248,7 +248,7 @@ module.exports = ({
           properties: {
             resourceValue: {
               type: 'string',
-              pattern: "^[A-Za-z0-9+/]+$",
+              pattern: '^[A-Za-z0-9+/]+$'
             }
           }
         }
@@ -265,7 +265,7 @@ module.exports = ({
           properties: {
             resourceValue: {
               type: 'string',
-              pattern: "^[A-Za-z0-9+/]+$"
+              pattern: '^[A-Za-z0-9+/]+$'
             }
           }
         }
@@ -316,7 +316,7 @@ module.exports = ({
           properties: {
             dpns: {
               type: 'string',
-              pattern: "^[A-Za-z0-9.-]+$",
+              pattern: '^[A-Za-z0-9.-]+$'
             }
           }
         }
@@ -605,7 +605,7 @@ module.exports = ({
             name: {
               type: 'string',
               // minimal token name is 3 but for search by part name we use minimal length 1
-              pattern: "^[A-Za-z0-9]+$",
+              pattern: '^[A-Za-z0-9]+$',
               minLength: 1,
               maxLength: 25
             }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -246,7 +246,10 @@ module.exports = ({
         params: {
           type: 'object',
           properties: {
-            resourceValue: { type: 'string' }
+            resourceValue: {
+              type: 'string',
+              pattern: "^[A-Za-z0-9+/]+$",
+            }
           }
         }
       }
@@ -260,7 +263,10 @@ module.exports = ({
         params: {
           type: 'object',
           properties: {
-            resourceValue: { type: 'string' }
+            resourceValue: {
+              type: 'string',
+              pattern: "^[A-Za-z0-9+/]+$"
+            }
           }
         }
       }
@@ -308,7 +314,10 @@ module.exports = ({
           type: 'object',
           required: ['dpns'],
           properties: {
-            dpns: { type: 'string' }
+            dpns: {
+              type: 'string',
+              pattern: "^[A-Za-z0-9.-]+$",
+            }
           }
         }
       }
@@ -596,6 +605,7 @@ module.exports = ({
             name: {
               type: 'string',
               // minimal token name is 3 but for search by part name we use minimal length 1
+              pattern: "^[A-Za-z0-9]+$",
               minLength: 1,
               maxLength: 25
             }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -246,10 +246,7 @@ module.exports = ({
         params: {
           type: 'object',
           properties: {
-            resourceValue: {
-              type: 'string',
-              pattern: '^[A-Za-z0-9+/]+$'
-            }
+            resourceValue: { type: 'string' }
           }
         }
       }
@@ -263,10 +260,7 @@ module.exports = ({
         params: {
           type: 'object',
           properties: {
-            resourceValue: {
-              type: 'string',
-              pattern: '^[A-Za-z0-9+/]+$'
-            }
+            resourceValue: { type: 'string' }
           }
         }
       }
@@ -608,7 +602,7 @@ module.exports = ({
             name: {
               type: 'string',
               // minimal token name is 3 but for search by part name we use minimal length 1
-              pattern: '^[A-Za-z0-9]+$',
+              pattern: '^[A-Za-z0-9-]+$',
               minLength: 1,
               maxLength: 25
             }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -399,7 +399,10 @@ module.exports = ({
         querystring: {
           type: 'object',
           properties: {
-            query: { type: 'string' }
+            query: {
+              type: 'string',
+              pattern: '^[A-Za-z0-9.-]+$'
+            }
           }
         }
       }

--- a/packages/api/src/schemas.js
+++ b/packages/api/src/schemas.js
@@ -2,7 +2,7 @@ const schemaTypes = [
   {
     $id: 'hash',
     type: 'string',
-    pattern: "^[A-Za-z0-9]+$",
+    pattern: '^[A-Za-z0-9]+$',
     minLength: 64,
     maxLength: 64
   },
@@ -51,7 +51,7 @@ const schemaTypes = [
       },
       hash: {
         type: 'string',
-        pattern: "^[A-Za-z0-9]+$",
+        pattern: '^[A-Za-z0-9]+$',
         minLength: 64,
         maxLength: 64
       },
@@ -119,7 +119,7 @@ const schemaTypes = [
       },
       owner: {
         type: ['string', 'null'],
-        pattern: "^[A-Za-z0-9]+$",
+        pattern: '^[A-Za-z0-9]+$',
         minLength: 43,
         maxLength: 44
       },
@@ -144,7 +144,7 @@ const schemaTypes = [
       },
       validator: {
         type: 'string',
-        pattern: "^[A-Za-z0-9]+$",
+        pattern: '^[A-Za-z0-9]+$',
         minLength: 64,
         maxLength: 64
       },
@@ -174,13 +174,13 @@ const schemaTypes = [
       },
       voter_identity: {
         type: ['string', 'null'],
-        pattern: "^[A-Za-z0-9]+$",
+        pattern: '^[A-Za-z0-9]+$',
         minLength: 43,
         maxLength: 44
       },
       towards_identity: {
         type: ['string', 'null'],
-        pattern: "^[A-Za-z0-9]+$",
+        pattern: '^[A-Za-z0-9]+$',
         minLength: 43,
         maxLength: 44
       },
@@ -195,7 +195,7 @@ const schemaTypes = [
       },
       start_at: {
         type: ['string', 'null'],
-        pattern: "^[A-Za-z0-9]+$",
+        pattern: '^[A-Za-z0-9]+$',
         minLength: 43,
         maxLength: 44
       }
@@ -227,7 +227,7 @@ const schemaTypes = [
   {
     $id: 'identifier',
     type: 'string',
-    pattern: "^[A-Za-z0-9]+$",
+    pattern: '^[A-Za-z0-9]+$',
     minLength: 43,
     maxLength: 44
   },

--- a/packages/api/src/schemas.js
+++ b/packages/api/src/schemas.js
@@ -2,6 +2,7 @@ const schemaTypes = [
   {
     $id: 'hash',
     type: 'string',
+    pattern: "^[A-Za-z0-9]+$",
     minLength: 64,
     maxLength: 64
   },
@@ -50,6 +51,7 @@ const schemaTypes = [
       },
       hash: {
         type: 'string',
+        pattern: "^[A-Za-z0-9]+$",
         minLength: 64,
         maxLength: 64
       },
@@ -116,7 +118,10 @@ const schemaTypes = [
         enum: ['SUCCESS', 'FAIL', 'ALL']
       },
       owner: {
-        type: ['string', 'null']
+        type: ['string', 'null'],
+        pattern: "^[A-Za-z0-9]+$",
+        minLength: 43,
+        maxLength: 44
       },
       gas_min: {
         type: ['number', 'null'],
@@ -139,6 +144,7 @@ const schemaTypes = [
       },
       validator: {
         type: 'string',
+        pattern: "^[A-Za-z0-9]+$",
         minLength: 64,
         maxLength: 64
       },
@@ -168,11 +174,13 @@ const schemaTypes = [
       },
       voter_identity: {
         type: ['string', 'null'],
+        pattern: "^[A-Za-z0-9]+$",
         minLength: 43,
         maxLength: 44
       },
       towards_identity: {
         type: ['string', 'null'],
+        pattern: "^[A-Za-z0-9]+$",
         minLength: 43,
         maxLength: 44
       },
@@ -187,6 +195,7 @@ const schemaTypes = [
       },
       start_at: {
         type: ['string', 'null'],
+        pattern: "^[A-Za-z0-9]+$",
         minLength: 43,
         maxLength: 44
       }
@@ -218,6 +227,7 @@ const schemaTypes = [
   {
     $id: 'identifier',
     type: 'string',
+    pattern: "^[A-Za-z0-9]+$",
     minLength: 43,
     maxLength: 44
   },


### PR DESCRIPTION
# Issue
Currently, we have a vulnerability when entering SQL queries. All places where whereILike or whereLike is used with user input can return all strings if a query is sent with a string containing only `_` characters as parameters. And all pattern checks using a regular expression with the value `[A-z]` also pass this character. 

Big thanks to @unabomber-primitive for finding the vulnerability.

# Things done
- Updated old pattern checks
- Implemented new pattern checks