### PR TITLE
Contested resource votes calculation update

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1827,7 +1827,7 @@ GET /contestedResource/WyJkYXNoIiwieHl6Il0=
       ],
       "towardsIdentityVotes": 0,
       "abstainVotes": 1,
-      "lockVotes": 2
+      "lockVotes": 0
     }
   ],
   "indexName": "parentNameAndLabel",

--- a/packages/api/src/dao/ContestedResourcesDAO.js
+++ b/packages/api/src/dao/ContestedResourcesDAO.js
@@ -141,7 +141,7 @@ module.exports = class ContestedDAO {
           ? accumulator + 1 * currentValue.masternode_power
           : accumulator
         , 0) ?? null,
-        lockVotes: uniqueVotes.reduce((accumulator, currentValue) => (currentValue.choice !== ChoiceEnum.ABSTAIN && currentValue.choice !== null) && currentValue.towards_identity?.trim() !== row.owner.trim()
+        lockVotes: uniqueVotes.reduce((accumulator, currentValue) => (currentValue.choice === ChoiceEnum.LOCK) && currentValue.towards_identity?.trim() !== row.owner.trim()
           ? accumulator + 1 * currentValue.masternode_power
           : accumulator
         , 0) ?? null

--- a/packages/api/test/integration/contested.spec.js
+++ b/packages/api/test/integration/contested.spec.js
@@ -277,8 +277,7 @@ describe('Contested documents routes', () => {
             lockVotes: contestedResources
               .filter(res =>
                 res.masternodeVote.index_values === JSON.stringify(['dash', 'xyz']) &&
-                res.masternodeVote.choice !== ChoiceEnum.ABSTAIN &&
-                (res.masternodeVote.choice === ChoiceEnum.LOCK || res.masternodeVote.towards_identity_identifier !== resource.contender.identifier))
+                res.masternodeVote.choice === ChoiceEnum.LOCK)
               .length
           })),
         indexName: 'parentNameAndLabel',

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1794,7 +1794,7 @@ GET /contestedResource/WyJkYXNoIiwieHl6Il0=
       ],
       "towardsIdentityVotes": 0,
       "abstainVotes": 1,
-      "lockVotes": 2
+      "lockVotes": 0
     }
   ],
   "indexName": "parentNameAndLabel",


### PR DESCRIPTION
# Issue
At this moment we calculate lock votes for contenders by lock count + towards to another identity count

# Things done
- lock count calculation now contains only lock votes
- Updated README.md
- Updated tests