### PR TITLE
Identity nonce and revision from DAPI

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1173,7 +1173,7 @@ GET /identity/3igSMtXaaS9iRQHbWU1w4hHveKdxixwMpgmhLzjVhFZJ
 {
   "identifier": "3igSMtXaaS9iRQHbWU1w4hHveKdxixwMpgmhLzjVhFZJ",
   "revision": 0,
-  "balance": 49989647300,
+  "balance": "49989647300",
   "timestamp": "2024-10-12T18:51:44.592Z",
   "txHash": "32FB988D87E4122A2FE030B5014A59A05786C1501FD97D765E2329F89A8AD01D",
   "totalTxs": 13,
@@ -1300,7 +1300,7 @@ GET /identities?page=1&limit=10&order=asc&order_by=block_height
           "identifier": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
           "owner": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
           "revision": 1,
-          "balance": 1000000,
+          "balance": "1000000",
           "timestamp": "2024-03-18T10:13:54.150Z",
           "txHash": "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
           "totalTxs": 1,

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -170,11 +170,15 @@ module.exports = class IdentitiesDAO {
     }
 
     const balance = await this.sdk.identities.getIdentityBalance(identity.identifier)
+    const identityNonce = await this.sdk.identities.getIdentityNonce(identity.identifier)
+    const identityInfo = await this.sdk.identities.getIdentityByIdentifier(identity.identifier)
 
     return Identity.fromObject({
       ...identity,
       aliases,
       balance: String(balance),
+      nonce: String(identityNonce),
+      revision: String(identityInfo.revision),
       publicKeys: publicKeys?.map(key => {
         const contractBounds = key.getContractBounds()
 
@@ -283,6 +287,7 @@ module.exports = class IdentitiesDAO {
 
     const resultSet = await Promise.all(rows.map(async row => {
       const balance = await this.sdk.identities.getIdentityBalance(row.identifier.trim())
+      const identityInfo = await this.sdk.identities.getIdentityByIdentifier(row.identifier)
 
       const aliases = []
       const [aliasDocument] = await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.identifier.trim()]], 1)
@@ -295,6 +300,7 @@ module.exports = class IdentitiesDAO {
         ...row,
         owner: row.identity_owner,
         total_data_contracts: parseInt(row.total_data_contracts),
+        revision: String(identityInfo.revision),
         total_documents: parseInt(row.total_documents),
         total_txs: parseInt(row.total_txs),
         balance: String(balance),

--- a/packages/api/src/models/Identity.js
+++ b/packages/api/src/models/Identity.js
@@ -20,6 +20,7 @@ module.exports = class Identity {
   totalTopUps
   totalWithdrawals
   lastWithdrawalTimestamp
+  nonce
 
   constructor (
     identifier, owner, revision,
@@ -30,7 +31,7 @@ module.exports = class Identity {
     totalTopUpsAmount, totalWithdrawalsAmount,
     lastWithdrawalHash, lastWithdrawalTimestamp,
     totalTopUps, totalWithdrawals, publicKeys,
-    fundingCoreTx
+    fundingCoreTx, nonce
   ) {
     this.identifier = identifier ? identifier.trim() : null
     this.owner = owner ? owner.trim() : null
@@ -54,6 +55,7 @@ module.exports = class Identity {
     this.totalTopUps = totalTopUps ?? null
     this.totalWithdrawals = totalWithdrawals ?? null
     this.lastWithdrawalTimestamp = lastWithdrawalTimestamp ?? null
+    this.nonce = nonce ?? null
   }
 
   static fromObject ({
@@ -64,7 +66,7 @@ module.exports = class Identity {
     aliases, totalGasSpent, averageGasSpent,
     totalTopUpsAmount, totalWithdrawalsAmount,
     lastWithdrawalHash, publicKeys, fundingCoreTx,
-    totalTopUps, totalWithdrawals, lastWithdrawalTimestamp
+    totalTopUps, totalWithdrawals, lastWithdrawalTimestamp, nonce
   }) {
     return new Identity(
       identifier,
@@ -88,7 +90,8 @@ module.exports = class Identity {
       totalTopUps,
       totalWithdrawals,
       publicKeys,
-      fundingCoreTx
+      fundingCoreTx,
+      nonce
     )
   }
 
@@ -101,13 +104,13 @@ module.exports = class Identity {
     aliases, total_gas_spent, average_gas_spent,
     total_top_ups_amount, total_withdrawals_amount,
     last_withdrawal_hash, last_withdrawal_timestamp,
-    total_top_ups, total_withdrawals
+    total_top_ups, total_withdrawals, nonce
   }) {
     return new Identity(
       identifier?.trim(),
       owner,
       revision,
-      Number(balance),
+      String(balance),
       timestamp,
       Number(total_txs),
       Number(total_data_contracts),
@@ -123,7 +126,10 @@ module.exports = class Identity {
       last_withdrawal_hash,
       last_withdrawal_timestamp,
       Number(total_top_ups),
-      Number(total_withdrawals)
+      Number(total_withdrawals),
+      undefined,
+      undefined,
+      nonce !== undefined ? String(nonce) : undefined
     )
   }
 }

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -10,7 +10,7 @@ const BatchEnum = require('../../src/enums/BatchEnum')
 const { ContestedResourcesController } = require('dash-platform-sdk/src/contestedResources')
 const { IdentitiesController } = require('dash-platform-sdk/src/identities')
 const { DocumentsController } = require('dash-platform-sdk/src/documents')
-const { IdentifierWASM } = require('pshenmic-dpp')
+const { IdentifierWASM, IdentityWASM } = require('pshenmic-dpp')
 
 describe('Identities routes', () => {
   let app
@@ -30,6 +30,7 @@ describe('Identities routes', () => {
   let transfers
   let transaction
   let transactions
+  let mockIdentity
 
   let dataContractSchema
 
@@ -170,7 +171,13 @@ describe('Identities routes', () => {
       }
     }
 
-    mock.method(IdentitiesController.prototype, 'getIdentityBalance', async () => 0)
+    mockIdentity = new IdentityWASM('5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5Bk')
+
+    mockIdentity.revision = 123n
+
+    mock.method(IdentitiesController.prototype, 'getIdentityBalance', async () => 0n)
+    mock.method(IdentitiesController.prototype, 'getIdentityNonce', async () => 0n)
+    mock.method(IdentitiesController.prototype, 'getIdentityByIdentifier', async () => mockIdentity)
 
     mock.method(IdentitiesController.prototype, 'getIdentityPublicKeys', async () => null)
 
@@ -230,7 +237,8 @@ describe('Identities routes', () => {
       const expectedIdentity = {
         identifier: identity.identifier,
         owner: identity.identifier,
-        revision: identity.revision,
+        revision: String(mockIdentity.revision),
+        nonce: '0',
         balance: '0',
         timestamp: block.timestamp.toISOString(),
         txHash: identity.txHash,
@@ -437,8 +445,9 @@ describe('Identities routes', () => {
       const expectedIdentities = identities.slice(0, 10).map((_identity) => ({
         identifier: _identity.identity.identifier,
         owner: _identity.identity.identifier,
-        revision: _identity.identity.revision,
-        balance: 0,
+        revision: String(mockIdentity.revision),
+        nonce: null,
+        balance: '0',
         timestamp: _identity.block.timestamp.toISOString(),
         txHash: _identity.identity.txHash,
         totalTxs: 1,
@@ -499,8 +508,9 @@ describe('Identities routes', () => {
         .slice(0, 10).map((_identity) => ({
           identifier: _identity.identity.identifier,
           owner: _identity.identity.identifier,
-          revision: _identity.identity.revision,
-          balance: 0,
+          revision: String(mockIdentity.revision),
+          nonce: null,
+          balance: '0',
           timestamp: _identity.block.timestamp.toISOString(),
           txHash: _identity.identity.txHash,
           totalTxs: 1,
@@ -562,8 +572,9 @@ describe('Identities routes', () => {
         .slice(10, 20).map((_identity) => ({
           identifier: _identity.identity.identifier,
           owner: _identity.identity.identifier,
-          revision: _identity.identity.revision,
-          balance: 0,
+          revision: String(mockIdentity.revision),
+          nonce: null,
+          balance: '0',
           timestamp: _identity.block.timestamp.toISOString(),
           txHash: _identity.identity.txHash,
           totalTxs: 1,
@@ -626,8 +637,9 @@ describe('Identities routes', () => {
         .map((_identity) => ({
           identifier: _identity.identity.identifier,
           owner: _identity.identity.identifier,
-          revision: _identity.identity.revision,
-          balance: 0,
+          revision: String(mockIdentity.revision),
+          nonce: null,
+          balance: '0',
           timestamp: _identity.block.timestamp.toISOString(),
           txHash: _identity.identity.txHash,
           totalTxs: 1,
@@ -706,8 +718,9 @@ describe('Identities routes', () => {
         .map((_identity) => ({
           identifier: _identity.identity.identifier,
           owner: _identity.identity.identifier,
-          revision: _identity.identity.revision,
-          balance: 0,
+          revision: String(mockIdentity.revision),
+          nonce: null,
+          balance: '0',
           timestamp: _identity.block.timestamp.toISOString(),
           txHash: _identity.identity.txHash,
           totalTxs: _identity.identity.transactions.length + 1,
@@ -781,6 +794,8 @@ describe('Identities routes', () => {
 
       mock.reset()
 
+      mock.method(IdentitiesController.prototype, 'getIdentityByIdentifier', async () => mockIdentity)
+
       mock.method(IdentitiesController.prototype, 'getIdentityBalance', async (identifier) => {
         const { identity } = identities.find(({ identity }) => identity.identifier === identifier)
         return identity.balance
@@ -808,8 +823,9 @@ describe('Identities routes', () => {
         .map((_identity) => ({
           identifier: _identity.identity.identifier,
           owner: _identity.identity.identifier,
-          revision: _identity.identity.revision,
-          balance: _identity.identity.balance,
+          revision: String(mockIdentity.revision),
+          nonce: null,
+          balance: String(_identity.identity.balance),
           timestamp: _identity.block.timestamp.toISOString(),
           txHash: _identity.identity.txHash,
           totalTxs: 2,

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -7,7 +7,7 @@ const fixtures = require('../utils/fixtures')
 const StateTransitionEnum = require('../../src/enums/StateTransitionEnum')
 const { getKnex } = require('../../src/utils')
 const tenderdashRpc = require('../../src/tenderdashRpc')
-const { IdentifierWASM, TokenConfigurationWASM } = require('pshenmic-dpp')
+const { IdentifierWASM, TokenConfigurationWASM, IdentityWASM} = require('pshenmic-dpp')
 const BatchEnum = require('../../src/enums/BatchEnum')
 const { IdentitiesController } = require('dash-platform-sdk/src/identities')
 const { NodeController } = require('dash-platform-sdk/src/node')
@@ -604,13 +604,22 @@ describe('Other routes', () => {
     })
 
     it('should search identity', async () => {
+      const mockIdentity = new IdentityWASM('5DbLwAxGBzUzo81VewMUwn4b5P4bpv9FNFybi25XB5Bk')
+
+      mockIdentity.revision = 123n
+
+      mock.method(IdentitiesController.prototype, 'getIdentityBalance', async () => 0n)
+      mock.method(IdentitiesController.prototype, 'getIdentityNonce', async () => 0n)
+      mock.method(IdentitiesController.prototype, 'getIdentityByIdentifier', async () => mockIdentity)
+
       const { body } = await client.get(`/search?query=${identity.identifier}`)
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       const expectedIdentity = {
         identifier: identity.identifier,
-        revision: 0,
+        revision: '123',
+        nonce: '0',
         balance: '0',
         timestamp: block.timestamp.toISOString(),
         txHash: identityTransaction.hash,

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1140,7 +1140,7 @@ GET /identity/3igSMtXaaS9iRQHbWU1w4hHveKdxixwMpgmhLzjVhFZJ
 {
   "identifier": "3igSMtXaaS9iRQHbWU1w4hHveKdxixwMpgmhLzjVhFZJ",
   "revision": 0,
-  "balance": 49989647300,
+  "balance": "49989647300",
   "timestamp": "2024-10-12T18:51:44.592Z",
   "txHash": "32FB988D87E4122A2FE030B5014A59A05786C1501FD97D765E2329F89A8AD01D",
   "totalTxs": 13,
@@ -1267,7 +1267,7 @@ GET /identities?page=1&limit=10&order=asc&order_by=block_height
           "identifier": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
           "owner": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
           "revision": 1,
-          "balance": 1000000,
+          "balance": "1000000",
           "timestamp": "2024-03-18T10:13:54.150Z",
           "txHash": "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
           "totalTxs": 1,
@@ -2436,16 +2436,16 @@ IDENTITY_CREATE with instantLock
 ```
 ```json
 {
-    "type": 7,
-    "typeString": "IDENTITY_CREDIT_TRANSFER",
-    "identityNonce": 1,
-    "userFeeIncrease": 0,
-    "senderId": "24YEeZmpy1QNKronDT8enYWLXnfoxYK7hrHUdpWHxURg",
-    "recipientId": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
-    "amount": 21856638,
-    "signaturePublicKeyId": 3,
-    "signature": "1f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8",
-    "raw": "07000fc3bf4a26bff60f4f79a1f4b929ce4d4c5833d226c1c7f68758e71d7ae229db569fd4f616b3dedecbeef95352cf38f1fb04d232a0d20623bc195b0c3f721840fc014d817e010003411f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8"
+  "type": 7,
+  "typeString": "IDENTITY_CREDIT_TRANSFER",
+  "identityNonce": 1,
+  "userFeeIncrease": 0,
+  "senderId": "24YEeZmpy1QNKronDT8enYWLXnfoxYK7hrHUdpWHxURg",
+  "recipientId": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
+  "amount": 21856638,
+  "signaturePublicKeyId": 3,
+  "signature": "1f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8",
+  "raw": "07000fc3bf4a26bff60f4f79a1f4b929ce4d4c5833d226c1c7f68758e71d7ae229db569fd4f616b3dedecbeef95352cf38f1fb04d232a0d20623bc195b0c3f721840fc014d817e010003411f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8"
 }
 ```
 ```json


### PR DESCRIPTION
# Issue
We need to show nonce and revision from dapi, because obtaining this data from the indexer does not always return the correct result

# Things done
- Added call for sdk methods `getIdentityNonce` and `getIdentityByIdentifier`
- Added nonce field for identity model
- All balances for identities now in String
- Updated tests
- Updated readme.md