### PR TITLE
Alias reuquests optimization

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
     "@scure/base": "^1.1.5",
     "bs58": "^6.0.0",
     "cbor": "^9.0.2",
-    "dash-platform-sdk": "1.3.0-dev.1",
+    "dash-platform-sdk": "1.3.0-dev.4",
     "dotenv": "^16.3.1",
     "fastify": "^4.21.0",
     "fastify-metrics": "^11.0.0",

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -1,9 +1,8 @@
 const Block = require('../models/Block')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-const { getAliasFromDocument } = require('../utils')
+const { getAliasFromDocument, getAliasDocumentForIdentifiers } = require('../utils')
 const Transaction = require('../models/Transaction')
 const StateTransitionEnum = require('../enums/StateTransitionEnum')
-const { DPNS_CONTRACT } = require('../constants')
 
 module.exports = class BlockDAO {
   constructor (knex, sdk) {
@@ -74,9 +73,13 @@ module.exports = class BlockDAO {
       return null
     }
 
+    const owners = rows.map(row => row.owner.trim())
+
+    const aliasDocuments = await getAliasDocumentForIdentifiers(owners, this.sdk)
+
     const txs = block.tx_hash
       ? await Promise.all(rows.map(async (row) => {
-        const [aliasDocument] = await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.owner.trim()]], 1)
+        const aliasDocument = aliasDocuments[row.owner.trim()]
 
         const aliases = []
 

--- a/packages/api/src/dao/ContestedResourcesDAO.js
+++ b/packages/api/src/dao/ContestedResourcesDAO.js
@@ -1,9 +1,9 @@
 const ChoiceEnum = require('../enums/ChoiceEnum')
 const ContestedResource = require('../models/ContestedResource')
-const { buildIndexBuffer, getAliasFromDocument } = require('../utils')
+const { buildIndexBuffer, getAliasFromDocument, getAliasDocumentForIdentifiers } = require('../utils')
 const Vote = require('../models/Vote')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-const { CONTESTED_RESOURCE_VOTE_DEADLINE, DPNS_CONTRACT } = require('../constants')
+const { CONTESTED_RESOURCE_VOTE_DEADLINE } = require('../constants')
 const ContestedResourceStatus = require('../models/ContestedResourcesStatus')
 const { ContestedStateResultType } = require('dash-platform-sdk/src/types')
 
@@ -116,8 +116,12 @@ module.exports = class ContestedDAO {
     const totalDocumentsGasUsed = uniqueContenders
       .reduce((accumulator, currentValue) => accumulator + Number((currentValue.document_tx_gas_used ?? 0)), 0)
 
+    const owners = rows.map(row => row.owner.trim())
+
+    const aliasDocuments = await getAliasDocumentForIdentifiers(owners, this.sdk)
+
     const contenders = await Promise.all(uniqueContenders.map(async (row) => {
-      const [aliasDocument] = row.owner ? await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.owner.trim()]], 1) : []
+      const aliasDocument = aliasDocuments[row.owner.trim()]
 
       const aliases = []
 
@@ -367,8 +371,14 @@ module.exports = class ContestedDAO {
       .leftJoin(contestedDocumentsSubquery, 'towards_identity_identifier', 'owner')
       .orderBy('subquery.id', order)
 
+    const towardsIdentityIdentifiers = rows
+      .filter(row => row.towards_identity_identifier)
+      .map(row => row.towards_identity_identifier.trim())
+
+    const aliasDocuments = await getAliasDocumentForIdentifiers(towardsIdentityIdentifiers, this.sdk)
+
     const resultSet = await Promise.all(rows.map(async (row) => {
-      const [aliasDocument] = row.towards_identity_identifier ? await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.towards_identity_identifier.trim()]], 1) : []
+      const aliasDocument = aliasDocuments[row.towards_identity_identifier.trim()]
 
       const aliases = []
 

--- a/packages/api/src/dao/IdentitiesDAO.js
+++ b/packages/api/src/dao/IdentitiesDAO.js
@@ -9,11 +9,10 @@ const {
   decodeStateTransition,
   getAliasStateByVote,
   getAliasFromDocument,
-  getAliasInfo
+  getAliasInfo, getAliasDocumentForIdentifiers
 } = require('../utils')
 const StateTransitionEnum = require('../enums/StateTransitionEnum')
 const BatchEnum = require('../enums/BatchEnum')
-const { DPNS_CONTRACT } = require('../constants')
 const SeriesData = require('../models/SeriesData')
 
 module.exports = class IdentitiesDAO {
@@ -285,12 +284,17 @@ module.exports = class IdentitiesDAO {
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 
+    const identifiers = rows.map(row => row.identifier.trim())
+
+    const aliasDocuments = await getAliasDocumentForIdentifiers(identifiers, this.sdk)
+
     const resultSet = await Promise.all(rows.map(async row => {
       const balance = await this.sdk.identities.getIdentityBalance(row.identifier.trim())
       const identityInfo = await this.sdk.identities.getIdentityByIdentifier(row.identifier)
 
+      const aliasDocument = aliasDocuments[row.identifier.trim()]
+
       const aliases = []
-      const [aliasDocument] = await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.identifier.trim()]], 1)
 
       if (aliasDocument) {
         aliases.push(getAliasFromDocument(aliasDocument))
@@ -397,9 +401,14 @@ module.exports = class IdentitiesDAO {
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 
+    const owners = rows.map(row => row.document_owner.trim())
+
+    const aliasDocuments = await getAliasDocumentForIdentifiers(owners, this.sdk)
+
     const resultSet = await Promise.all(rows.map(async (row) => {
+      const aliasDocument = aliasDocuments[row.document_owner.trim()]
+
       const aliases = []
-      const [aliasDocument] = await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.document_owner.trim()]], 1)
 
       if (aliasDocument) {
         aliases.push(getAliasFromDocument(aliasDocument))

--- a/packages/api/src/dao/MasternodeVotesDAO.js
+++ b/packages/api/src/dao/MasternodeVotesDAO.js
@@ -1,7 +1,6 @@
 const Vote = require('../models/Vote')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
-const { getAliasFromDocument } = require('../utils')
-const { DPNS_CONTRACT } = require('../constants')
+const { getAliasFromDocument, getAliasDocumentForIdentifiers } = require('../utils')
 
 module.exports = class MasternodeVotesDAO {
   constructor (knex, sdk) {
@@ -70,8 +69,12 @@ module.exports = class MasternodeVotesDAO {
       .limit(limit)
       .orderBy('subquery.id', order)
 
+    const identifiers = rows.map(row => row.towards_identity_identifier.trim())
+
+    const aliasDocuments = await getAliasDocumentForIdentifiers(identifiers, this.sdk)
+
     const resultSet = await Promise.all(rows.map(async (row) => {
-      const [aliasDocument] = row.towards_identity_identifier ? await this.sdk.documents.query(DPNS_CONTRACT, 'domain', [['records.identity', '=', row.towards_identity_identifier.trim()]], 1) : []
+      const aliasDocument = aliasDocuments[row.towards_identity_identifier.trim()]
 
       const aliases = []
 


### PR DESCRIPTION
# Issue
We need to optimize aliases requests because blocks with a lot of transactions generates GRPC error
Also alias requests slow down PE, because every dapi respone validates by proofs

# Things done
- Implemented `getAliasDocumentForIdentifiers`, which allows to get aliases from identifiers list without duplicates
- Implemented `getAliasDocumentForIdentifier`
- Updated All DAO's
- sdk version bump