### PR TITLE
Extended token info in tokens list

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2583,71 +2583,52 @@ Return list of tokens
 ```
 GET /tokens?limit=2&page=1&order=asc
 [
-  {
-    "identifier": "5kRUF1SRTFtdskfaaQE9pCdADq8wyLFB1TNttnrBq3F8",
-    "localizations": {
-      "en": {
-        "pluralForm": "k1-id1",
-        "singularForm": "k1-id1",
-        "shouldCapitalize": true
-      }
-    },
-    "baseSupply": "100000",
-    "totalSupply": "100500",
-    "maxSupply": null,
-    "owner": {
-      "identifier": "8GnWmaDGZe9HBchfWPeq2cRPM88c4BvAahCk9vxr34mg",
-      "aliases": [
-        {
-          "alias": "alias.dash",
-          "contested": true,
-          "documentId": "AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW",
-          "status": "ok",
-          "timestamp": "2025-08-10T19:09:39.485Z"
-        }
-      ]
-    },
-    "mintable": true,
-    "burnable": true,
-    "freezable": true,
-    "unfreezable": true,
-    "destroyable": true,
-    "allowedEmergencyActions": true,
-    "dataContractIdentifier": "CNvyZaBWofWPmgKYCBMF23h3cEhQfQHVY3wXCRkHEaau"
-  },
-  {
-    "identifier": "GUo3MpaLeaLDvjDnF5XQLRCjWC9WhkNPbtrVWZ5FKjLp",
-    "localizations": {
-      "en": {
-        "pluralForm": "a1-1",
-        "singularForm": "a1-1",
-        "shouldCapitalize": true
-      }
-    },
-    "baseSupply": "100000",
-    "totalSupply": "120000",
-    "maxSupply": "5000",
-    "owner": {
-      "identifier": "8GnWmaDGZe9HBchfWPeq2cRPM88c4BvAahCk9vxr34mg",
-      "aliases": [
-        {
-          "alias": "alias.dash",
-          "contested": true,
-          "documentId": "AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW",
-          "status": "ok",
-          "timestamp": "2025-08-10T19:09:39.485Z"
-        }
-      ]
-    },
-    "mintable": true,
-    "burnable": true,
-    "freezable": true,
-    "unfreezable": true,
-    "destroyable": true,
-    "allowedEmergencyActions": true,
-    "dataContractIdentifier": "5BwVvDstM6FaXQcLNUGkuPHAk5xH3uEoYEKqHKXjw5nL"
-    "decimals": null,
-  }
+    {
+        "identifier": "9YxdbQUjJmQsmVPen95HjAU3Esj7tVkWSY2EQWT84ZQP",
+        "position": 0,
+        "timestamp": null,
+        "description": "note",
+        "localizations": {
+            "en": {
+                "pluralForm": "tokens",
+                "singularForm": "token",
+                "shouldCapitalize": true
+            }
+        },
+        "baseSupply": "1",
+        "totalSupply": "1",
+        "maxSupply": null,
+        "owner": {
+            "identifier": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
+            "aliases": [
+                {
+                    "alias": "canusieethat7.dash",
+                    "status": "ok",
+                    "timestamp": "2024-10-10T19:40:05.824Z",
+                    "documentId": "Qwb2FuwfnexmxxYoJUsMhM9pd192NVDvaEVFyjkSXAa",
+                    "contested": false
+                }
+            ]
+        },
+        "mintable": false,
+        "burnable": false,
+        "freezable": false,
+        "unfreezable": false,
+        "destroyable": false,
+        "allowedEmergencyActions": false,
+        "dataContractIdentifier": "Y189uedQG3CJCuu83P3DqnG7ngQaRKz69x3gY8uDzQe",
+        "changeMaxSupply": false,
+        "totalGasUsed": null,
+        "mainGroup": null,
+        "totalTransitionsCount": null,
+        "totalFreezeTransitionsCount": null,
+        "totalBurnTransitionsCount": null,
+        "decimals": 1,
+        "perpetualDistribution": null,
+        "preProgrammedDistribution": null,
+        "price": null,
+        "prices": null
+    }, ...
 ]
 ```
 Response codes:

--- a/packages/api/test/integration/tokens.spec.js
+++ b/packages/api/test/integration/tokens.spec.js
@@ -225,12 +225,18 @@ describe('Tokens', () => {
         .slice(0, 10)
         .map(({ token }) => ({
           identifier: token.identifier,
-          localizations: token.localizations ?? null,
-          baseSupply: token.base_supply.toString(),
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
+          baseSupply: '1000',
           totalSupply: '1000',
-          maxSupply: token.max_supply?.toString() ?? null,
+          maxSupply: '1010',
           owner: {
-            identifier: token.owner,
+            identifier: '11111111111111111111111111111111',
             aliases: [
               {
                 alias: 'alias.dash',
@@ -241,30 +247,39 @@ describe('Tokens', () => {
               }
             ]
           },
-          mintable: token.mintable,
-          burnable: token.burnable,
-          freezable: token.freezable,
-          unfreezable: token.unfreezable,
-          destroyable: token.destroyable,
-          allowedEmergencyActions: token.allowed_emergency_actions,
+          mintable: false,
+          burnable: false,
+          freezable: false,
+          unfreezable: false,
+          destroyable: false,
+          allowedEmergencyActions: false,
           dataContractIdentifier: dataContract.identifier,
           mainGroup: null,
-          position: null,
+          position: 29,
           description: null,
-          changeMaxSupply: null,
+          changeMaxSupply: true,
           timestamp: null,
           totalBurnTransitionsCount: null,
           totalFreezeTransitionsCount: null,
           totalGasUsed: null,
           totalTransitionsCount: null,
-          decimals: null,
-          perpetualDistribution: null,
+          decimals: 1000,
+          perpetualDistribution: {
+            functionName: 'FixedAmount',
+            functionValue: {
+              amount: '100'
+            },
+            interval: 100,
+            recipientType: 'ContractOwner',
+            recipientValue: null,
+            type: 'BlockBasedDistribution'
+          },
           preProgrammedDistribution: null,
           prices: null,
           price: null
         }))
 
-      assert.deepEqual(expectedTokens, body.resultSet)
+      assert.deepEqual(body.resultSet, expectedTokens)
     })
 
     it('should return tokens set with order desc', async () => {
@@ -281,12 +296,18 @@ describe('Tokens', () => {
         .slice(0, 10)
         .map(({ token }) => ({
           identifier: token.identifier,
-          localizations: token.localizations ?? null,
-          baseSupply: token.base_supply.toString(),
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
+          baseSupply: '1000',
           totalSupply: '1000',
-          maxSupply: token.max_supply?.toString() ?? null,
+          maxSupply: '1010',
           owner: {
-            identifier: token.owner,
+            identifier: '11111111111111111111111111111111',
             aliases: [
               {
                 alias: 'alias.dash',
@@ -297,24 +318,33 @@ describe('Tokens', () => {
               }
             ]
           },
-          mintable: token.mintable,
-          burnable: token.burnable,
-          freezable: token.freezable,
-          unfreezable: token.unfreezable,
-          destroyable: token.destroyable,
-          allowedEmergencyActions: token.allowed_emergency_actions,
+          mintable: false,
+          burnable: false,
+          freezable: false,
+          unfreezable: false,
+          destroyable: false,
+          allowedEmergencyActions: false,
           dataContractIdentifier: dataContract.identifier,
           mainGroup: null,
-          position: null,
+          position: 29,
           description: null,
-          changeMaxSupply: null,
+          changeMaxSupply: true,
           timestamp: null,
           totalBurnTransitionsCount: null,
           totalFreezeTransitionsCount: null,
           totalGasUsed: null,
-          decimals: null,
           totalTransitionsCount: null,
-          perpetualDistribution: null,
+          decimals: 1000,
+          perpetualDistribution: {
+            functionName: 'FixedAmount',
+            functionValue: {
+              amount: '100'
+            },
+            interval: 100,
+            recipientType: 'ContractOwner',
+            recipientValue: null,
+            type: 'BlockBasedDistribution'
+          },
           preProgrammedDistribution: null,
           prices: null,
           price: null
@@ -337,12 +367,18 @@ describe('Tokens', () => {
         .slice(0, 3)
         .map(({ token }) => ({
           identifier: token.identifier,
-          localizations: token.localizations ?? null,
-          baseSupply: token.base_supply.toString(),
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
+          baseSupply: '1000',
           totalSupply: '1000',
-          maxSupply: token.max_supply?.toString() ?? null,
+          maxSupply: '1010',
           owner: {
-            identifier: token.owner,
+            identifier: '11111111111111111111111111111111',
             aliases: [
               {
                 alias: 'alias.dash',
@@ -353,24 +389,33 @@ describe('Tokens', () => {
               }
             ]
           },
-          mintable: token.mintable,
-          burnable: token.burnable,
-          freezable: token.freezable,
-          unfreezable: token.unfreezable,
-          destroyable: token.destroyable,
-          allowedEmergencyActions: token.allowed_emergency_actions,
+          mintable: false,
+          burnable: false,
+          freezable: false,
+          unfreezable: false,
+          destroyable: false,
+          allowedEmergencyActions: false,
           dataContractIdentifier: dataContract.identifier,
           mainGroup: null,
-          position: null,
+          position: 29,
           description: null,
-          changeMaxSupply: null,
+          changeMaxSupply: true,
           timestamp: null,
           totalBurnTransitionsCount: null,
           totalFreezeTransitionsCount: null,
           totalGasUsed: null,
-          decimals: null,
           totalTransitionsCount: null,
-          perpetualDistribution: null,
+          decimals: 1000,
+          perpetualDistribution: {
+            functionName: 'FixedAmount',
+            functionValue: {
+              amount: '100'
+            },
+            interval: 100,
+            recipientType: 'ContractOwner',
+            recipientValue: null,
+            type: 'BlockBasedDistribution'
+          },
           preProgrammedDistribution: null,
           prices: null,
           price: null
@@ -393,12 +438,18 @@ describe('Tokens', () => {
         .slice(11, 22)
         .map(({ token }) => ({
           identifier: token.identifier,
-          localizations: token.localizations ?? null,
-          baseSupply: token.base_supply.toString(),
+          localizations: {
+            en: {
+              pluralForm: 'tests',
+              singularForm: 'test',
+              shouldCapitalize: true
+            }
+          },
+          baseSupply: '1000',
           totalSupply: '1000',
-          maxSupply: token.max_supply?.toString() ?? null,
+          maxSupply: '1010',
           owner: {
-            identifier: token.owner,
+            identifier: '11111111111111111111111111111111',
             aliases: [
               {
                 alias: 'alias.dash',
@@ -409,24 +460,33 @@ describe('Tokens', () => {
               }
             ]
           },
-          mintable: token.mintable,
-          burnable: token.burnable,
-          freezable: token.freezable,
-          unfreezable: token.unfreezable,
-          destroyable: token.destroyable,
-          allowedEmergencyActions: token.allowed_emergency_actions,
+          mintable: false,
+          burnable: false,
+          freezable: false,
+          unfreezable: false,
+          destroyable: false,
+          allowedEmergencyActions: false,
           dataContractIdentifier: dataContract.identifier,
           mainGroup: null,
-          position: null,
+          position: 29,
           description: null,
-          changeMaxSupply: null,
+          changeMaxSupply: true,
           timestamp: null,
           totalBurnTransitionsCount: null,
           totalFreezeTransitionsCount: null,
           totalGasUsed: null,
-          decimals: null,
           totalTransitionsCount: null,
-          perpetualDistribution: null,
+          decimals: 1000,
+          perpetualDistribution: {
+            functionName: 'FixedAmount',
+            functionValue: {
+              amount: '100'
+            },
+            interval: 100,
+            recipientType: 'ContractOwner',
+            recipientValue: null,
+            type: 'BlockBasedDistribution'
+          },
           preProgrammedDistribution: null,
           prices: null,
           price: null

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -2550,71 +2550,52 @@ Return list of tokens
 ```
 GET /tokens?limit=2&page=1&order=asc
 [
-  {
-    "identifier": "5kRUF1SRTFtdskfaaQE9pCdADq8wyLFB1TNttnrBq3F8",
-    "localizations": {
-      "en": {
-        "pluralForm": "k1-id1",
-        "singularForm": "k1-id1",
-        "shouldCapitalize": true
-      }
-    },
-    "baseSupply": "100000",
-    "totalSupply": "100500",
-    "maxSupply": null,
-    "owner": {
-      "identifier": "8GnWmaDGZe9HBchfWPeq2cRPM88c4BvAahCk9vxr34mg",
-      "aliases": [
-        {
-          "alias": "alias.dash",
-          "contested": true,
-          "documentId": "AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW",
-          "status": "ok",
-          "timestamp": "2025-08-10T19:09:39.485Z"
-        }
-      ]
-    },
-    "mintable": true,
-    "burnable": true,
-    "freezable": true,
-    "unfreezable": true,
-    "destroyable": true,
-    "allowedEmergencyActions": true,
-    "dataContractIdentifier": "CNvyZaBWofWPmgKYCBMF23h3cEhQfQHVY3wXCRkHEaau"
-  },
-  {
-    "identifier": "GUo3MpaLeaLDvjDnF5XQLRCjWC9WhkNPbtrVWZ5FKjLp",
-    "localizations": {
-      "en": {
-        "pluralForm": "a1-1",
-        "singularForm": "a1-1",
-        "shouldCapitalize": true
-      }
-    },
-    "baseSupply": "100000",
-    "totalSupply": "120000",
-    "maxSupply": "5000",
-    "owner": {
-      "identifier": "8GnWmaDGZe9HBchfWPeq2cRPM88c4BvAahCk9vxr34mg",
-      "aliases": [
-        {
-          "alias": "alias.dash",
-          "contested": true,
-          "documentId": "AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW",
-          "status": "ok",
-          "timestamp": "2025-08-10T19:09:39.485Z"
-        }
-      ]
-    },
-    "mintable": true,
-    "burnable": true,
-    "freezable": true,
-    "unfreezable": true,
-    "destroyable": true,
-    "allowedEmergencyActions": true,
-    "dataContractIdentifier": "5BwVvDstM6FaXQcLNUGkuPHAk5xH3uEoYEKqHKXjw5nL"
-    "decimals": null,
-  }
+    {
+        "identifier": "9YxdbQUjJmQsmVPen95HjAU3Esj7tVkWSY2EQWT84ZQP",
+        "position": 0,
+        "timestamp": null,
+        "description": "note",
+        "localizations": {
+            "en": {
+                "pluralForm": "tokens",
+                "singularForm": "token",
+                "shouldCapitalize": true
+            }
+        },
+        "baseSupply": "1",
+        "totalSupply": "1",
+        "maxSupply": null,
+        "owner": {
+            "identifier": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
+            "aliases": [
+                {
+                    "alias": "canusieethat7.dash",
+                    "status": "ok",
+                    "timestamp": "2024-10-10T19:40:05.824Z",
+                    "documentId": "Qwb2FuwfnexmxxYoJUsMhM9pd192NVDvaEVFyjkSXAa",
+                    "contested": false
+                }
+            ]
+        },
+        "mintable": false,
+        "burnable": false,
+        "freezable": false,
+        "unfreezable": false,
+        "destroyable": false,
+        "allowedEmergencyActions": false,
+        "dataContractIdentifier": "Y189uedQG3CJCuu83P3DqnG7ngQaRKz69x3gY8uDzQe",
+        "changeMaxSupply": false,
+        "totalGasUsed": null,
+        "mainGroup": null,
+        "totalTransitionsCount": null,
+        "totalFreezeTransitionsCount": null,
+        "totalBurnTransitionsCount": null,
+        "decimals": 1,
+        "perpetualDistribution": null,
+        "preProgrammedDistribution": null,
+        "price": null,
+        "prices": null
+    }, ...
 ]
 ```
 Response codes:


### PR DESCRIPTION
# Issue
We need to show extended token info in tokens list. Because frontend should use fields such as decimals.

# Things done
- Updated `TokensDAO`
- Updated `README.md`
- Updated tests