### PR TITLE
Fix ending contested resource

### DIFF
--- a/packages/api/src/dao/ContestedResourcesDAO.js
+++ b/packages/api/src/dao/ContestedResourcesDAO.js
@@ -451,11 +451,11 @@ module.exports = class ContestedDAO {
       .leftJoin('documents', 'id', 'document_id')
       .leftJoin('state_transitions', 'state_transition_hash', 'hash')
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
-      .orderBy('timestamp', 'desc')
+      .orderBy('timestamp', 'asc')
       .limit(1)
       .as('joined_subquery')
 
-    const lastContestedResourceValue = this.knex(timestampResourceSubquery)
+    const endingContestedResourceValue = this.knex(timestampResourceSubquery)
       .select('resource_value', 'timestamp', 'choice')
       .select(this.knex.raw('NULL::bigint as total_contested_documents_count'))
       .select(this.knex.raw('NULL::bigint as pending_contested_documents_count'))
@@ -474,7 +474,7 @@ module.exports = class ContestedDAO {
       .leftJoin('state_transitions', 'state_transition_hash', 'state_transitions.hash')
       .leftJoin('blocks', 'blocks.hash', 'block_hash')
 
-    const rows = await this.knex.union(statusSubquery, lastContestedResourceValue)
+    const rows = await this.knex.union(statusSubquery, endingContestedResourceValue)
 
     const [status] = rows.filter(row => row.total_contested_documents_count !== null)
 


### PR DESCRIPTION
# Issue
At this moment we returns last created and active contested resource as soon ending contested resources

# Things done
- Fixed order

#### REQUIRES PRECISE OF ENVIRONMENT VARIBALE `CONTESTED_RESOURCE_VOTE_DEADLINE`
#### FOR TESTNET SOMETHING ABOUT 2 HOURS
#### DEFAULT 1209600000 ~~ 14 DAYS