### PR TITLE
Fix contract name 

### DIFF
--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -150,7 +150,15 @@ module.exports = class DataContractsDAO {
       .select(
         'identifier', 'filtered_data_contracts.owner', 'version',
         'filtered_data_contracts.tx_hash', 'is_system', 'timestamp', 'block_hash',
-        'filtered_data_contracts.id', 'name', 'tokens_count', 'keywords', 'description'
+        'filtered_data_contracts.id', 'tokens_count', 'keywords', 'description'
+      )
+      .select(
+        this.knex('data_contracts')
+          .select('name')
+          .whereRaw('data_contracts.identifier = filtered_data_contracts.identifier and name is not null')
+          .orderBy('id', 'desc')
+          .limit(1)
+          .as('name')
       )
       .orderBy(orderByOptions)
       .limit(limit)


### PR DESCRIPTION
# Issue
At this moment if we create contract, set name and then push update tx for this contract, we lost contract name in response

# Things done
- Updated query for data contract name in `getDataContractByIdentifier()`
- Updated query for data contract name in `getDataContracts()`