### PR TITLE
Updagrade sdk to 1.4.0-dev.4

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
     "@scure/base": "^1.1.5",
     "bs58": "^6.0.0",
     "cbor": "^9.0.2",
-    "dash-platform-sdk": "1.4.0-dev.3",
+    "dash-platform-sdk": "1.4.0-dev.4",
     "dotenv": "^16.3.1",
     "fastify": "^4.21.0",
     "fastify-metrics": "^11.0.0",


### PR DESCRIPTION
# Issue
We tested sdk on platform-explorer testnet and we found incorrect behavior when trying to pass json object with timestamp from rs level to js level.

# Things done
- Bump sdk version, which includes new dpp with fixes