### PR TITLE
Fix error with invoking contested resource vote poll on voting

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
     "bs58": "^6.0.0",
     "cbor": "^9.0.2",
     "dash-core-sdk": "1.1.0-dev.2",
-    "dash-platform-sdk": "1.4.0-dev.6",
+    "dash-platform-sdk": "1.4.0-dev.7",
     "dotenv": "^16.3.1",
     "fastify": "^4.21.0",
     "fastify-metrics": "^11.0.0",


### PR DESCRIPTION
# Issue
At this moment we get error on every page where we invoke request for contested resource vote poll for resource which on voting at this moment

# Things done
- Replaced default flag value for `allowIncludeLockedAndAbstainingVoteTally` from `true` to `false` in `pshenmic-dpp`
- Bump sdk version