### PR TITLE
Fix error on some aliases

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
     "bs58": "^6.0.0",
     "cbor": "^9.0.2",
     "dash-core-sdk": "1.1.0-dev.2",
-    "dash-platform-sdk": "1.4.0-dev.8",
+    "dash-platform-sdk": "1.4.0-dev.9",
     "dotenv": "^16.3.1",
     "fastify": "^4.21.0",
     "fastify-metrics": "^11.0.0",


### PR DESCRIPTION
# Issue
At this moment we can get alias with empty winner from grpc, but sdk contains incorrect ternary in data convertation
Example: https://testnet.platform-explorer.com/identity/CKKYnVeKoxCbvuEhiT6MDoQaRyXgDECwtxoKL5cqucZE

# Things done
- Bump sdk to `1.4.0-dev.9` which contains fixed ternary for empty `winner.identityId`