### PR TITLE
Implement order for withdrawals by identity

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1460,8 +1460,6 @@ Return all withdrawals for identity
 
 _Note: this request does not contain any pagination data in the response_
 
-* `timestamp_start` ISO String
-* `start_at` base58 encoded withdrawal document identifier; used only as the cursor for the first DAPI batch, subsequent batches use the id of the last fetched document
 * `order` `asc` or `desc`
 * returns 404 `not found` if identity don't have withdrawals
 * Pagination always `null`

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1460,13 +1460,13 @@ Return all withdrawals for identity
 
 _Note: this request does not contain any pagination data in the response_
 
-* `limit` cannot be more then 100
 * `timestamp_start` ISO String
-* `start_at` base58 encoded withdrawal document identifier
+* `start_at` base58 encoded withdrawal document identifier; used only as the cursor for the first DAPI batch, subsequent batches use the id of the last fetched document
+* `order` `asc` or `desc`
 * returns 404 `not found` if identity don't have withdrawals
 * Pagination always `null`
 ```
-GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?limit=5&start_at=95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs&timestamp_start=2024-10-10T02:37:39.187Z
+GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?order=asc&start_at=95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs&timestamp_start=2024-10-10T02:37:39.187Z
 
 {
   "pagination": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
     "bs58": "^6.0.0",
     "cbor": "^9.0.2",
     "dash-core-sdk": "1.1.0-dev.2",
-    "dash-platform-sdk": "1.4.0-dev.9",
+    "dash-platform-sdk": "1.4.0-dev.11",
     "dotenv": "^16.3.1",
     "fastify": "^4.21.0",
     "fastify-metrics": "^11.0.0",

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -131,30 +131,29 @@ class IdentitiesController {
 
   getWithdrawalsByIdentity = async (request, response) => {
     const { identifier } = request.params
-    const { timestamp_start: timestampStart, start_at: startAt, order = 'asc' } = request.query
+    const { order = 'asc' } = request.query
 
     // In Future maybe we don't need this.
     // at this moment used only for batch size
     const limit = 100
-    const maxDocuments = 2000
+    // 10000 documents
+    const maxPages = 100
 
     const query = [['$ownerId', '=', new IdentifierWASM(identifier).base58()]]
-
-    if (timestampStart) {
-      query.push(['status', 'in', [0, 1, 2, 3, 4]], ['$createdAt', '>=', new Date(timestampStart).getTime()])
-    }
 
     const documents = []
     let startAfter
 
-    while (documents.length <= maxDocuments) {
+    let currentPage = 0
+
+    do {
       const batch = await this.sdk.documents.query(
         WITHDRAWAL_CONTRACT,
         WITHDRAWAL_CONTRACT_TYPE,
         query,
         [['$ownerId', 'asc'], ['status', 'asc'], ['$createdAt', 'asc']],
         limit,
-        startAfter == null ? startAt : undefined,
+        undefined,
         startAfter
       )
 
@@ -163,7 +162,8 @@ class IdentitiesController {
       if (batch.length < limit) break
 
       startAfter = batch[batch.length - 1].id
-    }
+      currentPage += 1
+    } while (currentPage <= maxPages)
 
     if (documents.length === 0) {
       return response.send(new PaginatedResultSet([], null, null, null))

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -134,8 +134,8 @@ class IdentitiesController {
     const { order = 'asc' } = request.query
 
     // In Future maybe we don't need this.
-    // at this moment used only for batch size
-    const limit = 100
+    // at this moment used only for page size while requesting batches
+    const pageSize = 100
     // 10000 documents
     const maxPages = 100
 
@@ -152,14 +152,14 @@ class IdentitiesController {
         WITHDRAWAL_CONTRACT_TYPE,
         query,
         [['$ownerId', 'asc'], ['status', 'asc'], ['$createdAt', 'asc']],
-        limit,
+        pageSize,
         undefined,
         startAfter
       )
 
       documents.push(...batch)
 
-      if (batch.length < limit) break
+      if (batch.length < pageSize) break
 
       startAfter = batch[batch.length - 1].id
       currentPage += 1

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -186,9 +186,9 @@ class IdentitiesController {
       )?.hash
     }))
       .sort((a, b) => {
-        const direction = order === 'asc' ? 1 : -1;
-        return (a.timestamp - b.timestamp) * direction;
-      });
+        const direction = order === 'asc' ? 1 : -1
+        return (a.timestamp - b.timestamp) * direction
+      })
 
     response.send(new PaginatedResultSet(resultSet, null, null, null))
   }

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -133,9 +133,10 @@ class IdentitiesController {
     const { identifier } = request.params
     const { timestamp_start: timestampStart, start_at: startAt, order = 'asc' } = request.query
 
+    // In Future maybe we don't need this.
     // at this moment used only for batch size
     const limit = 100
-    const maxDocuments = 1000
+    const maxDocuments = 2000
 
     const query = [['$ownerId', '=', new IdentifierWASM(identifier).base58()]]
 

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -131,7 +131,11 @@ class IdentitiesController {
 
   getWithdrawalsByIdentity = async (request, response) => {
     const { identifier } = request.params
-    const { limit = 100, timestamp_start: timestampStart, start_at: startAt } = request.query
+    const { timestamp_start: timestampStart, start_at: startAt, order = 'asc' } = request.query
+
+    // at this moment used only for batch size
+    const limit = 100
+    const maxDocuments = 1000
 
     const query = [['$ownerId', '=', new IdentifierWASM(identifier).base58()]]
 
@@ -139,14 +143,26 @@ class IdentitiesController {
       query.push(['status', 'in', [0, 1, 2, 3, 4]], ['$createdAt', '>=', new Date(timestampStart).getTime()])
     }
 
-    const documents = await this.sdk.documents.query(
-      WITHDRAWAL_CONTRACT,
-      WITHDRAWAL_CONTRACT_TYPE,
-      query,
-      [['$ownerId', 'asc'], ['status', 'asc'], ['$createdAt', 'asc']],
-      limit,
-      startAt
-    )
+    const documents = []
+    let startAfter
+
+    while (documents.length <= maxDocuments) {
+      const batch = await this.sdk.documents.query(
+        WITHDRAWAL_CONTRACT,
+        WITHDRAWAL_CONTRACT_TYPE,
+        query,
+        [['$ownerId', 'asc'], ['status', 'asc'], ['$createdAt', 'asc']],
+        limit,
+        startAfter == null ? startAt : undefined,
+        startAfter
+      )
+
+      documents.push(...batch)
+
+      if (batch.length < limit) break
+
+      startAfter = batch[batch.length - 1].id
+    }
 
     if (documents.length === 0) {
       return response.send(new PaginatedResultSet([], null, null, null))
@@ -168,6 +184,10 @@ class IdentitiesController {
           withdrawal.timestamp.getTime() === Number(document.createdAt)
       )?.hash
     }))
+      .sort((a, b) => {
+        const direction = order === 'asc' ? 1 : -1;
+        return (a.timestamp - b.timestamp) * direction;
+      });
 
     response.send(new PaginatedResultSet(resultSet, null, null, null))
   }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -340,7 +340,7 @@ module.exports = ({
         params: {
           type: 'object',
           properties: {
-            validator: { $ref: 'hash#' }
+            identifier: { $ref: 'identifier#' }
           }
         },
         querystring: { $ref: 'paginationOptions#' }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1427,8 +1427,6 @@ Return all withdrawals for identity
 
 _Note: this request does not contain any pagination data in the response_
 
-* `timestamp_start` ISO String
-* `start_at` base58 encoded withdrawal document identifier; used only as the cursor for the first DAPI batch, subsequent batches use the id of the last fetched document
 * `order` `asc` or `desc`
 * returns 404 `not found` if identity don't have withdrawals
 * Pagination always `null`

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1427,13 +1427,13 @@ Return all withdrawals for identity
 
 _Note: this request does not contain any pagination data in the response_
 
-* `limit` cannot be more then 100
 * `timestamp_start` ISO String
-* `start_at` base58 encoded withdrawal document identifier
+* `start_at` base58 encoded withdrawal document identifier; used only as the cursor for the first DAPI batch, subsequent batches use the id of the last fetched document
+* `order` `asc` or `desc`
 * returns 404 `not found` if identity don't have withdrawals
 * Pagination always `null`
 ```
-GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?limit=5&start_at=95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs&timestamp_start=2024-10-10T02:37:39.187Z
+GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?order=asc&start_at=95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs&timestamp_start=2024-10-10T02:37:39.187Z
 
 {
   "pagination": {


### PR DESCRIPTION
# Issue
At this moment we return only 100 first withdrawals for identity, but total withdrawals amount for identity can be more than 100 and users interests new transaction (desc order)

# Things done 
- Founded and fixed incorrect logic for `startAt` and `startAfter` in documents query in `dash-platform-sdk`. Here's [1.3-dev release](https://www.npmjs.com/package/dash-platform-sdk/v/1.3.2-dev.5) and [1.4-dev release](https://www.npmjs.com/package/dash-platform-sdk/v/1.4.0-dev.11)
- Fixed query validation for `/identity/:identifier/withdrawals`
- Removed `startAt` and `timestamp_start` from query string in `/identity/:identifier/withdrawals`
- Updated logic for requesting withdrawal documents:
  - Now we requesting withdrawal documents by batches with 100 docs until we run out of pages for the documents
  - Order this array by query parameter `order`
- Updated `README.md`