### PR TITLE
fix: validator withdrawals pagination and status

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1463,6 +1463,7 @@ _Note: this request does not contain any pagination data in the response_
 * `order` `asc` or `desc`
 * returns 404 `not found` if identity don't have withdrawals
 * Pagination always `null`
+* `status` is a string. Possible values: `QUEUED`, `POOLED`, `BROADCASTED`, `COMPLETE`, `EXPIRED`
 ```
 GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?order=asc&start_at=95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs&timestamp_start=2024-10-10T02:37:39.187Z
 
@@ -1476,7 +1477,7 @@ GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?order=asc
     {
       "document": "95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs",
       "sender": "A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb",
-      "status": 3,
+      "status": "COMPLETE",
       "amount": 200000,
       "timestamp": "2024-10-10T02:37:39.187Z",
       "withdrawalAddress": "yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A",

--- a/packages/api/src/controllers/IdentitiesController.js
+++ b/packages/api/src/controllers/IdentitiesController.js
@@ -5,6 +5,7 @@ const { outputScriptToAddress, iso8601duration, calculateInterval } = require('.
 const { IdentifierWASM } = require('pshenmic-dpp')
 const StateTransitionEnum = require('../enums/StateTransitionEnum')
 const Intervals = require('../enums/IntervalsEnum')
+const WithdrawalStatusEnum = require('../enums/WithdrawalStatusEnum')
 
 class IdentitiesController {
   constructor (knex, sdk) {
@@ -176,7 +177,7 @@ class IdentitiesController {
     const resultSet = documents.map(document => ({
       document: document.id.base58(),
       sender: document.ownerId.base58(),
-      status: document.properties.status,
+      status: WithdrawalStatusEnum[document.properties.status],
       timestamp: new Date(Number(document.createdAt)),
       amount: document.properties.amount,
       withdrawalAddress: outputScriptToAddress(Buffer.from(document.properties.outputScript ?? [], 'base64')),

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -331,7 +331,7 @@ describe('Identities routes', () => {
         hash: withdrawal.id.base58(),
         document: withdrawal.id.base58(),
         sender: withdrawal.ownerId.base58(),
-        status: 0,
+        status: 'QUEUED',
         timestamp: new Date(withdrawal.createdAt).toISOString(),
         amount: withdrawal.properties.amount,
         withdrawalAddress: null

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1430,6 +1430,7 @@ _Note: this request does not contain any pagination data in the response_
 * `order` `asc` or `desc`
 * returns 404 `not found` if identity don't have withdrawals
 * Pagination always `null`
+* `status` is a string. Possible values: `QUEUED`, `POOLED`, `BROADCASTED`, `COMPLETE`, `EXPIRED`
 ```
 GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?order=asc&start_at=95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs&timestamp_start=2024-10-10T02:37:39.187Z
 
@@ -1443,7 +1444,7 @@ GET /identity/A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb/withdrawals?order=asc
     {
       "document": "95eiiqMotMvH23f6cv3BPC4ykcHFWTy2g3baCTWZANAs",
       "sender": "A1rgGVjRGuznRThdAA316VEEpKuVQ7mV8mBK1BFJvXnb",
-      "status": 3,
+      "status": "COMPLETE",
       "amount": 200000,
       "timestamp": "2024-10-10T02:37:39.187Z",
       "withdrawalAddress": "yeRZBWYfeNE4yVUHV4ZLs83Ppn9aMRH57A",

--- a/packages/frontend/src/app/validator/[hash]/Validator.js
+++ b/packages/frontend/src/app/validator/[hash]/Validator.js
@@ -91,10 +91,10 @@ function Validator ({ hash }) {
 
     setWithdrawals(state => ({ ...state, loading: true }))
 
-    Api.getWithdrawalsByIdentity(validator.data.identity, withdrawals.props.currentPage + 1, pageSize, 'desc')
+    Api.getWithdrawalsByIdentity(validator.data.identity, 1, 100, 'desc')
       .then(res => fetchHandlerSuccess(setWithdrawals, res))
       .catch(err => fetchHandlerError(setWithdrawals, err))
-  }, [validator, withdrawals.props.currentPage])
+  }, [validator])
 
   const handlePageClick = useCallback(({ selected }) => {
     setCurrentPage(selected)
@@ -105,6 +105,14 @@ function Validator ({ hash }) {
     setCurrentPage(0)
     handlePageClick({ selected: 0 })
   }, [pageSize, handlePageClick])
+
+  const withdrawalsAll = withdrawals?.data?.resultSet || []
+  const withdrawalsPage = withdrawals.props.currentPage
+  const visibleWithdrawals = withdrawalsAll.slice(
+    withdrawalsPage * pageSize,
+    (withdrawalsPage + 1) * pageSize
+  )
+  const withdrawalsPageCount = Math.max(1, Math.ceil(withdrawalsAll.length / pageSize))
 
   return (
     <PageDataContainer
@@ -494,7 +502,7 @@ function Validator ({ hash }) {
                     ? <div className={'ValidatorPage__List'}>
                         {!withdrawals.loading
                           ? <WithdrawalsList
-                              withdrawals={withdrawals?.data?.resultSet || Object.values(withdrawals.data) || []}
+                              withdrawals={visibleWithdrawals}
                               l1explorerBaseUrl={l1explorerBaseUrl}
                               rate={rate.data}
                               defaultPayoutAddress={validator.data?.proTxInfo?.state?.payoutAddress}
@@ -506,12 +514,12 @@ function Validator ({ hash }) {
                     : <ErrorMessageBlock/>
                   }
 
-                  {withdrawals.data?.resultSet &&
+                  {withdrawalsAll.length > 0 &&
                     <div className={'ValidatorPage__ListPagination'}>
                       <Pagination
                         onPageChange={pagination => paginationHandler(setWithdrawals, pagination.selected)}
-                        pageCount={Math.ceil(withdrawals.data?.pagination?.total / pageSize) || 1}
-                        forcePage={currentPage}
+                        pageCount={withdrawalsPageCount}
+                        forcePage={withdrawalsPage}
                         pageRangeDisplayed={0}
                       />
                     </div>


### PR DESCRIPTION
## Summary

Fix two bugs on the validator detail page → Withdrawals tab:

1. **Pagination broken** — only 13 records visible, only Page 1 in nav. Frontend hardcoded `pageSize = 13` (shared with Blocks/Transactions tabs), but the withdrawals endpoint returns `pagination: { page: null, limit: null, total: null }` → `Math.ceil(null / 13) || 1 = 1`, so the paginator collapses to a single page even when there are more records.

2. **Status column empty** — `/identity/{id}/withdrawals` returns `status` as a numeric value (0–4). Frontend `StatusIcon` looks up by string key (`QUEUED`, `POOLED`, `BROADCASTED`, `COMPLETE`, `EXPIRED`) and renders nothing for unknown keys.

## Changes

### Frontend — [packages/frontend/src/app/validator/[hash]/Validator.js](https://github.com/pshenmic/platform-explorer/blob/fix/validator-withdrawals/packages/frontend/src/app/validator/%5Bhash%5D/Validator.js)
Single fetch returns the entity's full withdrawals list (the backend serves all withdrawals for the identity in one response — no pagination on the API side at the moment). The frontend then paginates client-side via `Array.slice`.
- Withdrawals fetch is no longer re-triggered on page change (dep on `validator` only)
- `pageCount` computed locally from `resultSet.length`
- Same `pageSize = 13` and `Pagination` styling as Blocks/Transactions — visually consistent

### Backend — [packages/api/src/controllers/IdentitiesController.js](https://github.com/pshenmic/platform-explorer/blob/fix/validator-withdrawals/packages/api/src/controllers/IdentitiesController.js)
Map raw status integer to its enum string label using [`WithdrawalStatusEnum`](https://github.com/pshenmic/platform-explorer/blob/fix/validator-withdrawals/packages/api/src/enums/WithdrawalStatusEnum.js) (already defined in [`packages/api/src/enums/`](https://github.com/pshenmic/platform-explorer/tree/fix/validator-withdrawals/packages/api/src/enums)).

### Test — [packages/api/test/integration/identities.spec.js](https://github.com/pshenmic/platform-explorer/blob/fix/validator-withdrawals/packages/api/test/integration/identities.spec.js)
Update `getIdentityWithdrawalByIdentifier()` assertion: `status: 0` → `status: 'QUEUED'` to match the new enum-label response shape.

### Docs — [packages/api/README.md](https://github.com/pshenmic/platform-explorer/blob/fix/validator-withdrawals/packages/api/README.md), [packages/frontend/src/app/api/content.md](https://github.com/pshenmic/platform-explorer/blob/fix/validator-withdrawals/packages/frontend/src/app/api/content.md)
Both Identity Withdrawals sections updated: response example shows `"status": "COMPLETE"` (string), with a bullet listing the five possible values.

## Note on the API contract

The withdrawals endpoint currently returns **the identity's entire withdrawals list in a single response** — `limit` and `page` query params are accepted by the route schema for consistency with other paginated routes, but the controller does not paginate. So an identity with 252 withdrawals always gets all 252 back.

The frontend therefore fetches once on mount and slices client-side for the visible page.

## Verification

- [x] Manual: validator with 59 withdrawals — all 5 pages reachable, last page has 7 records
- [x] Status column renders icon (QUEUED / POOLED / BROADCASTED / COMPLETE / EXPIRED)
- [x] `npm run lint` (frontend) — no new warnings
- [x] `npm run test:integration` (api) — passing (CI green after test fix commit)