### PR TITLE
fix: show contract bounds on identity public keys

### DIFF
--- a/packages/frontend/src/components/publicKeys/PublicKeyBoundCard.js
+++ b/packages/frontend/src/components/publicKeys/PublicKeyBoundCard.js
@@ -3,10 +3,6 @@ import { ValueCard } from '../cards'
 import './PublicKeyBoundCard.scss'
 
 function PublicKeyBoundCard ({ publicKeyBounds, className }) {
-  const boundTypeTitles = {
-    documentType: 'Document Type'
-  }
-
   return (
     <ValueCard className={`PublicKeyBoundCard ${className || ''}`} colorScheme={'transparent'}>
       <div className={'PublicKeyBoundCard__Title'}>Bound to</div>
@@ -16,17 +12,15 @@ function PublicKeyBoundCard ({ publicKeyBounds, className }) {
           elipsed={true}
           size={'xs'}
           clickable={true}
-          link={'/dataContract/' + publicKeyBounds?.id}
+          link={'/dataContract/' + publicKeyBounds?.identifier}
         >
-          {publicKeyBounds?.id}
+          {publicKeyBounds?.identifier}
         </ValueContainer>
       </div>
       <div className={'PublicKeyBoundCard__Type'}>
-        <span className={'PublicKeyBoundCard__TypeTitle'}>
-          {boundTypeTitles[publicKeyBounds?.type] || publicKeyBounds.type}:
-        </span>
+        <span className={'PublicKeyBoundCard__TypeTitle'}>Document Type:</span>
         <span className={'PublicKeyBoundCard__TypeValue'}>
-          {publicKeyBounds.typeName}
+          {publicKeyBounds?.documentTypeName}
         </span>
       </div>
     </ValueCard>


### PR DESCRIPTION
## Summary

Identity Public Keys section was rendering an empty `Bound to` chip for ENCRYPTION/DECRYPTION keys (issue #775). The API returns `contractBounds` with fields `identifier` and `documentTypeName`, but the component was still reading the old field names (`id`, `typeName`, `type`) — so all values came back `undefined`.

Fix: read the current API field names. Removed the dead `type` fallback (API no longer returns it; only `documentType` bounds exist).

Closes #775.

## Test plan

- [x] Open `/identity/6LbRidC8b2Sbh8fUmT2CeDPmLsPq9V1aV36ekLwM4x6K` on testnet
- [x] Scroll to **Public Keys** → ENCRYPTION/DECRYPTION (Medium) keys show `Bound to <contractId>` and `Document Type: contactRequest`
- [x] Other keys (without `contractBounds`) do not render the chip