### PR TITLE
Null revision for deleted documents

### DIFF
--- a/packages/api/src/dao/DocumentsDAO.js
+++ b/packages/api/src/dao/DocumentsDAO.js
@@ -109,7 +109,7 @@ module.exports = class DocumentsDAO {
 
     const dataSubquery = this.knex('documents')
       .select('documents.data as data', 'documents.identifier as identifier')
-      .select(this.knex.raw('rank() over (partition by documents.identifier order by documents.revision desc) rank'))
+      .select(this.knex.raw('rank() over (partition by documents.identifier order by documents.revision desc nulls last) rank'))
       .orderBy('documents.id', 'desc')
       .as('documents_data')
 
@@ -220,7 +220,7 @@ module.exports = class DocumentsDAO {
         transitions = decodedTransitions.transitions ?? []
       }
 
-      const [transitionWithEntropy] = transitions?.filter(transition => transition.id === row.identifier && transition.revision === row.revision.toString())
+      const [transitionWithEntropy] = transitions?.filter(transition => transition.id === row.identifier && transition.revision === row.revision?.toString())
 
       const document = Document.fromRow({
         ...row,

--- a/packages/api/src/models/Document.js
+++ b/packages/api/src/models/Document.js
@@ -38,7 +38,7 @@ module.exports = class Document {
 
   // eslint-disable-next-line camelcase
   static fromRow ({ identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data, timestamp, is_system, document_type_name, transition_type, prefunded_voting_balance, gas_used, total_gas_used }) {
-    return new Document(identifier, owner, data_contract_identifier, deleted ? null : revision, tx_hash, deleted, data ? JSON.stringify(data) : null, timestamp, is_system, document_type_name, transition_type, prefunded_voting_balance, Number(gas_used), Number(total_gas_used))
+    return new Document(identifier, owner, data_contract_identifier, revision, tx_hash, deleted, data ? JSON.stringify(data) : null, timestamp, is_system, document_type_name, transition_type, prefunded_voting_balance, Number(gas_used), Number(total_gas_used))
   }
 
   static fromObject ({ identifier, owner, dataContractIdentifier, revision, txHash, deleted, data, timestamp, system, documentTypeName, transitionType, entropy, prefundedVotingBalance, identityContractNonce, gasUsed, totalGasUsed }) {

--- a/packages/api/test/utils/fixtures.js
+++ b/packages/api/test/utils/fixtures.js
@@ -304,7 +304,7 @@ const fixtures = {
     const row = {
       identifier,
       state_transition_hash,
-      revision: revision ?? 1,
+      revision: revision ?? (deleted ? null : 1),
       data: data ?? {},
       deleted: deleted ?? false,
       data_contract_id,

--- a/packages/indexer/migrations/V73__nullable_document_revision.sql
+++ b/packages/indexer/migrations/V73__nullable_document_revision.sql
@@ -1,0 +1,2 @@
+ALTER TABLE documents
+    ALTER COLUMN revision DROP NOT NULL;

--- a/packages/indexer/src/entities/document.rs
+++ b/packages/indexer/src/entities/document.rs
@@ -26,7 +26,7 @@ pub struct Document {
     pub data_contract_identifier: Identifier,
     pub data: Option<Value>,
     pub deleted: bool,
-    pub revision: Revision,
+    pub revision: Option<Revision>,
     pub is_system: bool,
     pub prefunded_voting_balance: Option<(String, Credits)>,
 }
@@ -54,7 +54,7 @@ impl From<DocumentTransition> for Document {
                     price: None,
                     data: Some(data_decoded),
                     data_contract_identifier,
-                    revision: revision.unwrap(),
+                    revision: revision,
                     deleted: false,
                     is_system: false,
                     prefunded_voting_balance,
@@ -76,7 +76,7 @@ impl From<DocumentTransition> for Document {
                     price: None,
                     data: Some(data_decoded),
                     data_contract_identifier,
-                    revision: revision.unwrap(),
+                    revision: revision,
                     deleted: false,
                     is_system: false,
                     prefunded_voting_balance: None,
@@ -96,7 +96,7 @@ impl From<DocumentTransition> for Document {
                     price: None,
                     data: None,
                     data_contract_identifier,
-                    revision: Revision::from(0 as u64),
+                    revision: None,
                     deleted: true,
                     is_system: false,
                     prefunded_voting_balance: None,
@@ -118,7 +118,7 @@ impl From<DocumentTransition> for Document {
                     price: None,
                     data: None,
                     data_contract_identifier,
-                    revision,
+                    revision: Some(revision),
                     deleted: false,
                     is_system: false,
                     prefunded_voting_balance: None,
@@ -140,7 +140,7 @@ impl From<DocumentTransition> for Document {
                     price: Some(price),
                     data: None,
                     data_contract_identifier,
-                    revision,
+                    revision: Some(revision),
                     deleted: false,
                     is_system: false,
                     prefunded_voting_balance: None,
@@ -162,7 +162,7 @@ impl From<DocumentTransition> for Document {
                     price: Some(price),
                     data: None,
                     data_contract_identifier,
-                    revision,
+                    revision: Some(revision),
                     deleted: false,
                     is_system: false,
                     prefunded_voting_balance: None,
@@ -181,7 +181,7 @@ impl From<Row> for Document {
         let owner: Option<String> = row.get(5);
         let price: Option<i64> = row.get(6);
         let deleted: bool = row.get(7);
-        let revision: i32 = row.get(8);
+        let revision: Option<i32> = row.get(8);
         let is_system: bool = row.get(9);
         let prefunded_voting_balance: Option<Value> = row.get(10);
 
@@ -205,7 +205,7 @@ impl From<Row> for Document {
             identifier: Identifier::from_string(identifier.as_str(), Base58).unwrap(),
             document_type_name,
             is_system,
-            revision: Revision::from(revision as u64),
+            revision: revision.map(|r| r as u64),
             transition_type: DocumentTransitionActionType::try_from(transition_type).unwrap(),
             prefunded_voting_balance: prefunded_voting_balance.map(|value| {
                 let test = value.as_object().unwrap();

--- a/packages/indexer/src/processor/psql/dao/documents.rs
+++ b/packages/indexer/src/processor/psql/dao/documents.rs
@@ -16,7 +16,7 @@ impl PostgresDAO {
     ) -> Result<(), PoolError> {
         let id = document.identifier;
         let revision = document.revision;
-        let revision_i32 = revision as i32;
+        let revision_i32 = revision.map(|r| r as i32);
         let transition_type = document.transition_type as i64;
         let raw_data = document.data;
         let normal_data = match raw_data.clone() {
@@ -100,7 +100,7 @@ impl PostgresDAO {
             .unwrap();
 
         println!(
-            "Created document {} [{} revision] [is_deleted {}]",
+            "Created document {} [{:?} revision] [is_deleted {}]",
             document.identifier.to_string(Base58),
             revision_i32,
             document.deleted

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -126,7 +126,7 @@ impl PSQLProcessor {
                     data_contract_identifier,
                     data: Some(serde_json::to_value(dash_tld_document_values).unwrap()),
                     deleted: false,
-                    revision: 0,
+                    revision: Some(1),
                     is_system: true,
                     price: None,
                     transition_type: DocumentTransitionActionType::Create,


### PR DESCRIPTION
# Issue
Currently the `revision` column for deleted documents is stored as `0`, but per protocol a deleted document's revision should be `null`. Using `0` as sentinel conflates "deleted" with a legal revision value and diverges from how Drive represents deleted documents, forcing translation logic in the API and indexer
# Things done 
- Updated migrations by removing `NOT NULL` modificator from `revision` column
- Updated indexation logic for nullable `revision` 
- Updated api logic for nullable `revision` 
- Updated Document model