### PR TITLE
Duplicated transactions

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -783,7 +783,7 @@ Return paged set of state transitions that appeared in more than one block. Each
 * `order` can be `asc` or `desc`
 
 ```
-GET /transactions/duplicated?page=1&limit=10&order=asc
+GET /transactions/duplicates?page=1&limit=10&order=asc
 
 {
     "pagination": {

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -53,6 +53,7 @@ Reference:
 * [Validator Blocks Statistic](#validator-stats-by-protxhash)
 * [Transaction by hash](#transaction-by-hash)
 * [Transactions](#transactions)
+* [Duplicated Transactions](#duplicated-transactions)
 * [Data Contract By Identifier](#data-contract-by-identifier)
 * [RAW Data Contract By Identifier](#raw-data-contract-by-identifier)
 * [Data Contracts](#data-contracts)
@@ -625,6 +626,8 @@ Get a transaction (state transition) by hash
 
 Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appear in the `error` field as Base64 string
 
+If the same state transition hash was observed in more than one block, the response includes a `duplicates` field — an array of `Transaction` objects, one per occurrence. Each duplicate has `status: "FAIL"` and its own `blockHash`/`blockHeight`/`timestamp`; all other fields are inherited from the canonical state transition.
+
 ```
 GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
 
@@ -650,7 +653,26 @@ GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEE
           "txHash": "2508B35FDDB3E2E797D4F2CB9C1FAEE71D4DC43B91CE2043BEC8CE2B4A442DD7"
         }
       ]
-    }
+    },
+    "duplicates": [
+        {
+            "blockHash": "9EFA730C41CE9408F9732E4C72A4DAE7A2701AF0F7B1DCE8A72F163E285BEBF3",
+            "blockHeight": 153886,
+            "data": "{}",
+            "hash": "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+            "index": 0,
+            "timestamp": "2024-03-18T10:14:02.350Z",
+            "type": 0,
+            "gasUsed": 1337000,
+            "status": "FAIL",
+            "error": null,
+            "owner": {
+              "identifier": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
+              "aliases": []
+            },
+            "duplicates": null
+        }, ...
+    ]
 }
 ```
 
@@ -743,6 +765,68 @@ GET /transactions?=1&limit=10&orderBy=id&order=asc&owner=6q9RFbeea73tE31LGMBLFZh
                 "identifier": "DTFPLKMVbnkVQWEfkxHX7Ch62ytjvbtqH6eG1TF3nMbD",
                 "aliases": []
             }
+        }, ...
+    ]
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+```
+---
+### Duplicated Transactions
+Return paged set of state transitions that appeared in more than one block. Each entry is a `Transaction` object representing the shared state-transition data (`blockHash`/`blockHeight`/`timestamp` are `null` since the tx spans multiple blocks), with a `duplicates` array listing one `Transaction` per occurrence (status `FAIL`, with the per-block fields populated).
+
+* `limit` cannot be more then 100
+* `page` cannot be less then 1
+* `order` can be `asc` or `desc`
+
+```
+GET /transactions/duplicated?page=1&limit=10&order=asc
+
+{
+    "pagination": {
+        "page": 1,
+        "limit": 10,
+        "total": 3
+    },
+    "resultSet": [
+      {
+            "hash": "1ba0895d9785eff87f0d69d1a7bc22b54e73d267fae3d14513af5c56358b42a5",
+            "index": 0,
+            "blockHash": null,
+            "blockHeight": null,
+            "type": "BATCH",
+            "batchType": "DOCUMENT_CREATE",
+            "data": "AgG5BZwAg32+...",
+            "timestamp": null,
+            "gasUsed": 1040160,
+            "status": "FAIL",
+            "error": null,
+            "owner": {
+                "identifier": "DTFPLKMVbnkVQWEfkxHX7Ch62ytjvbtqH6eG1TF3nMbD",
+                "aliases": []
+            },
+            "duplicates": [
+                {
+                    "hash": "1ba0895d9785eff87f0d69d1a7bc22b54e73d267fae3d14513af5c56358b42a5",
+                    "index": 0,
+                    "blockHash": "9EFA730C41CE9408F9732E4C72A4DAE7A2701AF0F7B1DCE8A72F163E285BEBF3",
+                    "blockHeight": 153886,
+                    "type": "BATCH",
+                    "batchType": "DOCUMENT_CREATE",
+                    "data": "AgG5BZwAg32+...",
+                    "timestamp": "2025-07-15T14:42:41.156Z",
+                    "gasUsed": 1040160,
+                    "status": "FAIL",
+                    "error": null,
+                    "owner": {
+                        "identifier": "DTFPLKMVbnkVQWEfkxHX7Ch62ytjvbtqH6eG1TF3nMbD",
+                        "aliases": []
+                    }
+                }, ...
+            ]
         }, ...
     ]
 }

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -224,7 +224,7 @@ class TransactionsController {
   }
 
   getDuplicatedTransactions = async (request, response) => {
-    const {page = 1, limit = 10, order = 'asc'} = request.query
+    const { page = 1, limit = 10, order = 'asc' } = request.query
 
     const result = await this.transactionsDAO.getDuplicatedTransactions(Number(page), Number(limit), order)
 

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -222,6 +222,14 @@ class TransactionsController {
       return response.status(500).send({ message: 'internal server error' })
     } while (true)
   }
+
+  getDuplicatedTransactions = async (request, response) => {
+    const {page = 1, limit = 10, order = 'asc'} = request.query
+
+    const result = await this.transactionsDAO.getDuplicatedTransactions(Number(page), Number(limit), order)
+
+    response.send(result)
+  }
 }
 
 module.exports = TransactionsController

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -46,7 +46,7 @@ module.exports = class TransactionsDAO {
         ...row,
         block_hash: dup.block_hash,
         block_height: dup.block_height,
-        timestamp: dup.timestamp,
+        timestamp: dup.timestamp ? new Date(dup.timestamp) : null,
         type: StateTransitionEnum[row.type],
         batch_type: BatchEnum[row.batch_type],
         status: 'FAIL',

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -381,6 +381,7 @@ module.exports = class TransactionsDAO {
         'blocks',
         this.knex.raw('UPPER(state_transition_duplicates.block_hash) = blocks.hash')
       )
+      .orderBy('grouped_subquery.min_id', order)
 
     const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
 

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -324,4 +324,81 @@ module.exports = class TransactionsDAO {
 
     return Number(row.total_collected_fees ?? 0)
   }
+
+  getDuplicatedTransactions = async (page, limit, order) => {
+    const fromRank = (page - 1) * limit
+
+    const groupedSubquery = this.knex('state_transition_duplicates')
+      .select('hash as tx_hash')
+      .select(this.knex.raw('count(block_hash) as duplicates_count'))
+      .select(this.knex.raw('count(*) over () as total_count'))
+      .min('id as min_id')
+      .groupBy('hash')
+      .orderBy('min_id', order)
+      .limit(limit)
+      .offset(fromRank)
+      .as('grouped_subquery')
+
+    const rows = await this.knex(groupedSubquery)
+      .select(
+        'tx_hash', 'state_transitions.data as data', 'state_transitions.gas_used as gas_used',
+        'state_transitions.error as error', 'state_transitions.type as type', 'state_transitions.batch_type as batch_type',
+        'state_transitions.index as index', 'blocks.height as block_height',
+        'blocks.hash as block_hash', 'blocks.timestamp as timestamp', 'state_transitions.owner as owner',
+        'grouped_subquery.total_count as total_count'
+      )
+      .select(this.knex.raw('\'FAIL\' as status',))
+      .leftJoin(
+        'state_transitions',
+        this.knex.raw('LOWER(state_transitions.hash) = LOWER(tx_hash)')
+      )
+      .leftJoin(
+        'state_transition_duplicates',
+        this.knex.raw('state_transition_duplicates.hash = tx_hash')
+      )
+      .leftJoin(
+        'blocks',
+        this.knex.raw('UPPER(state_transition_duplicates.block_hash) = blocks.hash')
+      )
+
+    const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
+
+    const owners = rows.filter(row => row.owner).map(row => row.owner.trim())
+
+    const aliasDocuments = await getAliasDocumentForIdentifiers(owners, this.sdk)
+
+    const resultSet = rows.reduce((acc, row) => {
+      const aliasDocument = row.owner ? aliasDocuments[row.owner.trim()] : undefined
+
+      const aliases = aliasDocument ? [getAliasFromDocument(aliasDocument)] : []
+
+      const duplicate = Transaction.fromRow({
+        ...row,
+        type: StateTransitionEnum[row.type],
+        batch_type: BatchEnum[row.batch_type],
+        aliases
+      })
+
+      const entry = acc.find(item => item.hash === row.tx_hash)
+
+      if (entry) {
+        entry.duplicates.push(duplicate)
+      } else {
+        acc.push(Transaction.fromRow({
+          ...row,
+          block_hash: null,
+          block_height: null,
+          timestamp: null,
+          type: StateTransitionEnum[row.type],
+          batch_type: BatchEnum[row.batch_type],
+          aliases,
+          duplicates: [duplicate]
+        }))
+      }
+
+      return acc
+    }, [])
+
+    return new PaginatedResultSet(resultSet, page, limit, totalCount)
+  }
 }

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -12,6 +12,11 @@ module.exports = class TransactionsDAO {
   }
 
   getTransactionByHash = async (hash) => {
+    const duplicatesSubquery = this.knex('state_transition_duplicates')
+      .leftJoin({ dup_blocks: 'blocks' }, this.knex.raw('UPPER(state_transition_duplicates.block_hash) = dup_blocks.hash'))
+      .whereRaw('LOWER(state_transition_duplicates.hash) = LOWER(state_transitions.hash)')
+      .select(this.knex.raw("json_agg(json_build_object('block_hash', dup_blocks.hash, 'block_height', dup_blocks.height, 'timestamp', dup_blocks.timestamp))"))
+
     const [row] = await this.knex('state_transitions')
       .select(
         'state_transitions.hash as tx_hash', 'state_transitions.data as data',
@@ -20,6 +25,7 @@ module.exports = class TransactionsDAO {
         'state_transitions.index as index', 'blocks.height as block_height',
         'blocks.hash as block_hash', 'blocks.timestamp as timestamp', 'state_transitions.owner as owner'
       )
+      .select(duplicatesSubquery.as('duplicates'))
       .whereILike('state_transitions.hash', hash)
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
 
@@ -35,11 +41,26 @@ module.exports = class TransactionsDAO {
       aliases.push(getAliasFromDocument(aliasDocument))
     }
 
+    const duplicates = row.duplicates
+      ? row.duplicates.map(dup => Transaction.fromRow({
+        ...row,
+        block_hash: dup.block_hash,
+        block_height: dup.block_height,
+        timestamp: dup.timestamp,
+        type: StateTransitionEnum[row.type],
+        batch_type: BatchEnum[row.batch_type],
+        status: 'FAIL',
+        aliases,
+        duplicates: null
+      }))
+      : undefined
+
     return Transaction.fromRow(
       {
         ...row,
         type: StateTransitionEnum[row.type],
-        aliases
+        aliases,
+        duplicates
       })
   }
 

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -368,7 +368,7 @@ module.exports = class TransactionsDAO {
         'blocks.hash as block_hash', 'blocks.timestamp as timestamp', 'state_transitions.owner as owner',
         'grouped_subquery.total_count as total_count'
       )
-      .select(this.knex.raw('\'FAIL\' as status',))
+      .select(this.knex.raw('\'FAIL\' as status'))
       .leftJoin(
         'state_transitions',
         this.knex.raw('LOWER(state_transitions.hash) = LOWER(tx_hash)')

--- a/packages/api/src/models/Transaction.js
+++ b/packages/api/src/models/Transaction.js
@@ -17,8 +17,9 @@ module.exports = class Transaction {
   incoming
   base58Address
   bech32mAddress
+  duplicates
 
-  constructor (hash, index, blockHash, blockHeight, type, batchType, data, timestamp, gasUsed, status, error, owner, incoming, base58Address, bech32mAddress) {
+  constructor (hash, index, blockHash, blockHeight, type, batchType, data, timestamp, gasUsed, status, error, owner, incoming, base58Address, bech32mAddress, duplicates) {
     this.hash = hash ?? null
     this.index = index ?? null
     this.blockHash = blockHash ?? null
@@ -34,6 +35,7 @@ module.exports = class Transaction {
     this.incoming = incoming ?? null
     this.base58Address = base58Address ?? null
     this.bech32mAddress = bech32mAddress ?? null
+    this.duplicates = duplicates
   }
 
   /* eslint-disable camelcase */
@@ -53,14 +55,15 @@ module.exports = class Transaction {
     aliases,
     incoming,
     base58_address,
-    bech32m_address
+    bech32m_address,
+    duplicates
   }) {
     let decodedError = null
 
     try {
       if (typeof error === 'string') {
         const { serializedError } = cbor.decode(Buffer.from(error, 'base64'))?.data
-        decodedError = ConsensusErrorWASM.deserialize(serializedError)?.message
+        decodedError = ConsensusErrorWASM.deserialize(new Uint8Array(serializedError))?.message
       }
     } catch (e) {
       console.error(e)
@@ -76,7 +79,8 @@ module.exports = class Transaction {
         identifier: owner?.trim() ?? null,
         aliases: aliases ?? []
       },
-      incoming, base58_address, bech32m_address
+      incoming, base58_address, bech32m_address,
+      duplicates
     )
   }
 }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -733,7 +733,7 @@ module.exports = ({
       }
     },
     {
-      path: '/transactions/duplicated',
+      path: '/transactions/duplicates',
       method: 'GET',
       handler: transactionsController.getDuplicatedTransactions,
       schema: {

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -731,6 +731,14 @@ module.exports = ({
       schema: {
         querystring: { $ref: 'paginationOptions#' }
       }
+    },
+    {
+      path: '/transactions/duplicated',
+      method: 'GET',
+      handler: transactionsController.getDuplicatedTransactions,
+      schema: {
+        querystring: { $ref: 'paginationOptions#' }
+      }
     }
   ]
 

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -1672,6 +1672,5 @@ describe('Transaction routes', () => {
       assert.equal(body.pagination.total, duplicatedTxs.length)
       assert.deepEqual(body.resultSet, expectedResultSet)
     })
-
   })
 })

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -1537,7 +1537,6 @@ describe('Transaction routes', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       const expectedResultSet = duplicatedTxs
-        .toReversed()
         .slice(0, 10)
         .map(({ transaction, block, duplicatesCount }) => ({
           base58Address: null,
@@ -1608,7 +1607,6 @@ describe('Transaction routes', () => {
         .expect('Content-Type', 'application/json; charset=utf-8')
 
       const expectedResultSet = duplicatedTxs
-        .toReversed()
         .slice(6, 9)
         .map(({ transaction, block, duplicatesCount }) => ({
           base58Address: null,

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -224,6 +224,84 @@ describe('Transaction routes', () => {
         .expect(404)
         .expect('Content-Type', 'application/json; charset=utf-8')
     })
+
+    it('should return transaction with duplicates', async () => {
+      const [, transaction] = transactions
+      const duplicatesCount = 2
+
+      for (let i = 0; i < duplicatesCount; i++) {
+        await fixtures.stateTransitionDuplicate(knex, {
+          hash: transaction.transaction.hash,
+          block_hash: transaction.block.hash
+        })
+      }
+
+      const { body } = await client.get(`/transaction/${transaction.transaction.hash}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedTransaction = {
+        base58Address: null,
+        bech32mAddress: null,
+        incoming: null,
+        blockHash: transaction.block.hash,
+        blockHeight: transaction.block.height,
+        data: '{}',
+        hash: transaction.transaction.hash,
+        index: transaction.transaction.index,
+        timestamp: transaction.block.timestamp.toISOString(),
+        type: StateTransitionEnum[transaction.transaction.type],
+        batchType: BatchTypeEnum[transaction.transaction.batch_type] ?? null,
+        gasUsed: 0,
+        status: 'FAIL',
+        error: 'Cannot deserialize',
+        owner: {
+          identifier: transaction.transaction.owner,
+          aliases: [
+            {
+              alias: 'alias.dash',
+              contested: true,
+              documentId: 'AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW',
+              status: 'ok',
+              timestamp: aliasTimestamp.toISOString()
+            }
+          ]
+        },
+        duplicates: Array.from({ length: duplicatesCount }, () => ({
+          base58Address: null,
+          bech32mAddress: null,
+          incoming: null,
+          blockHash: transaction.block.hash,
+          blockHeight: transaction.block.height,
+          data: '{}',
+          hash: transaction.transaction.hash,
+          index: transaction.transaction.index,
+          timestamp: transaction.block.timestamp.toISOString(),
+          type: StateTransitionEnum[transaction.transaction.type],
+          batchType: BatchTypeEnum[transaction.transaction.batch_type] ?? null,
+          gasUsed: 0,
+          status: 'FAIL',
+          error: 'Cannot deserialize',
+          owner: {
+            identifier: transaction.transaction.owner,
+            aliases: [
+              {
+                alias: 'alias.dash',
+                contested: true,
+                documentId: 'AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW',
+                status: 'ok',
+                timestamp: aliasTimestamp.toISOString()
+              }
+            ]
+          },
+          duplicates: null
+        }))
+      }
+
+      assert.deepEqual(expectedTransaction, body)
+
+      await knex.raw('DELETE FROM state_transition_duplicates')
+    })
   })
 
   describe('getTransactions()', async () => {
@@ -1594,5 +1672,6 @@ describe('Transaction routes', () => {
       assert.equal(body.pagination.total, duplicatedTxs.length)
       assert.deepEqual(body.resultSet, expectedResultSet)
     })
+
   })
 })

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -1532,7 +1532,7 @@ describe('Transaction routes', () => {
     })
 
     it('should return paginated duplicated transactions', async () => {
-      const { body } = await client.get('/transactions/duplicated')
+      const { body } = await client.get('/transactions/duplicates')
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
@@ -1602,7 +1602,7 @@ describe('Transaction routes', () => {
     })
 
     it('should be able to walk through pages', async () => {
-      const { body } = await client.get('/transactions/duplicated?page=3&limit=3')
+      const { body } = await client.get('/transactions/duplicates?page=3&limit=3')
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -1427,4 +1427,172 @@ describe('Transaction routes', () => {
       assert.deepEqual(expectedSeriesData.reverse(), body)
     })
   })
+
+  describe('getDuplicatedTransactions()', async () => {
+    let duplicatedTxs
+
+    before(async () => {
+      const baseTxs = transactions
+        .filter(t => t.transaction.type === StateTransitionEnum.BATCH)
+        .slice(0, 15)
+
+      duplicatedTxs = []
+
+      for (let i = 0; i < baseTxs.length; i++) {
+        const { transaction, block } = baseTxs[i]
+        const duplicatesCount = i % 2 === 0 ? 2 : 3
+
+        for (let j = 0; j < duplicatesCount; j++) {
+          await fixtures.stateTransitionDuplicate(knex, {
+            hash: transaction.hash,
+            block_hash: block.hash
+          })
+        }
+
+        duplicatedTxs.push({ transaction, block, duplicatesCount })
+      }
+    })
+
+    it('should return paginated duplicated transactions', async () => {
+      const { body } = await client.get('/transactions/duplicated')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedResultSet = duplicatedTxs
+        .toReversed()
+        .slice(0, 10)
+        .map(({ transaction, block, duplicatesCount }) => ({
+          base58Address: null,
+          bech32mAddress: null,
+          incoming: null,
+          hash: transaction.hash.toLowerCase(),
+          index: transaction.index,
+          blockHash: null,
+          blockHeight: null,
+          type: StateTransitionEnum[transaction.type],
+          batchType: BatchTypeEnum[transaction.batch_type] ?? null,
+          data: '{}',
+          timestamp: null,
+          gasUsed: transaction.gas_used,
+          status: 'FAIL',
+          error: transaction.error,
+          owner: {
+            identifier: transaction.owner,
+            aliases: [
+              {
+                alias: 'alias.dash',
+                contested: true,
+                documentId: 'AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW',
+                status: 'ok',
+                timestamp: aliasTimestamp.toISOString()
+              }
+            ]
+          },
+          duplicates: Array.from({ length: duplicatesCount }, () => ({
+            base58Address: null,
+            bech32mAddress: null,
+            incoming: null,
+            hash: transaction.hash.toLowerCase(),
+            index: transaction.index,
+            blockHash: block.hash,
+            blockHeight: block.height,
+            type: StateTransitionEnum[transaction.type],
+            batchType: BatchTypeEnum[transaction.batch_type] ?? null,
+            data: '{}',
+            timestamp: block.timestamp.toISOString(),
+            gasUsed: transaction.gas_used,
+            status: 'FAIL',
+            error: transaction.error,
+            owner: {
+              identifier: transaction.owner,
+              aliases: [
+                {
+                  alias: 'alias.dash',
+                  contested: true,
+                  documentId: 'AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW',
+                  status: 'ok',
+                  timestamp: aliasTimestamp.toISOString()
+                }
+              ]
+            }
+          }))
+        }))
+
+      assert.equal(body.pagination.page, 1)
+      assert.equal(body.pagination.limit, 10)
+      assert.equal(body.pagination.total, duplicatedTxs.length)
+      assert.deepEqual(body.resultSet, expectedResultSet)
+    })
+
+    it('should be able to walk through pages', async () => {
+      const { body } = await client.get('/transactions/duplicated?page=3&limit=3')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedResultSet = duplicatedTxs
+        .toReversed()
+        .slice(6, 9)
+        .map(({ transaction, block, duplicatesCount }) => ({
+          base58Address: null,
+          bech32mAddress: null,
+          incoming: null,
+          hash: transaction.hash.toLowerCase(),
+          index: transaction.index,
+          blockHash: null,
+          blockHeight: null,
+          type: StateTransitionEnum[transaction.type],
+          batchType: BatchTypeEnum[transaction.batch_type] ?? null,
+          data: '{}',
+          timestamp: null,
+          gasUsed: transaction.gas_used,
+          status: 'FAIL',
+          error: transaction.error,
+          owner: {
+            identifier: transaction.owner,
+            aliases: [
+              {
+                alias: 'alias.dash',
+                contested: true,
+                documentId: 'AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW',
+                status: 'ok',
+                timestamp: aliasTimestamp.toISOString()
+              }
+            ]
+          },
+          duplicates: Array.from({ length: duplicatesCount }, () => ({
+            base58Address: null,
+            bech32mAddress: null,
+            incoming: null,
+            hash: transaction.hash.toLowerCase(),
+            index: transaction.index,
+            blockHash: block.hash,
+            blockHeight: block.height,
+            type: StateTransitionEnum[transaction.type],
+            batchType: BatchTypeEnum[transaction.batch_type] ?? null,
+            data: '{}',
+            timestamp: block.timestamp.toISOString(),
+            gasUsed: transaction.gas_used,
+            status: 'FAIL',
+            error: transaction.error,
+            owner: {
+              identifier: transaction.owner,
+              aliases: [
+                {
+                  alias: 'alias.dash',
+                  contested: true,
+                  documentId: 'AQV2G2Egvqk8jwDBAcpngjKYcwAkck8Cecs5AjYJxfvW',
+                  status: 'ok',
+                  timestamp: aliasTimestamp.toISOString()
+                }
+              ]
+            }
+          }))
+        }))
+
+      assert.equal(body.pagination.page, 3)
+      assert.equal(body.pagination.limit, 3)
+      assert.equal(body.pagination.total, duplicatedTxs.length)
+      assert.deepEqual(body.resultSet, expectedResultSet)
+    })
+  })
 })

--- a/packages/api/test/utils/drop.js
+++ b/packages/api/test/utils/drop.js
@@ -2,7 +2,7 @@ const { getKnex } = require('../../src/utils')
 
 const knex = getKnex()
 
-const tables = ['token_holders', 'platform_address_transitions', 'data_contract_transitions', 'token_transitions', 'tokens', 'masternode_votes', 'transfers', 'documents', 'identity_aliases', 'identities', 'data_contracts', 'state_transitions', 'blocks', 'validators', 'refinery_schema_history', 'platform_addresses']
+const tables = ['state_transition_duplicates', 'token_holders', 'platform_address_transitions', 'data_contract_transitions', 'token_transitions', 'tokens', 'masternode_votes', 'transfers', 'documents', 'identity_aliases', 'identities', 'data_contracts', 'state_transitions', 'blocks', 'validators', 'refinery_schema_history', 'platform_addresses']
 
 const sql = tables.reduce((acc, table) => acc + `DROP TABLE IF EXISTS ${table};`, '')
 

--- a/packages/api/test/utils/fixtures.js
+++ b/packages/api/test/utils/fixtures.js
@@ -622,7 +622,25 @@ const fixtures = {
       id: result.id
     }
   },
+  stateTransitionDuplicate: async (knex, { hash, block_hash }) => {
+    if (!hash) {
+      throw new Error('hash must be provided for stateTransitionDuplicate fixture')
+    }
+    if (!block_hash) {
+      throw new Error('block_hash must be provided for stateTransitionDuplicate fixture')
+    }
+
+    const row = {
+      hash: hash.toLowerCase(),
+      block_hash: block_hash.toLowerCase()
+    }
+
+    const [result] = await knex('state_transition_duplicates').insert(row).returning('id')
+
+    return { ...row, id: result.id }
+  },
   cleanup: async (knex) => {
+    await knex.raw('DELETE FROM state_transition_duplicates')
     await knex.raw('DELETE FROM platform_address_transitions')
     await knex.raw('DELETE FROM platform_addresses')
     await knex.raw('DELETE FROM token_holders')

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -20,6 +20,7 @@ Reference:
 * [Validator Blocks Statistic](#validator-stats-by-protxhash)
 * [Transaction by hash](#transaction-by-hash)
 * [Transactions](#transactions)
+* [Duplicated Transactions](#duplicated-transactions)
 * [Data Contract By Identifier](#data-contract-by-identifier)
 * [RAW Data Contract By Identifier](#raw-data-contract-by-identifier)
 * [Data Contracts](#data-contracts)
@@ -592,6 +593,8 @@ Get a transaction (state transition) by hash
 
 Status can be either `SUCCESS` or `FAIL`. In case of error tx, message will appear in the `error` field as Base64 string
 
+If the same state transition hash was observed in more than one block, the response includes a `duplicates` field — an array of `Transaction` objects, one per occurrence. Each duplicate has `status: "FAIL"` and its own `blockHash`/`blockHeight`/`timestamp`; all other fields are inherited from the canonical state transition.
+
 ```
 GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF
 
@@ -617,7 +620,26 @@ GET /transaction/DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEE
           "txHash": "2508B35FDDB3E2E797D4F2CB9C1FAEE71D4DC43B91CE2043BEC8CE2B4A442DD7"
         }
       ]
-    }
+    },
+    "duplicates": [
+        {
+            "blockHash": "9EFA730C41CE9408F9732E4C72A4DAE7A2701AF0F7B1DCE8A72F163E285BEBF3",
+            "blockHeight": 153886,
+            "data": "{}",
+            "hash": "DEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEFDEADBEEF",
+            "index": 0,
+            "timestamp": "2024-03-18T10:14:02.350Z",
+            "type": 0,
+            "gasUsed": 1337000,
+            "status": "FAIL",
+            "error": null,
+            "owner": {
+              "identifier": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
+              "aliases": []
+            },
+            "duplicates": null
+        }, ...
+    ]
 }
 ```
 
@@ -710,6 +732,68 @@ GET /transactions?=1&limit=10&orderBy=id&order=asc&owner=6q9RFbeea73tE31LGMBLFZh
                 "identifier": "DTFPLKMVbnkVQWEfkxHX7Ch62ytjvbtqH6eG1TF3nMbD",
                 "aliases": []
             }
+        }, ...
+    ]
+}
+```
+Response codes:
+```
+200: OK
+500: Internal Server Error
+```
+---
+### Duplicated Transactions
+Return paged set of state transitions that appeared in more than one block. Each entry is a `Transaction` object representing the shared state-transition data (`blockHash`/`blockHeight`/`timestamp` are `null` since the tx spans multiple blocks), with a `duplicates` array listing one `Transaction` per occurrence (status `FAIL`, with the per-block fields populated).
+
+* `limit` cannot be more then 100
+* `page` cannot be less then 1
+* `order` can be `asc` or `desc`
+
+```
+GET /transactions/duplicated?page=1&limit=10&order=asc
+
+{
+    "pagination": {
+        "page": 1,
+        "limit": 10,
+        "total": 3
+    },
+    "resultSet": [
+      {
+            "hash": "1ba0895d9785eff87f0d69d1a7bc22b54e73d267fae3d14513af5c56358b42a5",
+            "index": 0,
+            "blockHash": null,
+            "blockHeight": null,
+            "type": "BATCH",
+            "batchType": "DOCUMENT_CREATE",
+            "data": "AgG5BZwAg32+...",
+            "timestamp": null,
+            "gasUsed": 1040160,
+            "status": "FAIL",
+            "error": null,
+            "owner": {
+                "identifier": "DTFPLKMVbnkVQWEfkxHX7Ch62ytjvbtqH6eG1TF3nMbD",
+                "aliases": []
+            },
+            "duplicates": [
+                {
+                    "hash": "1ba0895d9785eff87f0d69d1a7bc22b54e73d267fae3d14513af5c56358b42a5",
+                    "index": 0,
+                    "blockHash": "9EFA730C41CE9408F9732E4C72A4DAE7A2701AF0F7B1DCE8A72F163E285BEBF3",
+                    "blockHeight": 153886,
+                    "type": "BATCH",
+                    "batchType": "DOCUMENT_CREATE",
+                    "data": "AgG5BZwAg32+...",
+                    "timestamp": "2025-07-15T14:42:41.156Z",
+                    "gasUsed": 1040160,
+                    "status": "FAIL",
+                    "error": null,
+                    "owner": {
+                        "identifier": "DTFPLKMVbnkVQWEfkxHX7Ch62ytjvbtqH6eG1TF3nMbD",
+                        "aliases": []
+                    }
+                }, ...
+            ]
         }, ...
     ]
 }

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -750,7 +750,7 @@ Return paged set of state transitions that appeared in more than one block. Each
 * `order` can be `asc` or `desc`
 
 ```
-GET /transactions/duplicated?page=1&limit=10&order=asc
+GET /transactions/duplicates?page=1&limit=10&order=asc
 
 {
     "pagination": {

--- a/packages/indexer/migrations/V74__add_state_transition_duplicates.sql
+++ b/packages/indexer/migrations/V74__add_state_transition_duplicates.sql
@@ -4,13 +4,5 @@ CREATE TABLE state_transition_duplicates (
     block_hash char(64) NOT NULL
 );
 
-INSERT INTO state_transition_duplicates (hash, block_hash)
-VALUES
-    ('1ba0895d9785eff87f0d69d1a7bc22b54e73d267fae3d14513af5c56358b42a5', '9efa730c41ce9408f9732e4c72a4dae7a2701af0f7b1dce8a72f163e285bebf3'),
-    ('e2d274c484eceaba06864d537367e550bd278c09cb783ace45b999b92b02f8ef', '9efa730c41ce9408f9732e4c72a4dae7a2701af0f7b1dce8a72f163e285bebf3'),
-    ('cf285c01204a6811a06b4b60f599870fffd77f2ceafd771c2608ed56a4454ca0', 'f72dd58af03236502b13cefa918bc13089a689b4cd06dbd44bbe277d1a77e0ab'),
-    ('9be24f6636e70d288c82a37c6b6ff9622e8f3f7c2b6dccb44d005305febeadad', 'f72dd58af03236502b13cefa918bc13089a689b4cd06dbd44bbe277d1a77e0ab'),
-    ('90acb14d5e1d8807c96979e2f331f9efbfcef33133fd71c0841211d65bafdb6e', 'afdcdba8ee9d612cebb3bc9d3d2e8c01e6334c772d555c66316b50970e22b92c');
-
 CREATE INDEX state_transition_duplicates_hash ON state_transition_duplicates (hash);
 CREATE INDEX state_transition_duplicates_block_hash ON state_transition_duplicates (block_hash);

--- a/packages/indexer/migrations/V74__add_state_transition_duplicates.sql
+++ b/packages/indexer/migrations/V74__add_state_transition_duplicates.sql
@@ -1,0 +1,16 @@
+CREATE TABLE state_transition_duplicates (
+    id SERIAL PRIMARY KEY,
+    hash char(64) NOT NULL,
+    block_hash char(64) NOT NULL
+);
+
+INSERT INTO state_transition_duplicates (hash, block_hash)
+VALUES
+    ('1ba0895d9785eff87f0d69d1a7bc22b54e73d267fae3d14513af5c56358b42a5', '9efa730c41ce9408f9732e4c72a4dae7a2701af0f7b1dce8a72f163e285bebf3'),
+    ('e2d274c484eceaba06864d537367e550bd278c09cb783ace45b999b92b02f8ef', '9efa730c41ce9408f9732e4c72a4dae7a2701af0f7b1dce8a72f163e285bebf3'),
+    ('cf285c01204a6811a06b4b60f599870fffd77f2ceafd771c2608ed56a4454ca0', 'f72dd58af03236502b13cefa918bc13089a689b4cd06dbd44bbe277d1a77e0ab'),
+    ('9be24f6636e70d288c82a37c6b6ff9622e8f3f7c2b6dccb44d005305febeadad', 'f72dd58af03236502b13cefa918bc13089a689b4cd06dbd44bbe277d1a77e0ab'),
+    ('90acb14d5e1d8807c96979e2f331f9efbfcef33133fd71c0841211d65bafdb6e', 'afdcdba8ee9d612cebb3bc9d3d2e8c01e6334c772d555c66316b50970e22b92c');
+
+CREATE INDEX state_transition_duplicates_hash ON state_transition_duplicates (hash);
+CREATE INDEX state_transition_duplicates_block_hash ON state_transition_duplicates (block_hash);

--- a/packages/indexer/src/indexer/mod.rs
+++ b/packages/indexer/src/indexer/mod.rs
@@ -1,4 +1,4 @@
-use crate::processor::psql::PSQLProcessor;
+use crate::processor::psql::{state_transition_duplicates, PSQLProcessor};
 use crate::utils::TenderdashRpcApi;
 use dashcore_rpc::{Auth, Client};
 use std::cell::Cell;
@@ -51,10 +51,15 @@ impl Indexer {
         let processor = PSQLProcessor::new(dashcore_rpc, network);
         let txs_to_skip_str = env::var("TXS_TO_SKIP").unwrap_or(String::from(""));
 
-        let txs_to_skip = txs_to_skip_str
+        let mut txs_to_skip = txs_to_skip_str
             .split(",")
+            .filter(|s| !s.is_empty())
             .map(|s| String::from(s).to_lowercase())
             .collect::<Vec<String>>();
+
+        for (hash, block_hash) in state_transition_duplicates(network) {
+            txs_to_skip.push(format!("{}:{}", block_hash, hash).to_lowercase());
+        }
 
         let start_height = processor.get_latest_block_height().await;
 

--- a/packages/indexer/src/processor/psql/dao/mod.rs
+++ b/packages/indexer/src/processor/psql/dao/mod.rs
@@ -9,6 +9,7 @@ pub mod documents;
 pub mod identities;
 pub mod masternode_votes;
 mod platform_addresses;
+pub mod state_transition_duplicates;
 pub mod state_transitions;
 pub mod token;
 mod token_holders;

--- a/packages/indexer/src/processor/psql/dao/state_transition_duplicates.rs
+++ b/packages/indexer/src/processor/psql/dao/state_transition_duplicates.rs
@@ -1,0 +1,21 @@
+use crate::processor::psql::PostgresDAO;
+use deadpool_postgres::Transaction;
+
+impl PostgresDAO {
+    pub async fn create_state_transition_duplicate(
+        &self,
+        hash: String,
+        block_hash: String,
+        sql_transaction: &Transaction<'_>,
+    ) {
+        let query =
+            "INSERT INTO state_transition_duplicates(hash, block_hash) VALUES ($1, $2);";
+
+        let stmt = sql_transaction.prepare_cached(query).await.unwrap();
+
+        sql_transaction
+            .execute(&stmt, &[&hash, &block_hash])
+            .await
+            .unwrap();
+    }
+}

--- a/packages/indexer/src/processor/psql/handlers/handle_init_chain.rs
+++ b/packages/indexer/src/processor/psql/handlers/handle_init_chain.rs
@@ -30,6 +30,9 @@ impl PSQLProcessor {
         self.process_system_data_contract(SystemDataContract::WalletUtils, sql_transaction)
             .await;
 
+        println!("Processing state transition duplicates");
+        self.process_state_transition_duplicates(sql_transaction).await;
+
         println!("Finished initChain processing");
     }
 }

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -56,12 +56,14 @@ pub struct PSQLProcessor {
 // ST HASH, BLOCK HASH
 pub fn state_transition_duplicates(network: Network) -> Vec<(String, String)> {
     match network {
-        Network::Dash => vec![],
+        Network::Dash => vec![
+            ("35C08D574302D32D7160E603D8159042C8606BE12FD97D952CF5FD40DB57313C".into(), "67DF4322B8062C17326414BC4D2D0FDDA60C44C44EF08592DFB01A3F125A0F25".into())
+        ],
         Network::Testnet => vec![
+            ("1ba0895d9785eff87f0d69d1a7bc22b54e73d267fae3d14513af5c56358b42a5".into(), "9efa730c41ce9408f9732e4c72a4dae7a2701af0f7b1dce8a72f163e285bebf3".into()),
             ("e2d274c484eceaba06864d537367e550bd278c09cb783ace45b999b92b02f8ef".into(), "9efa730c41ce9408f9732e4c72a4dae7a2701af0f7b1dce8a72f163e285bebf3".into()),
             ("cf285c01204a6811a06b4b60f599870fffd77f2ceafd771c2608ed56a4454ca0".into(), "f72dd58af03236502b13cefa918bc13089a689b4cd06dbd44bbe277d1a77e0ab".into()),
             ("9be24f6636e70d288c82a37c6b6ff9622e8f3f7c2b6dccb44d005305febeadad".into(), "f72dd58af03236502b13cefa918bc13089a689b4cd06dbd44bbe277d1a77e0ab".into()),
-            ("90acb14d5e1d8807c96979e2f331f9efbfcef33133fd71c0841211d65bafdb6e".into(), "afdcdba8ee9d612cebb3bc9d3d2e8c01e6334c772d555c66316b50970e22b92c".into()),
         ],
         _ => vec![],
     }

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -50,6 +50,21 @@ pub struct PSQLProcessor {
     dao: PostgresDAO,
     platform_explorer_identifier: Identifier,
     dashcore_rpc: Client,
+    network: Network,
+}
+
+// ST HASH, BLOCK HASH
+pub fn state_transition_duplicates(network: Network) -> Vec<(String, String)> {
+    match network {
+        Network::Dash => vec![],
+        Network::Testnet => vec![
+            ("e2d274c484eceaba06864d537367e550bd278c09cb783ace45b999b92b02f8ef".into(), "9efa730c41ce9408f9732e4c72a4dae7a2701af0f7b1dce8a72f163e285bebf3".into()),
+            ("cf285c01204a6811a06b4b60f599870fffd77f2ceafd771c2608ed56a4454ca0".into(), "f72dd58af03236502b13cefa918bc13089a689b4cd06dbd44bbe277d1a77e0ab".into()),
+            ("9be24f6636e70d288c82a37c6b6ff9622e8f3f7c2b6dccb44d005305febeadad".into(), "f72dd58af03236502b13cefa918bc13089a689b4cd06dbd44bbe277d1a77e0ab".into()),
+            ("90acb14d5e1d8807c96979e2f331f9efbfcef33133fd71c0841211d65bafdb6e".into(), "afdcdba8ee9d612cebb3bc9d3d2e8c01e6334c772d555c66316b50970e22b92c".into()),
+        ],
+        _ => vec![],
+    }
 }
 
 impl PSQLProcessor {
@@ -70,6 +85,22 @@ impl PSQLProcessor {
             dao,
             platform_explorer_identifier,
             dashcore_rpc,
+            network,
+        }
+    }
+
+    pub async fn process_state_transition_duplicates(
+        &self,
+        sql_transaction: &Transaction<'_>,
+    ) -> () {
+        for (hash, block_hash) in state_transition_duplicates(self.network) {
+            self.dao
+                .create_state_transition_duplicate(
+                    hash.to_string(),
+                    block_hash.to_string(),
+                    sql_transaction,
+                )
+                .await;
         }
     }
 


### PR DESCRIPTION
# Issue
In platform chain some time we can see duplicated transaction. That's not logical, but it's exist. We need to implement mechanism which allows to show duplicated transactions on PE

# Things done
- Implemented endpoint `/transactions/duplicates`, which shows all duplicated transaction in network
- Updated migrations, now we have `state_transition_duplicates` table, which filling manually
- Updated `getTransactionByHash()`, now he also return transaction duplicates if they exist
- Updated old tests and implemented new
- Updated tests utils for new table
- Implement `state_transition_duplicates` in indexer which returns st duplicates by network and then insert it to `state_transition_duplicates` duplicates
- Updated `README.md`