### PR TITLE
feat: identities & contestedResources filters

### DIFF
--- a/packages/frontend/src/app/contestedResources/ContestedResources.js
+++ b/packages/frontend/src/app/contestedResources/ContestedResources.js
@@ -14,7 +14,8 @@ import {
   Container,
   Heading
 } from '@chakra-ui/react'
-import { ContestedResourcesList } from '../../components/contestedResources'
+import { ContestedResourcesList, ContestedResourcesFilter, useContestedResourcesFilters } from '../../components/contestedResources'
+import './ContestedResourcesPage.scss'
 
 const paginateConfig = {
   pageSize: {
@@ -29,15 +30,16 @@ function ContestedResources ({ defaultPage = 1, defaultPageSize }) {
   const [total, setTotal] = useState(1)
   const [pageSize, setPageSize] = useState(defaultPageSize || paginateConfig.pageSize.default)
   const [currentPage, setCurrentPage] = useState(defaultPage ? defaultPage - 1 : 0)
+  const { filters, setFilters } = useContestedResourcesFilters()
   const pageCount = Math.ceil(total / pageSize) ? Math.ceil(total / pageSize) : 1
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
-  const fetchData = (page, count) => {
+  const fetchData = (page, count, currentFilters) => {
     setContestedResources(state => ({ ...state, loading: true }))
 
-    Api.getContestedResources(page, count, 'desc')
+    Api.getContestedResources(page, count, 'desc', undefined, currentFilters)
       .then(res => {
         if (res.pagination.total === -1) {
           setCurrentPage(0)
@@ -48,7 +50,11 @@ function ContestedResources ({ defaultPage = 1, defaultPageSize }) {
       .catch(err => fetchHandlerError(setContestedResources, err))
   }
 
-  useEffect(() => fetchData(currentPage + 1, pageSize), [pageSize, currentPage])
+  useEffect(
+    () => fetchData(currentPage + 1, pageSize, filters),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pageSize, currentPage, JSON.stringify(filters)]
+  )
 
   useEffect(() => {
     const page = parseInt(searchParams.get('page')) || paginateConfig.defaultPage
@@ -72,11 +78,20 @@ function ContestedResources ({ defaultPage = 1, defaultPageSize }) {
 
   return (
     <Container
-      className={'InfoBlock ContestedResources'}
+      className={'InfoBlock ContestedResources ContestedResourcesPage'}
       maxW={'container.maxPageW'}
       my={8}
     >
       <Heading className={'InfoBlock__Title'} as={'h1'}>Contested Resources</Heading>
+
+      <ContestedResourcesFilter
+        initialFilters={filters}
+        className={'ContestedResourcesPage__Filters'}
+        onFilterChange={(next) => {
+          setFilters(next)
+          setCurrentPage(0)
+        }}
+      />
 
       {!contestedResources.error
         ? <>

--- a/packages/frontend/src/app/contestedResources/ContestedResourcesPage.scss
+++ b/packages/frontend/src/app/contestedResources/ContestedResourcesPage.scss
@@ -1,0 +1,5 @@
+.ContestedResourcesPage {
+  &__Filters {
+    margin: 0.75rem 0 1.5rem;
+  }
+}

--- a/packages/frontend/src/app/dataContract/[identifier]/DataContract.js
+++ b/packages/frontend/src/app/dataContract/[identifier]/DataContract.js
@@ -181,6 +181,7 @@ function DataContract ({ identifier }) {
                 <DocumentsFilter
                   onFilterChange={handleDocFiltersChange}
                   isMobile={isMobile}
+                  excludeFilters={['transition_type', 'status']}
                   className={'DataContract__DocumentsFilter'}
                 />
               </Box>

--- a/packages/frontend/src/app/identities/Identities.js
+++ b/packages/frontend/src/app/identities/Identities.js
@@ -130,7 +130,14 @@ function Identities ({ defaultPage = 1, defaultPageSize, defaultShowAll = false 
 
         {!identities.error
           ? !identities.loading
-              ? <IdentitiesList identities={identities.data.resultSet}/>
+              ? <IdentitiesList
+                  identities={identities.data.resultSet}
+                  sort={{ order_by: filters.order_by, order: filters.order }}
+                  onSortChange={(next) => {
+                    setFilters(next)
+                    setCurrentPage(0)
+                  }}
+                />
               : <LoadingList itemsCount={pageSize}/>
           : <ErrorMessageBlock h={20}/>
         }

--- a/packages/frontend/src/app/identities/Identities.js
+++ b/packages/frontend/src/app/identities/Identities.js
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 import * as Api from '../../util/Api'
 import IdentitiesList from '../../components/identities/IdentitiesList'
+import { IdentitiesFilter, useIdentitiesFilters } from '../../components/identities'
 import Pagination from '../../components/pagination'
 import PageSizeSelector from '../../components/pageSizeSelector/PageSizeSelector'
 import { LoadingList } from '../../components/loading'
@@ -34,15 +35,16 @@ function Identities ({ defaultPage = 1, defaultPageSize, defaultShowAll = false 
   const [pageSize, setPageSize] = useState(defaultPageSize || paginateConfig.pageSize.default)
   const [currentPage, setCurrentPage] = useState(defaultPage ? defaultPage - 1 : 0)
   const [showAll, setShowAll] = useState(defaultShowAll)
+  const { filters, setFilters } = useIdentitiesFilters()
   const pageCount = Math.ceil(total / pageSize)
   const router = useRouter()
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
-  const fetchData = (page, count, includeMasternodes) => {
+  const fetchData = (page, count, includeMasternodes, currentFilters) => {
     setIdentities(state => ({ ...state, loading: true }))
 
-    Api.getIdentities(page, count, 'desc', undefined, { includeMasternodes })
+    Api.getIdentities(page, count, 'desc', undefined, { includeMasternodes, filters: currentFilters })
       .then(res => {
         if (res.pagination.total === -1) {
           setCurrentPage(0)
@@ -53,7 +55,11 @@ function Identities ({ defaultPage = 1, defaultPageSize, defaultShowAll = false 
       .catch(err => fetchHandlerError(setIdentities, err))
   }
 
-  useEffect(() => fetchData(currentPage + 1, pageSize, showAll), [pageSize, currentPage, showAll])
+  useEffect(
+    () => fetchData(currentPage + 1, pageSize, showAll, filters),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [pageSize, currentPage, showAll, JSON.stringify(filters)]
+  )
 
   useEffect(() => {
     const page = parseInt(searchParams.get('page')) || paginateConfig.defaultPage
@@ -112,6 +118,15 @@ function Identities ({ defaultPage = 1, defaultPageSize, defaultShowAll = false 
             />
           </FormControl>
         </Flex>
+
+        <IdentitiesFilter
+          initialFilters={filters}
+          className={'IdentitiesPage__Filters'}
+          onFilterChange={(next) => {
+            setFilters(next)
+            setCurrentPage(0)
+          }}
+        />
 
         {!identities.error
           ? !identities.loading

--- a/packages/frontend/src/app/identities/IdentitiesPage.scss
+++ b/packages/frontend/src/app/identities/IdentitiesPage.scss
@@ -1,6 +1,10 @@
 @import '../../styles/variables.scss';
 
 .IdentitiesPage {
+  &__Filters {
+    margin: 0.75rem 0 1.5rem;
+  }
+
   &__IntroTabs {
     width: 100%;
     padding-bottom: 0;

--- a/packages/frontend/src/app/identity/[identifier]/Identity.js
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.js
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import * as Api from '../../../util/Api'
 import TransactionsList from '../../../components/transactions/TransactionsList'
+import TransactionsFilter from '../../../components/transactions/TransactionsFilter'
 import DocumentsList from '../../../components/documents/DocumentsList'
 import DataContractsList from '../../../components/dataContracts/DataContractsList'
 import TransfersList from '../../../components/transfers/TransfersList'
@@ -37,6 +38,7 @@ function Identity ({ identifier }) {
   const [tokens, setTokens] = useState({ data: {}, props: { currentPage: 0 }, loading: true, error: false })
   const [transactions, setTransactions] = useState({ data: {}, props: { currentPage: 0 }, loading: true, error: false })
   const [transfers, setTransfers] = useState({ data: {}, props: { currentPage: 0 }, loading: true, error: false })
+  const [txFilters, setTxFilters] = useState({})
   const [rate, setRate] = useState({ data: {}, loading: true, error: false })
   const pageSize = 10
   const [activeTab, setActiveTab] = useState(tabs.indexOf(defaultTabName.toLowerCase()) !== -1
@@ -66,10 +68,16 @@ function Identity ({ identifier }) {
     if (!identifier) return
     setLoadingProp(setTransactions)
 
-    Api.getTransactionsByIdentity(identifier, transactions.props.currentPage + 1, pageSize, 'desc')
-      .then(paginatedDataContracts => fetchHandlerSuccess(setTransactions, paginatedDataContracts))
+    Api.getTransactions(transactions.props.currentPage + 1, pageSize, 'desc', { owner: identifier, ...txFilters })
+      .then(paginatedTransactions => fetchHandlerSuccess(setTransactions, paginatedTransactions))
       .catch(err => fetchHandlerError(setTransactions, err))
-  }, [identifier, transactions.props.currentPage])
+  }, [identifier, transactions.props.currentPage, txFilters])
+
+  const txFiltersChangeHandler = (newFilters) => {
+    if (JSON.stringify(newFilters) === JSON.stringify(txFilters)) return
+    setTxFilters(newFilters)
+    setTransactions(prev => ({ ...prev, props: { ...prev.props, currentPage: 0 } }))
+  }
 
   useEffect(() => {
     if (!identifier) return
@@ -174,6 +182,11 @@ function Identity ({ identifier }) {
           </TabList>
           <TabPanels>
             <TabPanel>
+              <TransactionsFilter
+                onFilterChange={txFiltersChangeHandler}
+                excludeFilters={['owner']}
+                className={'IdentityPage__TransactionsFilter'}
+              />
               {!transactions.error
                 ? <TransactionsList
                     transactions={transactions.data?.resultSet}

--- a/packages/frontend/src/app/identity/[identifier]/Identity.js
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.js
@@ -5,6 +5,7 @@ import * as Api from '../../../util/Api'
 import TransactionsList from '../../../components/transactions/TransactionsList'
 import TransactionsFilter from '../../../components/transactions/TransactionsFilter'
 import DocumentsList from '../../../components/documents/DocumentsList'
+import { DocumentsFilter } from '../../../components/documents/DocumentsFilter'
 import DataContractsList from '../../../components/dataContracts/DataContractsList'
 import TransfersList from '../../../components/transfers/TransfersList'
 import { fetchHandlerSuccess, fetchHandlerError, paginationHandler, setLoadingProp } from '../../../util'
@@ -39,6 +40,7 @@ function Identity ({ identifier }) {
   const [transactions, setTransactions] = useState({ data: {}, props: { currentPage: 0 }, loading: true, error: false })
   const [transfers, setTransfers] = useState({ data: {}, props: { currentPage: 0 }, loading: true, error: false })
   const [txFilters, setTxFilters] = useState({})
+  const [docFilters, setDocFilters] = useState({})
   const [rate, setRate] = useState({ data: {}, loading: true, error: false })
   const pageSize = 10
   const [activeTab, setActiveTab] = useState(tabs.indexOf(defaultTabName.toLowerCase()) !== -1
@@ -101,10 +103,16 @@ function Identity ({ identifier }) {
     if (!identifier) return
     setLoadingProp(setDocuments)
 
-    Api.getDocumentsByIdentity(identifier, documents.props.currentPage + 1, pageSize, 'desc')
+    Api.getDocumentsByIdentity(identifier, documents.props.currentPage + 1, pageSize, 'desc', docFilters)
       .then(paginatedDataContracts => fetchHandlerSuccess(setDocuments, paginatedDataContracts))
       .catch(err => fetchHandlerError(setDocuments, err))
-  }, [identifier, documents.props.currentPage])
+  }, [identifier, documents.props.currentPage, docFilters])
+
+  const docFiltersChangeHandler = (newFilters) => {
+    if (JSON.stringify(newFilters) === JSON.stringify(docFilters)) return
+    setDocFilters(newFilters)
+    setDocuments(prev => ({ ...prev, props: { ...prev.props, currentPage: 0 } }))
+  }
 
   useEffect(() => {
     if (!identifier) return
@@ -217,9 +225,15 @@ function Identity ({ identifier }) {
               }
             </TabPanel>
             <TabPanel>
+              <DocumentsFilter
+                onFilterChange={docFiltersChangeHandler}
+                excludeFilters={['owner', 'revision']}
+                className={'IdentityPage__DocumentsFilter'}
+              />
               {!documents.error
                 ? <DocumentsList
                     documents={documents.data?.resultSet}
+                    showDataContract={true}
                     pagination={{
                       onPageChange: pagination => paginationHandler(setDocuments, pagination.selected),
                       pageCount: Math.ceil(documents.data?.pagination?.total / pageSize) || 1,

--- a/packages/frontend/src/app/identity/[identifier]/Identity.scss
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.scss
@@ -6,4 +6,8 @@
     width: max-content;
     margin-left: auto;
   }
+
+  &__TransactionsFilter {
+    margin: 0.75rem 0 1.5rem;
+  }
 }

--- a/packages/frontend/src/app/identity/[identifier]/Identity.scss
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.scss
@@ -7,7 +7,8 @@
     margin-left: auto;
   }
 
-  &__TransactionsFilter {
+  &__TransactionsFilter,
+  &__DocumentsFilter {
     margin: 0.75rem 0 1.5rem;
   }
 }

--- a/packages/frontend/src/components/contestedResources/ContestedResourcesFilter.js
+++ b/packages/frontend/src/components/contestedResources/ContestedResourcesFilter.js
@@ -1,0 +1,95 @@
+import { Filters } from '../filters'
+import { Identifier } from '../data'
+
+const VotingStateEnum = {
+  PENDING: 'pending',
+  FINISHED: 'finished'
+}
+
+const votingStateOptions = [
+  { label: 'Pending', title: 'Voting in progress', value: VotingStateEnum.PENDING },
+  { label: 'Finished', title: 'Voting finished', value: VotingStateEnum.FINISHED }
+]
+
+const pickVotingState = (values) => {
+  if (!Array.isArray(values) || values.length === 0 || values.length === votingStateOptions.length) {
+    return undefined
+  }
+  return values[0]
+}
+
+const toIsVotingFinished = (votingState) => {
+  if (votingState === VotingStateEnum.FINISHED) return true
+  if (votingState === VotingStateEnum.PENDING) return false
+  return undefined
+}
+
+const filtersConfig = {
+  voting_state: {
+    type: 'multiselect',
+    label: 'Status',
+    title: 'Filter by voting status',
+    options: votingStateOptions,
+    defaultValue: [VotingStateEnum.PENDING, VotingStateEnum.FINISHED],
+    formatValue: (values) => pickVotingState(values) || undefined,
+    isAllSelected: (values) => values.length === votingStateOptions.length
+  },
+  document_type_name: {
+    label: 'Document type',
+    title: 'Filter by document type',
+    type: 'input',
+    placeholder: 'e.g. domain',
+    defaultValue: '',
+    formatValue: (value) => value || null
+  },
+  contract_id: {
+    label: 'Data Contract',
+    title: 'Filter by Data Contract',
+    type: 'search',
+    entityType: 'dataContracts',
+    placeholder: 'Data Contract name or identifier',
+    defaultValue: '',
+    formatValue: (value) => value || null,
+    mobileTagRenderer: (value) => (
+      <Identifier avatar={true} ellipsis={true} styles={['highlight-both']}>{value}</Identifier>
+    )
+  },
+  timestamp: {
+    label: 'Created date',
+    title: 'Creation date range',
+    type: 'daterange',
+    defaultValue: null,
+    formatValue: (value) => {
+      return `${value?.start ? `from ${value?.start?.toLocaleDateString()}` : ''} ${value?.end ? `to ${value?.end?.toLocaleDateString()}` : ''}`
+    }
+  }
+}
+
+export const ContestedResourcesFilter = ({ initialFilters, onFilterChange, isMobile, className }) => {
+  return (
+    <Filters
+      filtersConfig={filtersConfig}
+      initialFilters={initialFilters}
+      onFilterChange={(values) => {
+        const payload = {
+          is_voting_finished: toIsVotingFinished(pickVotingState(values.voting_state)),
+          document_type_name: values.document_type_name || undefined,
+          contract_id: values.contract_id || undefined,
+          timestamp_start: values.timestamp_start
+            ? new Date(values.timestamp_start).toISOString()
+            : undefined,
+          timestamp_end: values.timestamp_end
+            ? new Date(values.timestamp_end).toISOString()
+            : undefined
+        }
+        onFilterChange && onFilterChange(payload)
+      }}
+      isMobile={isMobile}
+      className={`ContestedResourcesFilter ${className || ''}`}
+      buttonText={'Add filter'}
+      applyOnChange={false}
+    />
+  )
+}
+
+export default ContestedResourcesFilter

--- a/packages/frontend/src/components/contestedResources/hooks/index.js
+++ b/packages/frontend/src/components/contestedResources/hooks/index.js
@@ -1,0 +1,1 @@
+export * from './useContestedResourcesFilters'

--- a/packages/frontend/src/components/contestedResources/hooks/useContestedResourcesFilters.js
+++ b/packages/frontend/src/components/contestedResources/hooks/useContestedResourcesFilters.js
@@ -1,0 +1,37 @@
+import { useQueryState } from 'nuqs'
+
+export const useContestedResourcesFilters = () => {
+  const [timestampStart, setTimestampStart] = useQueryState('timestamp_start', { scroll: false, shallow: true })
+  const [timestampEnd, setTimestampEnd] = useQueryState('timestamp_end', { scroll: false, shallow: true })
+  const [documentTypeName, setDocumentTypeName] = useQueryState('document_type_name', { scroll: false, shallow: true })
+  const [contractId, setContractId] = useQueryState('contract_id', { scroll: false, shallow: true })
+  const [isVotingFinished, setIsVotingFinished] = useQueryState('is_voting_finished', { scroll: false, shallow: true })
+
+  const filters = {
+    timestamp_start: timestampStart || undefined,
+    timestamp_end: timestampEnd || undefined,
+    document_type_name: documentTypeName || undefined,
+    contract_id: contractId || undefined,
+    is_voting_finished: isVotingFinished === 'true' ? true : isVotingFinished === 'false' ? false : undefined
+  }
+
+  const setFilters = (next) => {
+    if (!next) return
+
+    if ('timestamp_start' in next) setTimestampStart(next.timestamp_start || null)
+    if ('timestamp_end' in next) setTimestampEnd(next.timestamp_end || null)
+    if ('document_type_name' in next) setDocumentTypeName(next.document_type_name || null)
+    if ('contract_id' in next) setContractId(next.contract_id || null)
+    if ('is_voting_finished' in next) {
+      setIsVotingFinished(
+        next.is_voting_finished === true || next.is_voting_finished === 'true'
+          ? 'true'
+          : next.is_voting_finished === false || next.is_voting_finished === 'false'
+            ? 'false'
+            : null
+      )
+    }
+  }
+
+  return { filters, setFilters }
+}

--- a/packages/frontend/src/components/contestedResources/index.js
+++ b/packages/frontend/src/components/contestedResources/index.js
@@ -4,3 +4,5 @@ export { default as ContestedResourceTotalCard } from './ContestedResourceTotalC
 export { default as ContestedResourceDigestCard } from './ContestedResourceDigestCard'
 export { default as VoteStatusValue } from './VoteStatusValue'
 export { default as MasternodeVotesFilters } from './MasternodeVotesFilters'
+export { ContestedResourcesFilter } from './ContestedResourcesFilter'
+export * from './hooks'

--- a/packages/frontend/src/components/documents/DocumentsFilter.js
+++ b/packages/frontend/src/components/documents/DocumentsFilter.js
@@ -1,5 +1,39 @@
 import Identifier from '@components/data/Identifier'
 import { Filters } from '@components/filters'
+import BatchTypeBadge from '@components/transactions/BatchTypeBadge'
+import { Badge } from '@chakra-ui/react'
+import { BatchActions } from '../../enums/batchTypes'
+
+const actionOptions = [
+  {
+    label: <BatchTypeBadge batchType={'DOCUMENT_CREATE'} />,
+    title: BatchActions.DOCUMENT_CREATE.title,
+    value: 'DOCUMENT_CREATE'
+  },
+  {
+    label: <BatchTypeBadge batchType={'DOCUMENT_REPLACE'} />,
+    title: BatchActions.DOCUMENT_REPLACE.title,
+    value: 'DOCUMENT_REPLACE'
+  },
+  {
+    label: <BatchTypeBadge batchType={'DOCUMENT_DELETE'} />,
+    title: BatchActions.DOCUMENT_DELETE.title,
+    value: 'DOCUMENT_DELETE'
+  }
+]
+
+const statusOptions = [
+  {
+    label: <Badge colorScheme={'green'}>Active</Badge>,
+    title: 'Active',
+    value: 'active'
+  },
+  {
+    label: <Badge colorScheme={'red'}>Deleted</Badge>,
+    title: 'Deleted',
+    value: 'deleted'
+  }
+]
 
 const filtersConfig = {
   document_type_name: {
@@ -9,6 +43,32 @@ const filtersConfig = {
     placeholder: 'ex. note',
     defaultValue: '',
     formatValue: (value) => value || null
+  },
+  transition_type: {
+    type: 'multiselect',
+    label: 'Action',
+    title: 'Action',
+    options: actionOptions,
+    defaultValue: actionOptions.map(a => a.value),
+    formatValue: (values) => {
+      if (values.length === actionOptions.length) return null
+      if (values.length > 1) return `${values.length} actions`
+      return actionOptions.find(a => a.value === values[0])?.title || values[0]
+    },
+    isAllSelected: (values) => values.length === actionOptions.length
+  },
+  status: {
+    type: 'multiselect',
+    label: 'Status',
+    title: 'Status',
+    options: statusOptions,
+    defaultValue: statusOptions.map(s => s.value),
+    formatValue: (values) => {
+      if (values.length === statusOptions.length) return null
+      if (values.length > 1) return `${values.length} values`
+      return statusOptions.find(s => s.value === values[0])?.title || values[0]
+    },
+    isAllSelected: (values) => values.length === statusOptions.length
   },
   owner: {
     label: 'Owner',
@@ -53,14 +113,28 @@ const filtersConfig = {
 export const DocumentsFilter = ({
   onFilterChange,
   isMobile,
-  className
+  className,
+  excludeFilters = []
 }) => {
+  const config = excludeFilters.length
+    ? Object.fromEntries(Object.entries(filtersConfig).filter(([key]) => !excludeFilters.includes(key)))
+    : filtersConfig
+
   return (
     <Filters
-      filtersConfig={filtersConfig}
+      filtersConfig={config}
       onFilterChange={(values) => {
+        const statusValues = values.status
+        let deleted
+        if (Array.isArray(statusValues) && statusValues.length === 1) {
+          // 'true' / 'false' as strings — prepareQueryParams drops falsy values
+          deleted = statusValues[0] === 'deleted' ? 'true' : 'false'
+        }
+
         const payload = {
           document_type_name: values.document_type_name || undefined,
+          transition_type: values.transition_type || undefined,
+          deleted,
           owner: values.owner || undefined,
           revision_min: values.revision_min || undefined,
           revision_max: values.revision_max || undefined,

--- a/packages/frontend/src/components/documents/DocumentsList.js
+++ b/packages/frontend/src/components/documents/DocumentsList.js
@@ -11,7 +11,8 @@ export default function DocumentsList ({
   headerStyles,
   pagination,
   loading,
-  itemsCount = 10
+  itemsCount = 10,
+  showDataContract = false
 }) {
   const headerExtraClass = {
     default: '',
@@ -20,6 +21,7 @@ export default function DocumentsList ({
 
   return (
     <div className={'DocumentsList'}>
+      <div className={'DocumentsList__Table'}>
       <Grid className={`DocumentsList__ColumnTitles ${headerExtraClass?.[headerStyles] || ''}`}>
         <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--Timestamp'}>
           Time
@@ -36,8 +38,8 @@ export default function DocumentsList ({
         <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--Identifier'}>
           Identifier
         </GridItem>
-        <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--Owner'}>
-          Owner
+        <GridItem className={`DocumentsList__ColumnTitle DocumentsList__ColumnTitle--${showDataContract ? 'DataContract' : 'Owner'}`}>
+          {showDataContract ? 'Data Contract' : 'Owner'}
         </GridItem>
         <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--Gas'}>
           Gas
@@ -48,17 +50,18 @@ export default function DocumentsList ({
       </Grid>
 
       {!loading
-        ? <div className={'DocumentsList__Items'}>
+        ? <>
           {documents?.map((document, key) =>
-            <DocumentsListItem document={document} key={key}/>
+            <DocumentsListItem document={document} showDataContract={showDataContract} key={key}/>
           )}
           {documents?.length === 0 &&
             <EmptyListMessage>There are no documents created yet.</EmptyListMessage>
           }
           {documents === undefined && <ErrorMessageBlock/>}
-        </div>
+        </>
         : <LoadingList itemsCount={itemsCount}/>
       }
+      </div>
 
       {pagination &&
         <Pagination

--- a/packages/frontend/src/components/documents/DocumentsList.scss
+++ b/packages/frontend/src/components/documents/DocumentsList.scss
@@ -6,9 +6,18 @@
   @include mixins.List;
   container-type: inline-size;
 
+  &__Table {
+    @include docs.ColumnsMaster();
+
+    // loading / empty / error states span the full table width
+    > *:not(.DocumentsList__ColumnTitles):not(.DocumentsListItem) {
+      grid-column: 1 / -1;
+    }
+  }
+
   &__ColumnTitles {
     @include mixins.defListTitles;
-    @include docs.Columns();
+    @include docs.SubColumns();
   }
 
   &__ColumnTitle {

--- a/packages/frontend/src/components/documents/DocumentsListItem.js
+++ b/packages/frontend/src/components/documents/DocumentsListItem.js
@@ -1,4 +1,4 @@
-import { Badge, Grid, GridItem } from '@chakra-ui/react'
+import { Badge, GridItem } from '@chakra-ui/react'
 import { Alias, Identifier, NotActive, TimeDelta } from '../data'
 import { LinkContainer } from '../ui/containers'
 import BatchTypeBadge from '../transactions/BatchTypeBadge'
@@ -7,69 +7,87 @@ import { useRouter } from 'next/navigation'
 import { findActiveAlias } from '../../util'
 import './DocumentsListItem.scss'
 
-function DocumentsListItem ({ document }) {
+function DocumentsListItem ({ document, showDataContract = false }) {
   const activeAlias = findActiveAlias(document?.owner?.aliases)
   const router = useRouter()
 
   return (
     <Link href={`/document/${document?.identifier}`} className={'DocumentsListItem'}>
-      <Grid className={'DocumentsListItem__Content'}>
-        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Timestamp'}>
-          <TimeDelta endDate={document?.timestamp}/>
-        </GridItem>
+      <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Timestamp'}>
+        <TimeDelta endDate={document?.timestamp}/>
+      </GridItem>
 
-        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--TransitionType'}>
-          {document?.transitionType
-            ? <BatchTypeBadge batchType={document.transitionType}/>
-            : <NotActive/>
-          }
-        </GridItem>
+      <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--TransitionType'}>
+        {document?.transitionType
+          ? <BatchTypeBadge batchType={document.transitionType}/>
+          : <NotActive/>
+        }
+      </GridItem>
 
-        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--DocumentType'}>
-          {document?.documentTypeName ?? <NotActive/>}
-        </GridItem>
+      <GridItem
+        className={'DocumentsListItem__Column DocumentsListItem__Column--DocumentType'}
+        title={document?.documentTypeName || undefined}
+      >
+        {document?.documentTypeName ?? <NotActive/>}
+      </GridItem>
 
-        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Revision'}>
-          {document?.revision ?? <NotActive/>}
-        </GridItem>
+      <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Revision'}>
+        {document?.revision ?? <NotActive/>}
+      </GridItem>
 
-        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Identifier'}>
-          {document?.identifier
-            ? <Identifier ellipsis={true} styles={['highlight-both']}>{document?.identifier}</Identifier>
-            : <NotActive/>
-          }
-        </GridItem>
+      <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Identifier'}>
+        {document?.identifier
+          ? <Identifier ellipsis={true} styles={['highlight-both']}>{document?.identifier}</Identifier>
+          : <NotActive/>
+        }
+      </GridItem>
 
-        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Owner'}>
-          {document?.owner
-            ? <LinkContainer
-                className={'DocumentsListItem__ColumnContent'}
-                onClick={e => {
-                  e.stopPropagation()
-                  e.preventDefault()
-                  router.push(`/identity/${document?.owner?.identifier}`)
-                }}
-              >
-                {activeAlias
-                  ? <Alias avatarSource={document?.owner?.identifier || null}>{activeAlias?.alias}</Alias>
-                  : <Identifier ellipsis={true} avatar={true} styles={['highlight-both']}>{document?.owner?.identifier}</Identifier>
-                }
-              </LinkContainer>
-            : <NotActive/>
-          }
-        </GridItem>
+      {showDataContract
+        ? <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--DataContract'}>
+            {document?.dataContractIdentifier
+              ? <LinkContainer
+                  className={'DocumentsListItem__ColumnContent'}
+                  onClick={e => {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    router.push(`/dataContract/${document?.dataContractIdentifier}`)
+                  }}
+                >
+                  <Identifier ellipsis={true} avatar={true} styles={['highlight-both']}>{document?.dataContractIdentifier}</Identifier>
+                </LinkContainer>
+              : <NotActive/>
+            }
+          </GridItem>
+        : <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Owner'}>
+            {document?.owner
+              ? <LinkContainer
+                  className={'DocumentsListItem__ColumnContent'}
+                  onClick={e => {
+                    e.stopPropagation()
+                    e.preventDefault()
+                    router.push(`/identity/${document?.owner?.identifier}`)
+                  }}
+                >
+                  {activeAlias
+                    ? <Alias avatarSource={document?.owner?.identifier || null}>{activeAlias?.alias}</Alias>
+                    : <Identifier ellipsis={true} avatar={true} styles={['highlight-both']}>{document?.owner?.identifier}</Identifier>
+                  }
+                </LinkContainer>
+              : <NotActive/>
+            }
+          </GridItem>
+      }
 
-        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Gas'}>
-          {Number.isFinite(document?.gasUsed) ? document.gasUsed.toLocaleString() : <NotActive/>}
-        </GridItem>
+      <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Gas'}>
+        {Number.isFinite(document?.gasUsed) ? document.gasUsed.toLocaleString() : <NotActive/>}
+      </GridItem>
 
-        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Status'}>
-          {document?.deleted
-            ? <Badge colorScheme={'red'}>Deleted</Badge>
-            : <Badge colorScheme={'green'}>Active</Badge>
-          }
-        </GridItem>
-      </Grid>
+      <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Status'}>
+        {document?.deleted
+          ? <Badge colorScheme={'red'}>Deleted</Badge>
+          : <Badge colorScheme={'green'}>Active</Badge>
+        }
+      </GridItem>
     </Link>
   )
 }

--- a/packages/frontend/src/components/documents/DocumentsListItem.scss
+++ b/packages/frontend/src/components/documents/DocumentsListItem.scss
@@ -4,11 +4,7 @@
 
 .DocumentsListItem {
   @include mixins.DefListItem;
-  display: block;
-
-  &__Content {
-    @include docs.Columns();
-  }
+  @include docs.SubColumns();
 
   &__Column {
     @include docs.Column();

--- a/packages/frontend/src/components/documents/_variables.scss
+++ b/packages/frontend/src/components/documents/_variables.scss
@@ -43,6 +43,7 @@
 @mixin Column () {
   display: flex;
   align-items: center;
+  font-size: 0.75rem;
 
   &--Timestamp {
     max-width: 70px;
@@ -80,7 +81,7 @@
   &--Gas {
     justify-content: flex-end;
     font-variant-numeric: tabular-nums;
-    font-size: 0.85em;
+    font-size: 0.75rem;
     opacity: 0.85;
   }
 

--- a/packages/frontend/src/components/documents/_variables.scss
+++ b/packages/frontend/src/components/documents/_variables.scss
@@ -1,43 +1,43 @@
-@mixin Columns () {
+// Master grid: defines the column tracks once for the whole table.
+// Header and every row inherit these tracks via `subgrid` (see SubColumns),
+// so columns stay aligned AND the TYPE track sizes to the widest type on the
+// page (fit-content) — no per-row drift, no truncation for normal names.
+@mixin ColumnsMaster () {
   display: grid;
-  gap: 12px;
+  column-gap: 12px;
 
   grid-template-columns:
-    70px
-    150px
-    minmax(0, 130px)
-    50px
-    auto
-    minmax(0, 280px)
-    100px
-    80px;
+    70px               // time
+    150px              // action
+    fit-content(220px) // type
+    50px               // rev
+    minmax(0, 1fr)     // identifier
+    minmax(0, 1fr)     // owner / data contract
+    100px              // gas
+    80px;              // status
 
   @container (max-width: 64rem) {
     grid-template-columns:
-      70px
-      150px
-      minmax(0, 120px)
-      50px
-      auto
-      minmax(0, 240px)
-      80px;
+      70px 150px fit-content(220px) 50px minmax(0, 1fr) minmax(0, 1fr) 80px;
   }
 
   @container (max-width: 48rem) {
     grid-template-columns:
-      70px
-      150px
-      minmax(0, 120px)
-      50px
-      auto
-      80px;
+      70px 150px fit-content(200px) 50px minmax(0, 1fr) 80px;
   }
 
   @container (max-width: 22rem) {
-    grid-template-columns:
-      70px
-      auto;
+    grid-template-columns: 70px minmax(0, 1fr);
   }
+}
+
+// Header / row: a grid item that spans all master columns and re-uses the
+// master tracks via subgrid.
+@mixin SubColumns () {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  column-gap: 12px;
 }
 
 @mixin Column () {
@@ -71,7 +71,8 @@
     overflow: hidden;
   }
 
-  &--Owner {
+  &--Owner,
+  &--DataContract {
     overflow: hidden;
     justify-content: flex-end;
   }
@@ -94,7 +95,8 @@
   }
 
   @container (max-width: 48rem) {
-    &--Owner {
+    &--Owner,
+    &--DataContract {
       display: none;
     }
 
@@ -116,7 +118,8 @@
       display: none;
     }
 
-    &--Owner {
+    &--Owner,
+    &--DataContract {
       display: none;
     }
 

--- a/packages/frontend/src/components/identities/IdentitiesFilter.js
+++ b/packages/frontend/src/components/identities/IdentitiesFilter.js
@@ -1,0 +1,127 @@
+import { Filters } from '@components/filters'
+
+const IdentityTypeEnum = {
+  REGULAR: 'regular',
+  MASTERNODE: 'masternode'
+}
+
+const identityTypeOptions = [
+  { label: 'Regular', title: 'Regular identities', value: IdentityTypeEnum.REGULAR },
+  { label: 'Masternode', title: 'Masternode identities', value: IdentityTypeEnum.MASTERNODE }
+]
+
+const pickIdentityType = (values) => {
+  if (!Array.isArray(values) || values.length === 0 || values.length === identityTypeOptions.length) {
+    return undefined
+  }
+  return values[0]
+}
+
+const orderByOptions = [
+  { label: 'Block height', title: 'Order by block height', value: 'block_height' },
+  { label: 'Balance', title: 'Order by balance', value: 'balance' },
+  { label: 'Transactions', title: 'Order by tx count', value: 'tx_count' },
+  { label: 'Documents', title: 'Order by documents count', value: 'documents_count' }
+]
+
+const rangeFormat = ({ min, max }) => {
+  if (min && max) return `${min} – ${max}`
+  if (min) return `Min ${min}`
+  if (max) return `Max ${max}`
+  return null
+}
+
+const filtersConfig = {
+  identity_type: {
+    type: 'multiselect',
+    label: 'Type',
+    title: 'Filter by identity type',
+    options: identityTypeOptions,
+    defaultValue: [IdentityTypeEnum.REGULAR, IdentityTypeEnum.MASTERNODE],
+    formatValue: (values) => pickIdentityType(values) || undefined,
+    isAllSelected: (values) => values.length === identityTypeOptions.length
+  },
+  balance: {
+    type: 'range',
+    label: 'Balance',
+    title: 'Balance (credits)',
+    defaultValue: { min: '', max: '' },
+    minTitle: 'Min',
+    minPlaceholder: 'ex. 1000000',
+    maxTitle: 'Max',
+    maxPlaceholder: 'ex. 1000000000',
+    formatValue: rangeFormat
+  },
+  tx_count: {
+    type: 'range',
+    label: 'Transactions',
+    title: 'Total transactions',
+    defaultValue: { min: '', max: '' },
+    minTitle: 'Min',
+    minPlaceholder: 'ex. 0',
+    maxTitle: 'Max',
+    maxPlaceholder: 'ex. 1000',
+    formatValue: rangeFormat
+  },
+  documents_count: {
+    type: 'range',
+    label: 'Documents',
+    title: 'Total documents',
+    defaultValue: { min: '', max: '' },
+    minTitle: 'Min',
+    minPlaceholder: 'ex. 0',
+    maxTitle: 'Max',
+    maxPlaceholder: 'ex. 100',
+    formatValue: rangeFormat
+  },
+  data_contracts: {
+    type: 'range',
+    label: 'Data contracts',
+    title: 'Total data contracts',
+    defaultValue: { min: '', max: '' },
+    minTitle: 'Min',
+    minPlaceholder: 'ex. 0',
+    maxTitle: 'Max',
+    maxPlaceholder: 'ex. 10',
+    formatValue: rangeFormat
+  },
+  order_by: {
+    type: 'multiselect',
+    label: 'Sort by',
+    title: 'Order results by',
+    options: orderByOptions,
+    defaultValue: [],
+    formatValue: (values) => (Array.isArray(values) && values[0]) || undefined,
+    isAllSelected: () => false
+  }
+}
+
+export const IdentitiesFilter = ({ initialFilters, onFilterChange, isMobile, className }) => {
+  return (
+    <Filters
+      filtersConfig={filtersConfig}
+      initialFilters={initialFilters}
+      onFilterChange={(values) => {
+        const payload = {
+          identity_type: pickIdentityType(values.identity_type),
+          balance_min: values.balance_min || undefined,
+          balance_max: values.balance_max || undefined,
+          tx_count_min: values.tx_count_min || undefined,
+          tx_count_max: values.tx_count_max || undefined,
+          documents_count_min: values.documents_count_min || undefined,
+          documents_count_max: values.documents_count_max || undefined,
+          data_contracts_min: values.data_contracts_min || undefined,
+          data_contracts_max: values.data_contracts_max || undefined,
+          order_by: (Array.isArray(values.order_by) && values.order_by[0]) || undefined
+        }
+        onFilterChange && onFilterChange(payload)
+      }}
+      isMobile={isMobile}
+      className={`IdentitiesFilter ${className || ''}`}
+      buttonText={'Add filter'}
+      applyOnChange={false}
+    />
+  )
+}
+
+export default IdentitiesFilter

--- a/packages/frontend/src/components/identities/IdentitiesFilter.js
+++ b/packages/frontend/src/components/identities/IdentitiesFilter.js
@@ -17,13 +17,6 @@ const pickIdentityType = (values) => {
   return values[0]
 }
 
-const orderByOptions = [
-  { label: 'Block height', title: 'Order by block height', value: 'block_height' },
-  { label: 'Balance', title: 'Order by balance', value: 'balance' },
-  { label: 'Transactions', title: 'Order by tx count', value: 'tx_count' },
-  { label: 'Documents', title: 'Order by documents count', value: 'documents_count' }
-]
-
 const rangeFormat = ({ min, max }) => {
   if (min && max) return `${min} – ${max}`
   if (min) return `Min ${min}`
@@ -84,15 +77,6 @@ const filtersConfig = {
     maxTitle: 'Max',
     maxPlaceholder: 'ex. 10',
     formatValue: rangeFormat
-  },
-  order_by: {
-    type: 'multiselect',
-    label: 'Sort by',
-    title: 'Order results by',
-    options: orderByOptions,
-    defaultValue: [],
-    formatValue: (values) => (Array.isArray(values) && values[0]) || undefined,
-    isAllSelected: () => false
   }
 }
 
@@ -111,8 +95,7 @@ export const IdentitiesFilter = ({ initialFilters, onFilterChange, isMobile, cla
           documents_count_min: values.documents_count_min || undefined,
           documents_count_max: values.documents_count_max || undefined,
           data_contracts_min: values.data_contracts_min || undefined,
-          data_contracts_max: values.data_contracts_max || undefined,
-          order_by: (Array.isArray(values.order_by) && values.order_by[0]) || undefined
+          data_contracts_max: values.data_contracts_max || undefined
         }
         onFilterChange && onFilterChange(payload)
       }}

--- a/packages/frontend/src/components/identities/IdentitiesList.js
+++ b/packages/frontend/src/components/identities/IdentitiesList.js
@@ -3,16 +3,57 @@
 import IdentitiesListItem from './IdentitiesListItem'
 import { EmptyListMessage } from '../ui/lists'
 import { Grid, GridItem } from '@chakra-ui/react'
+import { ChevronUpIcon, ChevronDownIcon } from '@chakra-ui/icons'
 import Pagination from '../pagination'
 import { ErrorMessageBlock } from '../Errors'
 import { LoadingList } from '../loading'
 
 import './IdentitiesList.scss'
 
-function IdentitiesList ({ identities, headerStyles = 'default', pagination, loading, itemsCount = 10 }) {
+const SORTABLE_HEADERS = [
+  { key: 'balance', modifier: 'Balance', label: 'Balance' },
+  { key: 'tx_count', modifier: 'Txs', label: 'Transactions' },
+  { key: 'documents_count', modifier: 'Documents', label: 'Documents' },
+  { key: 'timestamp', modifier: 'Timestamp', label: 'Timestamp' }
+]
+
+function SortableHeader ({ headerKey, label, modifier, sort, onSortChange }) {
+  const isActive = sort?.order_by === headerKey
+  const direction = isActive ? sort.order : null
+  const className = [
+    'IdentitiesList__ColumnTitle',
+    `IdentitiesList__ColumnTitle--${modifier}`,
+    'IdentitiesList__ColumnTitle--Sortable',
+    isActive ? 'IdentitiesList__ColumnTitle--Active' : ''
+  ].filter(Boolean).join(' ')
+
+  const handleClick = () => {
+    if (!onSortChange) return
+    const nextOrder = isActive && direction === 'desc' ? 'asc' : 'desc'
+    onSortChange({ order_by: headerKey, order: nextOrder })
+  }
+
+  return (
+    <GridItem as={'button'} type={'button'} className={className} onClick={handleClick}>
+      {isActive
+        ? direction === 'asc'
+          ? <ChevronUpIcon w={4} h={4}/>
+          : <ChevronDownIcon w={4} h={4}/>
+        : <span aria-hidden className={'IdentitiesList__SortSpacer'}/>}
+      <span>{label}</span>
+    </GridItem>
+  )
+}
+
+function IdentitiesList ({ identities, headerStyles = 'default', pagination, loading, itemsCount = 10, sort, onSortChange }) {
   const headerExtraClass = {
     default: '',
     light: 'IdentitiesList__ColumnTitles--Light'
+  }
+
+  const sortableProps = (key) => {
+    const header = SORTABLE_HEADERS.find(h => h.key === key)
+    return { headerKey: header.key, label: header.label, modifier: header.modifier, sort, onSortChange }
   }
 
   return (
@@ -21,21 +62,13 @@ function IdentitiesList ({ identities, headerStyles = 'default', pagination, loa
         <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Identifier'}>
           Identifier
         </GridItem>
-        <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Balance'}>
-          Balance
-        </GridItem>
-        <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Txs'}>
-          Transactions
-        </GridItem>
-        <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Documents'}>
-          Documents
-        </GridItem>
+        <SortableHeader {...sortableProps('balance')}/>
+        <SortableHeader {...sortableProps('tx_count')}/>
+        <SortableHeader {...sortableProps('documents_count')}/>
         <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Contracts'}>
           Data Contracts
         </GridItem>
-        <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Timestamp'}>
-          Timestamp
-        </GridItem>
+        <SortableHeader {...sortableProps('timestamp')}/>
       </Grid>
 
       {!loading

--- a/packages/frontend/src/components/identities/IdentitiesList.js
+++ b/packages/frontend/src/components/identities/IdentitiesList.js
@@ -21,6 +21,18 @@ function IdentitiesList ({ identities, headerStyles = 'default', pagination, loa
         <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Identifier'}>
           Identifier
         </GridItem>
+        <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Balance'}>
+          Balance
+        </GridItem>
+        <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Txs'}>
+          Transactions
+        </GridItem>
+        <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Documents'}>
+          Documents
+        </GridItem>
+        <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Contracts'}>
+          Data Contracts
+        </GridItem>
         <GridItem className={'IdentitiesList__ColumnTitle IdentitiesList__ColumnTitle--Timestamp'}>
           Timestamp
         </GridItem>

--- a/packages/frontend/src/components/identities/IdentitiesList.scss
+++ b/packages/frontend/src/components/identities/IdentitiesList.scss
@@ -22,6 +22,41 @@
     &:last-child {
       text-align: right;
     }
+
+    &--Sortable {
+      cursor: pointer;
+      user-select: none;
+      background: none;
+      border: 0;
+      padding: 0;
+      font: inherit;
+      color: inherit;
+      text-align: inherit;
+      display: flex;
+      align-items: center;
+      gap: 0.25rem;
+      transition: color 0.15s ease;
+
+      &:hover { color: var(--chakra-colors-brand-normal); }
+      &:focus-visible {
+        outline: 1px solid var(--chakra-colors-brand-normal);
+        outline-offset: 2px;
+      }
+
+      &:last-child {
+        justify-content: flex-end;
+      }
+    }
+
+    &--Active {
+      color: var(--chakra-colors-brand-normal);
+    }
+  }
+
+  &__SortSpacer {
+    display: inline-block;
+    width: 1rem;
+    height: 1rem;
   }
 
   &__EmptyMessage {

--- a/packages/frontend/src/components/identities/IdentitiesList.scss
+++ b/packages/frontend/src/components/identities/IdentitiesList.scss
@@ -15,13 +15,9 @@
     @include identities.Column();
     width: 100%;
     display: block;
-    word-break: normal;
-    white-space: normal;
-    overflow-wrap: break-word;
-
-    &--Hash {
-      white-space: nowrap;
-    }
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 
     &:last-child {
       text-align: right;

--- a/packages/frontend/src/components/identities/IdentitiesListItem.js
+++ b/packages/frontend/src/components/identities/IdentitiesListItem.js
@@ -1,10 +1,15 @@
 import Link from 'next/link'
-import { Identifier, Alias, DateBlock } from '../data'
+import { Identifier, Alias, DateBlock, BigNumber, NotActive } from '../data'
 import { Grid, GridItem } from '@chakra-ui/react'
 import './IdentitiesListItem.scss'
 
+const renderCount = (value) =>
+  value != null && Number.isFinite(Number(value))
+    ? <BigNumber>{value}</BigNumber>
+    : <NotActive>—</NotActive>
+
 function IdentitiesListItem ({ identity }) {
-  const { aliases, identifier, timestamp, isSystem } = identity
+  const { aliases, identifier, timestamp, isSystem, balance, totalTxs, totalDocuments, totalDataContracts } = identity
   const activeAlias = aliases?.find(alias => alias?.status === 'ok')
 
   return (
@@ -32,6 +37,22 @@ function IdentitiesListItem ({ identity }) {
                 </Identifier>
             }
           </div>
+        </GridItem>
+
+        <GridItem className={'IdentitiesListItem__Column IdentitiesListItem__Column--Balance'}>
+          {balance != null ? <BigNumber>{balance}</BigNumber> : <NotActive>—</NotActive>}
+        </GridItem>
+
+        <GridItem className={'IdentitiesListItem__Column IdentitiesListItem__Column--Txs'}>
+          {renderCount(totalTxs)}
+        </GridItem>
+
+        <GridItem className={'IdentitiesListItem__Column IdentitiesListItem__Column--Documents'}>
+          {renderCount(totalDocuments)}
+        </GridItem>
+
+        <GridItem className={'IdentitiesListItem__Column IdentitiesListItem__Column--Contracts'}>
+          {renderCount(totalDataContracts)}
         </GridItem>
 
         <GridItem className={'IdentitiesListItem__Column IdentitiesListItem__Column--Timestamp'}>

--- a/packages/frontend/src/components/identities/IdentitiesListItem.scss
+++ b/packages/frontend/src/components/identities/IdentitiesListItem.scss
@@ -16,5 +16,14 @@
     &--Identifier {
       overflow: hidden;
     }
+
+    &--Balance,
+    &--Txs,
+    &--Documents,
+    &--Contracts {
+      font-family: $font-mono;
+      font-size: 0.75rem;
+      color: var(--chakra-colors-white-50);
+    }
   }
 }

--- a/packages/frontend/src/components/identities/_variables.scss
+++ b/packages/frontend/src/components/identities/_variables.scss
@@ -3,12 +3,36 @@
 @mixin Columns () {
   display: grid;
   gap: 1rem;
-  grid-template-columns: auto 10rem;
+  grid-template-columns: auto 12rem 7rem 7rem 8rem 11rem;
+
+  @container (max-width: 72rem) {
+    grid-template-columns: auto 12rem 7rem 7rem 11rem;
+
+    .IdentitiesList__ColumnTitle--Contracts,
+    .IdentitiesListItem__Column--Contracts { display: none; }
+  }
+
+  @container (max-width: 56rem) {
+    grid-template-columns: auto 12rem 7rem 11rem;
+
+    .IdentitiesList__ColumnTitle--Documents,
+    .IdentitiesListItem__Column--Documents { display: none; }
+  }
+
+  @container (max-width: 44rem) {
+    grid-template-columns: auto 11rem;
+
+    .IdentitiesList__ColumnTitle--Balance,
+    .IdentitiesListItem__Column--Balance,
+    .IdentitiesList__ColumnTitle--Txs,
+    .IdentitiesListItem__Column--Txs { display: none; }
+  }
 }
 
 @mixin Column () {
   display: flex;
   align-items: center;
+  white-space: nowrap;
 
   &:last-child {
     justify-content: flex-end;

--- a/packages/frontend/src/components/identities/hooks/index.js
+++ b/packages/frontend/src/components/identities/hooks/index.js
@@ -1,0 +1,1 @@
+export * from './useIdentitiesFilters'

--- a/packages/frontend/src/components/identities/hooks/useIdentitiesFilters.js
+++ b/packages/frontend/src/components/identities/hooks/useIdentitiesFilters.js
@@ -11,6 +11,7 @@ export const useIdentitiesFilters = () => {
   const [contractsMin, setContractsMin] = useQueryState('data_contracts_min', { scroll: false, shallow: true })
   const [contractsMax, setContractsMax] = useQueryState('data_contracts_max', { scroll: false, shallow: true })
   const [orderBy, setOrderBy] = useQueryState('order_by', { scroll: false, shallow: true })
+  const [order, setOrder] = useQueryState('order', { scroll: false, shallow: true })
 
   const filters = {
     identity_type: identityType === 'regular' || identityType === 'masternode' ? identityType : undefined,
@@ -22,7 +23,8 @@ export const useIdentitiesFilters = () => {
     documents_count_max: docsMax != null && docsMax !== '' ? Number(docsMax) : undefined,
     data_contracts_min: contractsMin != null && contractsMin !== '' ? Number(contractsMin) : undefined,
     data_contracts_max: contractsMax != null && contractsMax !== '' ? Number(contractsMax) : undefined,
-    order_by: orderBy || undefined
+    order_by: orderBy || undefined,
+    order: order === 'asc' || order === 'desc' ? order : undefined
   }
 
   const setFilters = (next) => {
@@ -42,6 +44,7 @@ export const useIdentitiesFilters = () => {
     if ('data_contracts_max' in next) setContractsMax(next.data_contracts_max !== '' && next.data_contracts_max != null ? String(next.data_contracts_max) : null)
 
     if ('order_by' in next) setOrderBy(next.order_by || null)
+    if ('order' in next) setOrder(next.order === 'asc' || next.order === 'desc' ? next.order : null)
   }
 
   return { filters, setFilters }

--- a/packages/frontend/src/components/identities/hooks/useIdentitiesFilters.js
+++ b/packages/frontend/src/components/identities/hooks/useIdentitiesFilters.js
@@ -1,0 +1,48 @@
+import { useQueryState } from 'nuqs'
+
+export const useIdentitiesFilters = () => {
+  const [identityType, setIdentityType] = useQueryState('identity_type', { scroll: false, shallow: true })
+  const [balanceMin, setBalanceMin] = useQueryState('balance_min', { scroll: false, shallow: true })
+  const [balanceMax, setBalanceMax] = useQueryState('balance_max', { scroll: false, shallow: true })
+  const [txCountMin, setTxCountMin] = useQueryState('tx_count_min', { scroll: false, shallow: true })
+  const [txCountMax, setTxCountMax] = useQueryState('tx_count_max', { scroll: false, shallow: true })
+  const [docsMin, setDocsMin] = useQueryState('documents_count_min', { scroll: false, shallow: true })
+  const [docsMax, setDocsMax] = useQueryState('documents_count_max', { scroll: false, shallow: true })
+  const [contractsMin, setContractsMin] = useQueryState('data_contracts_min', { scroll: false, shallow: true })
+  const [contractsMax, setContractsMax] = useQueryState('data_contracts_max', { scroll: false, shallow: true })
+  const [orderBy, setOrderBy] = useQueryState('order_by', { scroll: false, shallow: true })
+
+  const filters = {
+    identity_type: identityType === 'regular' || identityType === 'masternode' ? identityType : undefined,
+    balance_min: balanceMin || undefined,
+    balance_max: balanceMax || undefined,
+    tx_count_min: txCountMin != null && txCountMin !== '' ? Number(txCountMin) : undefined,
+    tx_count_max: txCountMax != null && txCountMax !== '' ? Number(txCountMax) : undefined,
+    documents_count_min: docsMin != null && docsMin !== '' ? Number(docsMin) : undefined,
+    documents_count_max: docsMax != null && docsMax !== '' ? Number(docsMax) : undefined,
+    data_contracts_min: contractsMin != null && contractsMin !== '' ? Number(contractsMin) : undefined,
+    data_contracts_max: contractsMax != null && contractsMax !== '' ? Number(contractsMax) : undefined,
+    order_by: orderBy || undefined
+  }
+
+  const setFilters = (next) => {
+    if (!next) return
+
+    if ('identity_type' in next) setIdentityType(next.identity_type || null)
+    if ('balance_min' in next) setBalanceMin(next.balance_min || null)
+    if ('balance_max' in next) setBalanceMax(next.balance_max || null)
+
+    if ('tx_count_min' in next) setTxCountMin(next.tx_count_min !== '' && next.tx_count_min != null ? String(next.tx_count_min) : null)
+    if ('tx_count_max' in next) setTxCountMax(next.tx_count_max !== '' && next.tx_count_max != null ? String(next.tx_count_max) : null)
+
+    if ('documents_count_min' in next) setDocsMin(next.documents_count_min !== '' && next.documents_count_min != null ? String(next.documents_count_min) : null)
+    if ('documents_count_max' in next) setDocsMax(next.documents_count_max !== '' && next.documents_count_max != null ? String(next.documents_count_max) : null)
+
+    if ('data_contracts_min' in next) setContractsMin(next.data_contracts_min !== '' && next.data_contracts_min != null ? String(next.data_contracts_min) : null)
+    if ('data_contracts_max' in next) setContractsMax(next.data_contracts_max !== '' && next.data_contracts_max != null ? String(next.data_contracts_max) : null)
+
+    if ('order_by' in next) setOrderBy(next.order_by || null)
+  }
+
+  return { filters, setFilters }
+}

--- a/packages/frontend/src/components/identities/index.js
+++ b/packages/frontend/src/components/identities/index.js
@@ -3,6 +3,9 @@ import { TopIdentitiesCards, TopIdentityCard } from './TopIdentities/TopIdentity
 import TopIdentities from './TopIdentities/TopIdentities'
 import IdentityTotalCard from './IdentityTotalCard'
 import IdentityDigestCard from './IdentityDigestCard'
+import { IdentitiesFilter } from './IdentitiesFilter'
+
+export * from './hooks'
 
 export {
   IdentitiesList,
@@ -10,5 +13,6 @@ export {
   TopIdentityCard,
   TopIdentities,
   IdentityTotalCard,
-  IdentityDigestCard
+  IdentityDigestCard,
+  IdentitiesFilter
 }

--- a/packages/frontend/src/components/transactions/TransactionsFilter.js
+++ b/packages/frontend/src/components/transactions/TransactionsFilter.js
@@ -258,10 +258,14 @@ const filtersConfig = {
   }
 }
 
-export default function TransactionsFilter ({ onFilterChange, isMobile, className }) {
+export default function TransactionsFilter ({ onFilterChange, isMobile, className, excludeFilters = [] }) {
+  const config = excludeFilters.length
+    ? Object.fromEntries(Object.entries(filtersConfig).filter(([key]) => !excludeFilters.includes(key)))
+    : filtersConfig
+
   return (
     <Filters
-      filtersConfig={filtersConfig}
+      filtersConfig={config}
       onFilterChange={onFilterChange}
       isMobile={isMobile}
       className={`TransactionsFilter ${className || ''}`}

--- a/packages/frontend/src/components/transactions/TransactionsList.js
+++ b/packages/frontend/src/components/transactions/TransactionsList.js
@@ -19,8 +19,14 @@ const columns = [
   columnHelper.accessor('timestamp', {
     header: 'Time'
   }),
+  columnHelper.accessor('status', {
+    header: 'Status'
+  }),
   columnHelper.accessor('hash', {
     header: 'Hash'
+  }),
+  columnHelper.accessor('blockHeight', {
+    header: 'Block'
   }),
   columnHelper.accessor('gasUsed', {
     header: 'Gas used'
@@ -63,8 +69,14 @@ export default function TransactionsList ({
         <GridItem className={'TransactionsList__ColumnTitle TransactionsList__ColumnTitle--Timestamp'}>
           Time
         </GridItem>
+        <GridItem className={'TransactionsList__ColumnTitle TransactionsList__ColumnTitle--Status'}>
+          Status
+        </GridItem>
         <GridItem className={'TransactionsList__ColumnTitle TransactionsList__ColumnTitle--Hash'}>
           Hash
+        </GridItem>
+        <GridItem className={'TransactionsList__ColumnTitle TransactionsList__ColumnTitle--Block'}>
+          Block
         </GridItem>
         <GridItem className={'TransactionsList__ColumnTitle TransactionsList__ColumnTitle--GasUsed'}>
           Gas used

--- a/packages/frontend/src/components/transactions/TransactionsListItem.js
+++ b/packages/frontend/src/components/transactions/TransactionsListItem.js
@@ -4,9 +4,9 @@ import Link from 'next/link'
 import { Grid, GridItem } from '@chakra-ui/react'
 import TypeBadge from './TypeBadge'
 import BatchTypeBadge from './BatchTypeBadge'
+import TransactionStatusBadge from './TransactionStatusBadge'
 import { Identifier, BigNumber, Alias, TimeDelta, NotActive } from '../data'
-import StatusIcon from './StatusIcon'
-import { RateTooltip, Tooltip } from '../ui/Tooltips'
+import { RateTooltip } from '../ui/Tooltips'
 import ImageGenerator from '../imageGenerator'
 import { useRouter } from 'next/navigation'
 import { LinkContainer } from '../ui/containers'
@@ -22,32 +22,34 @@ function TransactionsListItem ({ transaction, rate }) {
       <Grid className={'TransactionsListItem__Content'}>
         <GridItem className={'TransactionsListItem__Column TransactionsListItem__Column--Timestamp'}>
           {transaction?.timestamp
-            ? <>
-                {transaction?.status &&
-                  <Tooltip
-                    title={transaction.status}
-                    content={transaction?.error || ''}
-                    placement={'top'}
-                  >
-                    <span>
-                      <StatusIcon
-                        className={'TransactionsListItem__StatusIcon'}
-                        status={transaction.status}
-                        w={'1.125rem'}
-                        h={'1.125rem'}
-                        mr={'0.5rem'}
-                      />
-                    </span>
-                  </Tooltip>
-                }
-                <TimeDelta endDate={new Date(transaction.timestamp)}/>
-              </>
+            ? <TimeDelta endDate={new Date(transaction.timestamp)}/>
+            : <NotActive/>
+          }
+        </GridItem>
+        <GridItem className={'TransactionsListItem__Column TransactionsListItem__Column--Status'}>
+          {transaction?.status
+            ? <TransactionStatusBadge status={transaction.status}/>
             : <NotActive/>
           }
         </GridItem>
         <GridItem className={'TransactionsListItem__Column TransactionsListItem__Column--Hash'}>
           {transaction?.hash
             ? <Identifier styles={['highlight-both']}>{transaction.hash}</Identifier>
+            : <NotActive/>
+          }
+        </GridItem>
+        <GridItem className={'TransactionsListItem__Column TransactionsListItem__Column--Block'}>
+          {transaction?.blockHeight != null
+            ? <LinkContainer
+                className={'TransactionsListItem__BlockLink'}
+                onClick={e => {
+                  e.stopPropagation()
+                  e.preventDefault()
+                  router.push(`/block/${transaction?.blockHash}`)
+                }}
+              >
+                <BigNumber>{transaction.blockHeight}</BigNumber>
+              </LinkContainer>
             : <NotActive/>
           }
         </GridItem>

--- a/packages/frontend/src/components/transactions/TransactionsListItem.scss
+++ b/packages/frontend/src/components/transactions/TransactionsListItem.scss
@@ -48,6 +48,24 @@
       white-space: nowrap;
       text-align: left;
     }
+
+    &--Block {
+      font-family: $font-mono;
+      font-size: 0.75rem;
+      color: var(--chakra-colors-gray-250);
+      white-space: nowrap;
+    }
+  }
+
+  &__BlockLink {
+    position: relative;
+    z-index: 2;
+    transition: mixins.$transition-time-def;
+    border-radius: 4px;
+
+    &:hover {
+      background: rgba(255, 255, 255, .1);
+    }
   }
 
   &__AliasContainer {

--- a/packages/frontend/src/components/transactions/_variables.scss
+++ b/packages/frontend/src/components/transactions/_variables.scss
@@ -4,9 +4,11 @@
   display: grid;
   gap: 16px;
 
-  grid-template-columns: 
+  grid-template-columns:
     minmax(120px, 120px) // time
+    minmax(90px, 110px) // status
     minmax(0, 600px) // hash
+    minmax(70px, 90px) // block
     auto // gas used
     minmax(0, 400px) // owner
     150px; // type
@@ -66,7 +68,9 @@
   }
 
   @container (max-width: 810px) {
-    &--GasUsed {
+    &--GasUsed,
+    &--Status,
+    &--Block {
       display: none;
     }
   }

--- a/packages/frontend/src/util/Api.ts
+++ b/packages/frontend/src/util/Api.ts
@@ -365,7 +365,7 @@ const getIdentities = (
   const params = prepareQueryParams({
     page,
     limit,
-    order,
+    order: filters?.order ?? order,
     order_by: filters?.order_by ?? orderBy,
     identity_type:
       filters?.identity_type ?? (includeMasternodes ? null : 'regular'),

--- a/packages/frontend/src/util/Api.ts
+++ b/packages/frontend/src/util/Api.ts
@@ -307,10 +307,22 @@ const getDocumentsByIdentity = (
   identifier,
   page = 1,
   limit = 10,
-  order = 'asc'
+  order = 'asc',
+  filters = {}
 ) => {
+  const params = prepareQueryParams({
+    page,
+    limit,
+    order,
+    // document_type_name works today; transition_type/deleted/timestamp_* await backend (see #798)
+    document_type_name: filters.document_type_name,
+    transition_type: filters.transition_type,
+    deleted: filters.deleted,
+    timestamp_start: filters.timestamp_start,
+    timestamp_end: filters.timestamp_end
+  })
   return call(
-    `identity/${identifier}/documents?page=${page}&limit=${limit}&order=${order}`,
+    `identity/${identifier}/documents?${params.toString()}`,
     'GET'
   )
 }

--- a/packages/frontend/src/util/Api.ts
+++ b/packages/frontend/src/util/Api.ts
@@ -44,7 +44,10 @@ const getBlockByHash = (hash) => {
 }
 
 const getTransactionsHistory = (start, end, intervalsCount) => {
-  return call(`transactions/history?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
+  return call(
+    `transactions/history?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`,
+    'GET'
+  )
 }
 
 const prepareQueryParams = (params = {}) => {
@@ -61,7 +64,7 @@ const prepareQueryParams = (params = {}) => {
 
     if (Array.isArray(value)) {
       if (value.length > 0) {
-        value.forEach(item => {
+        value.forEach((item) => {
           if (parameterIsValid(item)) {
             queryParams.append(key, item)
           }
@@ -116,8 +119,16 @@ const getToken = (identifier) => {
   return call(`token/${identifier}`, 'GET')
 }
 
-const getTokenTransitions = (identifier, page = 1, limit = 30, order = 'asc') => {
-  return call(`token/${identifier}/transitions?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getTokenTransitions = (
+  identifier,
+  page = 1,
+  limit = 30,
+  order = 'asc'
+) => {
+  return call(
+    `token/${identifier}/transitions?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
 const getBlocks = (page = 1, limit = 30, order = 'asc', filters = {}) => {
@@ -131,11 +142,25 @@ const getBlocks = (page = 1, limit = 30, order = 'asc', filters = {}) => {
   return call(`blocks?${params.toString()}`, 'GET')
 }
 
-const getBlocksByValidator = (proTxHash, page = 1, limit = 30, order = 'asc') => {
-  return call(`validator/${proTxHash}/blocks?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getBlocksByValidator = (
+  proTxHash,
+  page = 1,
+  limit = 30,
+  order = 'asc'
+) => {
+  return call(
+    `validator/${proTxHash}/blocks?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
-const getContestedResources = (page = 1, limit = 30, order = 'asc', orderBy, filters = {}) => {
+const getContestedResources = (
+  page = 1,
+  limit = 30,
+  order = 'asc',
+  orderBy,
+  filters = {}
+) => {
   const params = prepareQueryParams({
     page: Math.max(1, parseInt(page)),
     limit: Math.max(1, parseInt(limit)),
@@ -151,7 +176,13 @@ const getContestedResourceByValue = (value) => {
   return call(`contestedResource/${value}`, 'GET')
 }
 
-const getContestedResourceVotes = (value, page = 1, limit = 30, order = 'asc', filters = {}) => {
+const getContestedResourceVotes = (
+  value,
+  page = 1,
+  limit = 30,
+  order = 'asc',
+  filters = {}
+) => {
   const params = prepareQueryParams({
     page: Math.max(1, parseInt(page)),
     limit: Math.max(1, parseInt(limit)),
@@ -166,11 +197,25 @@ const getDataContractByIdentifier = (identifier) => {
   return call(`dataContract/${identifier}`, 'GET')
 }
 
-const getDataContractTransactions = (identifier, page = 1, limit = 30, order = 'asc') => {
-  return call(`dataContract/${identifier}/transactions?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getDataContractTransactions = (
+  identifier,
+  page = 1,
+  limit = 30,
+  order = 'asc'
+) => {
+  return call(
+    `dataContract/${identifier}/transactions?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
-const getDataContracts = (page = 1, limit = 30, order = 'asc', orderBy, filters = {}) => {
+const getDataContracts = (
+  page = 1,
+  limit = 30,
+  order = 'asc',
+  orderBy,
+  filters = {}
+) => {
   const params = prepareQueryParams({
     page: Math.max(1, parseInt(page)),
     limit: Math.max(1, parseInt(limit)),
@@ -188,14 +233,31 @@ const getDocumentByIdentifier = (identifier, dataContractId, typeName) => {
   if (typeName) params.push(`document_type_name=${typeName}`)
   const queryParams = params.join('&')
 
-  return call(`document/${identifier}?${queryParams ? `?${queryParams}` : ''}`, 'GET')
+  return call(
+    `document/${identifier}?${queryParams ? `?${queryParams}` : ''}`,
+    'GET'
+  )
 }
 
-const getDocumentRevisions = (identifier, page = 1, limit = 30, order = 'asc') => {
-  return call(`document/${identifier}/revisions?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getDocumentRevisions = (
+  identifier,
+  page = 1,
+  limit = 30,
+  order = 'asc'
+) => {
+  return call(
+    `document/${identifier}/revisions?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
-const getDocumentsByDataContract = (dataContractIdentifier, page = 1, limit = 30, order = 'asc', filters = {}) => {
+const getDocumentsByDataContract = (
+  dataContractIdentifier,
+  page = 1,
+  limit = 30,
+  order = 'asc',
+  filters = {}
+) => {
   const params = prepareQueryParams({
     page,
     limit,
@@ -207,56 +269,123 @@ const getDocumentsByDataContract = (dataContractIdentifier, page = 1, limit = 30
     timestamp_start: filters.timestamp_start,
     timestamp_end: filters.timestamp_end
   })
-  return call(`dataContract/${dataContractIdentifier}/documents?${params.toString()}`, 'GET')
+  return call(
+    `dataContract/${dataContractIdentifier}/documents?${params.toString()}`,
+    'GET'
+  )
 }
 
 const getEpoch = (identifier) => {
   return call(`epoch/${identifier || ''}`, 'GET')
 }
 
-const getTransactionsByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {
-  return call(`identity/${identifier}/transactions?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getTransactionsByIdentity = (
+  identifier,
+  page = 1,
+  limit = 10,
+  order = 'asc'
+) => {
+  return call(
+    `identity/${identifier}/transactions?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
-const getDataContractsByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {
-  return call(`identity/${identifier}/dataContracts?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getDataContractsByIdentity = (
+  identifier,
+  page = 1,
+  limit = 10,
+  order = 'asc'
+) => {
+  return call(
+    `identity/${identifier}/dataContracts?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
-const getDocumentsByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {
-  return call(`identity/${identifier}/documents?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getDocumentsByIdentity = (
+  identifier,
+  page = 1,
+  limit = 10,
+  order = 'asc'
+) => {
+  return call(
+    `identity/${identifier}/documents?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
-const getWithdrawalsByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {
-  return call(`identity/${identifier}/withdrawals?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getWithdrawalsByIdentity = (
+  identifier,
+  page = 1,
+  limit = 10,
+  order = 'asc'
+) => {
+  return call(
+    `identity/${identifier}/withdrawals?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
-const getTransfersByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {
-  return call(`identity/${identifier}/transfers?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getTransfersByIdentity = (
+  identifier,
+  page = 1,
+  limit = 10,
+  order = 'asc'
+) => {
+  return call(
+    `identity/${identifier}/transfers?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
-const getTokensByIdentity = (identifier, page = 1, limit = 10, order = 'asc') => {
-  return call(`identity/${identifier}/tokens?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getTokensByIdentity = (
+  identifier,
+  page = 1,
+  limit = 10,
+  order = 'asc'
+) => {
+  return call(
+    `identity/${identifier}/tokens?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
 const getIdentity = (identifier) => {
   return call(`identity/${identifier}`, 'GET')
 }
 
-const getIdentities = (page = 1, limit = 30, order = 'asc', orderBy, { includeMasternodes = false } = {}) => {
+const getIdentities = (
+  page = 1,
+  limit = 30,
+  order = 'asc',
+  orderBy,
+  { includeMasternodes = false, filters = {} } = {}
+) => {
   const params = prepareQueryParams({
     page,
     limit,
     order,
-    order_by: orderBy,
-    // includeMasternodes=true (Show all toggle on) → omit param so backend returns everything
-    // includeMasternodes=false (default) → request only regular identities
-    identity_type: includeMasternodes ? null : 'regular'
+    order_by: filters?.order_by ?? orderBy,
+    identity_type:
+      filters?.identity_type ?? (includeMasternodes ? null : 'regular'),
+    balance_min: filters?.balance_min,
+    balance_max: filters?.balance_max,
+    tx_count_min: filters?.tx_count_min,
+    tx_count_max: filters?.tx_count_max,
+    documents_count_min: filters?.documents_count_min,
+    documents_count_max: filters?.documents_count_max,
+    data_contracts_min: filters?.data_contracts_min,
+    data_contracts_max: filters?.data_contracts_max
   })
   return call(`identities?${params.toString()}`, 'GET')
 }
 
 const getIdentitiesHistory = (start, end, intervalsCount) => {
-  return call(`identities/history?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
+  return call(
+    `identities/history?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`,
+    'GET'
+  )
 }
 
 const getValidators = (page = 1, limit = 30, order = 'asc', filters) => {
@@ -280,14 +409,25 @@ const getValidatorByMasternodeIdentity = (identity) => {
 }
 
 const getBlocksStatsByValidator = (proTxHash, start, end, intervalsCount) => {
-  return call(`validator/${proTxHash}/stats?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
+  return call(
+    `validator/${proTxHash}/stats?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`,
+    'GET'
+  )
 }
 
 const getRewardsStatsByValidator = (proTxHash, start, end, intervalsCount) => {
-  return call(`validator/${proTxHash}/rewards/stats?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`, 'GET')
+  return call(
+    `validator/${proTxHash}/rewards/stats?timestamp_start=${start}&timestamp_end=${end}${intervalsCount ? `&intervalsCount=${intervalsCount}` : ''}`,
+    'GET'
+  )
 }
 
-const getMasternodeVotes = (page = 1, limit = 10, order = 'asc', filters = {}) => {
+const getMasternodeVotes = (
+  page = 1,
+  limit = 10,
+  order = 'asc',
+  filters = {}
+) => {
   const params = prepareQueryParams({
     page: Math.max(1, parseInt(page)),
     limit: Math.max(1, parseInt(limit)),
@@ -306,8 +446,16 @@ const getPlatformAddressInfo = (hash) => {
   return call(`platformAddress/${hash}/info`, 'GET')
 }
 
-const getPlatformAddressTransitions = (hash, page = 1, limit = 10, order = 'desc') => {
-  return call(`platformAddress/${hash}/transactions?page=${page}&limit=${limit}&order=${order}`, 'GET')
+const getPlatformAddressTransitions = (
+  hash,
+  page = 1,
+  limit = 10,
+  order = 'desc'
+) => {
+  return call(
+    `platformAddress/${hash}/transactions?page=${page}&limit=${limit}&order=${order}`,
+    'GET'
+  )
 }
 
 const getStatus = () => {


### PR DESCRIPTION
# Issue
`/identities` list had no filtering and only 2 columns (Identifier, Timestamp). Some natural queries — "masternode identities with balance > X", "identities sorted by tx count" — weren't expressible.

# Things done
- Added `<IdentitiesFilter>` toolbar: Type (regular/masternode), Balance, Tx, Documents, Data Contracts range filters
- Added `useIdentitiesFilters` hook (nuqs URL state)
- Added 4 list columns: Balance, Transactions, Documents, Data Contracts. Container queries hide them progressively at 72rem / 56rem / 44rem
- Made column headers clickable for sort — Balance, Tx, Documents, Timestamp toggle direction; URL carries `?order_by=…&order=…`
- Extended `Api.getIdentities` to forward filter + order params
- Kept the existing `Show all (incl. masternode)` Switch — overlaps with the new Type filter by design (#782)
- Added `<ContestedResourcesFilter>` toolbar with Status, Document type, Data Contract, Created date filters (uses #793)
- Filed #791 for backend sort gaps (`documents_count` / `timestamp` silently fall through; `data_contracts_count` not in enum). Frontend works today for Balance + Tx sort; the others light up after backend lands

# Test plan
- [ ] Filter toolbar visible; range / multiselect filters narrow the list server-side
- [ ] Click Balance header → chevron-down, list re-sorts; second click → chevron-up
- [ ] 6 columns at wide viewport; hide progressively at narrow widths
- [ ] `npm run lint` clean

# Update — transactions columns & identity transactions tab
- TransactionsList: added **Status** and **Block** columns to the shared component. Visible on wide viewports; hidden ≤810px via container queries so the 8 existing usages (home, /transactions, identity, validator, block, dataContract, platformAddress, token activity) keep their layout
- Identity page → Transactions tab: added a filter toolbar (Type, Batch type, Status, Gas range, Date range). Reuses the existing `/transactions?owner=` endpoint + `<TransactionsFilter>` instead of `getTransactionsByIdentity` — no backend changes needed
- Added `excludeFilters` prop to `<TransactionsFilter>` (hides the Owner filter on the identity page, where owner is fixed)
- Fixes: spacing between the filter toolbar and the table; no extra table refetch when opening/closing the filter menu with no change

## Test plan (update)
- [ ] Identity → Transactions: Status/Block columns visible; collapse on narrow widths
- [ ] Filter toolbar narrows the list (Status / Type / Gas / Date); pagination resets to page 1
- [ ] Open + close filter menu without changes → no new /transactions request
- [ ] /transactions and other transaction tables unaffected
- [ ] `npm run lint` clean


# Update — identity Documents tab (data contract, full type names, filters)
- Identity → Documents: replaced the redundant **Owner** column (always the identity itself) with a **Data Contract** link column → you can now see and open each document's contract. Driven by a `showDataContract` prop on the shared `<DocumentsList>`; the dataContract page keeps Owner.
- Reworked the documents table to a single **CSS subgrid** so the header and every row share one column grid. The TYPE column (`fit-content`) now shows full document type names (e.g. `websiteRegistration`) without truncation and stays vertically aligned across rows regardless of content length (previous per-row grids drifted).
- Identity → Documents filter toolbar (Type / Action / Status / Date) by reusing `<DocumentsFilter>` (added `excludeFilters` prop + Action/Status options). Frontend already sends `transition_type` / `deleted` / `timestamp_*`.

### Backend follow-up
Blocked by #798 — the **Action / Status / Date** document filters and the **Gas** column on the identity Documents tab need the `getDocumentsByIdentity` changes in that issue. The frontend already sends the params and renders the column, so merging #798 enables them with no further frontend change. (Type filter already works; it's supported today.)

## Test plan (documents)
- [ ] Identity → Documents: Data Contract column shows per-row contract, click opens `/dataContract/{id}` (not the document)
- [ ] Long type names (`websiteRegistration`) shown in full and columns stay aligned across rows
- [ ] Filter toolbar shows Type / Action / Status / Date; Type narrows the list today
- [ ] dataContract page Documents tab unchanged (Owner/Revision present, no Action/Status)
- [ ] `npm run lint` clean
