### PR TITLE
Contested resources filters

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2046,9 +2046,13 @@ Return set of contested resources
 
 * `page` cannot be less than 1
 * `limit` cannot be more than 100
+* `document_type_name` filter by document type name
+* `contract_id` filter by data contract identifier
+* `voting_finished` bool field, filter resources whose voting deadline has passed (`true`) or is still pending (`false`)
+* `timestamp_start` and `timestamp_end` timestamp start and end of the contested resource creation date
 
 ```
-GET /contestedResources?page=1&limit=10&order=asc
+GET /contestedResources?page=1&limit=10&order=asc&document_type_name=domain&contract_id=GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec&voting_finished=true&timestamp_start=2024-08-01T00:00:00.000Z&timestamp_end=2025-08-01T00:00:00.000Z
 
 {
     "resultSet": [
@@ -2071,7 +2075,9 @@ GET /contestedResources?page=1&limit=10&order=asc
             "totalCountAbstain": 0,
             "totalCountTowardsIdentity": 1,
             "status": null,
-            "endTimestamp": "2024-09-02T22:14:06.680Z"
+            "endTimestamp": "2024-09-02T22:14:06.680Z",
+            "finished": true,
+            "towardsIdentity": null
         },
         ...
     ],
@@ -2117,7 +2123,9 @@ GET /contestedResources/stats
         "totalCountAbstain": 0,
         "totalCountTowardsIdentity": 0,
         "status": null,
-        "endTimestamp": "2025-02-19T14:08:55.321Z"
+        "endTimestamp": "2025-02-19T14:08:55.321Z",
+        "finished": true,
+        "towardsIdentity": null
     }
 }
 ```

--- a/packages/api/src/controllers/ContestedResourcesController.js
+++ b/packages/api/src/controllers/ContestedResourcesController.js
@@ -51,7 +51,7 @@ class ContestedResourcesController {
       contract_id: contractId,
       voting_finished: votingFinished,
       timestamp_start: timestampStart,
-      timestamp_end: timestampEnd,
+      timestamp_end: timestampEnd
     } = request.query
 
     const votes = await this.contestedResourcesDAO.getContestedResources(

--- a/packages/api/src/controllers/ContestedResourcesController.js
+++ b/packages/api/src/controllers/ContestedResourcesController.js
@@ -43,9 +43,27 @@ class ContestedResourcesController {
   }
 
   getContestedResources = async (request, response) => {
-    const { page = 1, limit = 10, order = 'asc' } = request.query
+    const {
+      page = 1,
+      limit = 10,
+      order = 'asc',
+      document_type_name: documentTypeName,
+      contract_id: contractId,
+      voting_finished: votingFinished,
+      timestamp_start: timestampStart,
+      timestamp_end: timestampEnd,
+    } = request.query
 
-    const votes = await this.contestedResourcesDAO.getContestedResources(Number(page ?? 1), Number(limit ?? 10), order)
+    const votes = await this.contestedResourcesDAO.getContestedResources(
+      Number(page ?? 1),
+      Number(limit ?? 10),
+      order,
+      documentTypeName,
+      contractId,
+      votingFinished,
+      timestampStart,
+      timestampEnd
+    )
 
     response.send(votes)
   }

--- a/packages/api/src/dao/ContestedResourcesDAO.js
+++ b/packages/api/src/dao/ContestedResourcesDAO.js
@@ -183,7 +183,7 @@ module.exports = class ContestedDAO {
     })
   }
 
-  getContestedResources = async (page, limit, order) => {
+  getContestedResources = async (page, limit, order, documentTypeName, contractId, votingFinished, timestampStart, timestampEnd) => {
     const fromRank = (page - 1) * limit + 1
     const toRank = fromRank + limit - 1
 
@@ -192,6 +192,17 @@ module.exports = class ContestedDAO {
       .andWhereRaw('data is not null')
       .groupBy('identifier', 'id', 'data_contract_id')
       .as('sub')
+
+    if (documentTypeName) {
+      prefundedDocumentsSubquery.where('document_type_name', documentTypeName)
+    }
+
+    if (contractId) {
+      prefundedDocumentsSubquery.whereIn(
+        'data_contract_id',
+        this.knex('data_contracts').select('id').where('identifier', contractId)
+      )
+    }
 
     const documentsPrefundingIndexeKeysSubquery = this.knex(prefundedDocumentsSubquery)
       .select('id', 'data_contract_id', 'data', 'state_transition_hash')
@@ -233,6 +244,31 @@ module.exports = class ContestedDAO {
       .select('document_id', 'resource_value')
       .select(this.knex.raw(`rank() over (order by document_id ${order})`))
       .where('value_rank', '=', '1')
+
+    if (timestampStart || timestampEnd || typeof votingFinished === 'boolean') {
+      const votingFinishedThreshold = new Date(Date.now() - CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString()
+
+      paginationRankSubquery
+        .leftJoin('documents', 'documents.id', 'ranked_documents.document_id')
+        .leftJoin('state_transitions', 'documents.state_transition_hash', 'state_transitions.hash')
+        .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
+
+      if (timestampStart) {
+        paginationRankSubquery.where('blocks.timestamp', '>=', timestampStart)
+      }
+
+      if (timestampEnd) {
+        paginationRankSubquery.where('blocks.timestamp', '<=', timestampEnd)
+      }
+
+      if (votingFinished === true) {
+        paginationRankSubquery.where('blocks.timestamp', '<', votingFinishedThreshold)
+      }
+
+      if (votingFinished === false) {
+        paginationRankSubquery.where('blocks.timestamp', '>=', votingFinishedThreshold)
+      }
+    }
 
     const rows = await this.knex
       .with('ranked_documents', paginationRankSubquery)

--- a/packages/api/src/schemas.js
+++ b/packages/api/src/schemas.js
@@ -318,6 +318,9 @@ const schemaTypes = [
       balance_max: {
         type: ['string', 'null'],
         pattern: '^[0-9]+$'
+      },
+      voting_finished: {
+        type: ['boolean', 'null'],
       }
     }
   },

--- a/packages/api/src/schemas.js
+++ b/packages/api/src/schemas.js
@@ -320,7 +320,7 @@ const schemaTypes = [
         pattern: '^[0-9]+$'
       },
       voting_finished: {
-        type: ['boolean', 'null'],
+        type: ['boolean', 'null']
       }
     }
   },

--- a/packages/api/test/integration/contested.spec.js
+++ b/packages/api/test/integration/contested.spec.js
@@ -238,6 +238,73 @@ describe('Contested documents routes', () => {
         masternodeVote
       })
     }
+
+    // Extra fixture with a different document_type_name (old timestamp, so still "finished")
+    {
+      const block = await fixtures.block(knex, {
+        timestamp: new Date(50),
+        height: 41
+      })
+      const contender = await fixtures.identity(knex, {
+        block_hash: block.hash,
+        block_height: block.height
+      })
+      const documentTransaction = await fixtures.transaction(knex, {
+        block_hash: block.hash,
+        block_height: block.height,
+        type: 0,
+        owner: contender.identifier,
+        gas_used: 11
+      })
+      const document = await fixtures.document(knex, {
+        owner: contender.identifier,
+        data_contract_id: dataContract.id,
+        document_type_name: 'other_type',
+        data: {
+          label: 'othertype01',
+          records: { identity: '36LGwPSXef8q8wpdnx4EdDeVNuqCYNAE9boDu5bxytsm' },
+          preorderSalt: 'r9uAaZjEz+lsPrpqt+rqGQ+qIxZS40Ci7wkV8cGI7k4=',
+          subdomainRules: { allowSubdomains: false },
+          normalizedLabel: 'othertype01',
+          parentDomainName: 'dash',
+          normalizedParentDomainName: 'dash'
+        },
+        prefunded_voting_balance: { parentNameAndLabel: 20000000 },
+        state_transition_hash: documentTransaction.hash
+      })
+
+      const masternodeIdentity = await fixtures.identity(knex, {
+        block_hash: block.hash,
+        block_height: block.height
+      })
+      const masternodeTransaction = await fixtures.transaction(knex, {
+        block_hash: block.hash,
+        block_height: block.height,
+        type: 0,
+        owner: masternodeIdentity.identifier,
+        gas_used: 13
+      })
+      const masternodeVote = await fixtures.masternodeVote(knex, {
+        state_transition_hash: masternodeTransaction.hash,
+        voter_identity_id: masternodeIdentity.identifier,
+        data_contract_id: dataContract.id,
+        choice: 0,
+        towards_identity_identifier: contender.identifier,
+        index_values: JSON.stringify(['dash', 'othertype01']),
+        document_type_name: 'other_type',
+        index_name: 'parentNameAndLabel'
+      })
+
+      contestedResources.push({
+        block,
+        contender,
+        documentTransaction,
+        document,
+        masternodeIdentity,
+        masternodeTransaction,
+        masternodeVote
+      })
+    }
   })
 
   after(async () => {
@@ -544,6 +611,182 @@ describe('Contested documents routes', () => {
 
       assert.deepEqual(body.resultSet, expectedResources)
     })
+
+    it('should filter contested resources by document_type_name', async () => {
+      const { body } = await client.get('/contestedResources?document_type_name=other_type&limit=100&order=asc')
+
+      const expectedResources = contestedResources
+        .filter(({ document }) => document.document_type_name === 'other_type')
+        .sort((a, b) => a.block.height - b.block.height)
+        .filter((item, pos, self) => self
+          .findIndex((resource) => resource.document.data.label === self[pos].document.data.label) === pos
+        )
+        .slice(0, 100)
+        .map((resource) => {
+          const lock = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.LOCK).length
+          const abstain = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.ABSTAIN).length
+          const towards = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.TowardsIdentity).length
+          return {
+            contenders: null,
+            indexName: resource.masternodeVote.index_name,
+            resourceValue: JSON.parse(resource.masternodeVote.index_values),
+            dataContractIdentifier: dataContract.identifier,
+            prefundedVotingBalance: null,
+            documentTypeName: resource.document.document_type_name,
+            timestamp: resource.block.timestamp.toISOString(),
+            totalGasUsed: null,
+            totalVotesGasUsed: null,
+            totalCountVotes: towards + abstain + lock,
+            totalDocumentsGasUsed: null,
+            totalCountLock: lock,
+            totalCountAbstain: abstain,
+            totalCountTowardsIdentity: towards,
+            status: null,
+            endTimestamp: new Date(resource.block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString(),
+            finished: true,
+            towardsIdentity: null
+          }
+        })
+
+      assert.equal(body.resultSet.length, expectedResources.length)
+      assert.ok(expectedResources.length > 0)
+      assert.deepEqual(body.resultSet, expectedResources)
+    })
+
+    it('should filter contested resources by contract_id', async () => {
+      const { body } = await client.get(`/contestedResources?contract_id=${dataContract.identifier}&limit=100&order=asc`)
+
+      const expectedResources = contestedResources
+        .sort((a, b) => a.block.height - b.block.height)
+        .filter((item, pos, self) => self
+          .findIndex((resource) => resource.document.data.label === self[pos].document.data.label) === pos
+        )
+        .slice(0, 100)
+        .map((resource) => {
+          const lock = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.LOCK).length
+          const abstain = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.ABSTAIN).length
+          const towards = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.TowardsIdentity).length
+          return {
+            contenders: null,
+            indexName: resource.masternodeVote.index_name,
+            resourceValue: JSON.parse(resource.masternodeVote.index_values),
+            dataContractIdentifier: dataContract.identifier,
+            prefundedVotingBalance: null,
+            documentTypeName: resource.document.document_type_name,
+            timestamp: resource.block.timestamp.toISOString(),
+            totalGasUsed: null,
+            totalVotesGasUsed: null,
+            totalCountVotes: towards + abstain + lock,
+            totalDocumentsGasUsed: null,
+            totalCountLock: lock,
+            totalCountAbstain: abstain,
+            totalCountTowardsIdentity: towards,
+            status: null,
+            endTimestamp: new Date(resource.block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString(),
+            finished: true,
+            towardsIdentity: null
+          }
+        })
+
+      assert.deepEqual(body.resultSet, expectedResources)
+    })
+
+    it('should return empty set when contract_id does not match any contract', async () => {
+      const { body } = await client.get(`/contestedResources?contract_id=${'A'.repeat(43)}&limit=100`)
+
+      assert.deepEqual(body.resultSet, [])
+    })
+
+    it('should filter contested resources by voting_finished=true and return all (every fixture is past the deadline)', async () => {
+      const { body } = await client.get('/contestedResources?voting_finished=true&limit=100&order=asc')
+
+      const expectedResources = contestedResources
+        .sort((a, b) => a.block.height - b.block.height)
+        .filter((item, pos, self) => self
+          .findIndex((resource) => resource.document.data.label === self[pos].document.data.label) === pos
+        )
+        .filter((resource) => resource.block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE <= Date.now())
+        .slice(0, 100)
+        .map((resource) => {
+          const lock = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.LOCK).length
+          const abstain = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.ABSTAIN).length
+          const towards = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.TowardsIdentity).length
+          return {
+            contenders: null,
+            indexName: resource.masternodeVote.index_name,
+            resourceValue: JSON.parse(resource.masternodeVote.index_values),
+            dataContractIdentifier: dataContract.identifier,
+            prefundedVotingBalance: null,
+            documentTypeName: resource.document.document_type_name,
+            timestamp: resource.block.timestamp.toISOString(),
+            totalGasUsed: null,
+            totalVotesGasUsed: null,
+            totalCountVotes: towards + abstain + lock,
+            totalDocumentsGasUsed: null,
+            totalCountLock: lock,
+            totalCountAbstain: abstain,
+            totalCountTowardsIdentity: towards,
+            status: null,
+            endTimestamp: new Date(resource.block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString(),
+            finished: true,
+            towardsIdentity: null
+          }
+        })
+
+      assert.deepEqual(body.resultSet, expectedResources)
+    })
+
+    it('should filter contested resources by voting_finished=false and return empty (no recent fixtures)', async () => {
+      const { body } = await client.get('/contestedResources?voting_finished=false&limit=100')
+
+      assert.deepEqual(body.resultSet, [])
+    })
+
+    it('should filter contested resources by timestamp range', async () => {
+      const timestampStart = new Date(0).toISOString()
+      const timestampEnd = new Date(2000).toISOString()
+
+      const { body } = await client.get(`/contestedResources?timestamp_start=${timestampStart}&timestamp_end=${timestampEnd}&limit=100&order=asc`)
+
+      const expectedResources = contestedResources
+        .sort((a, b) => a.block.height - b.block.height)
+        .filter((item, pos, self) => self
+          .findIndex((resource) => resource.document.data.label === self[pos].document.data.label) === pos
+        )
+        .filter((resource) =>
+          resource.block.timestamp.getTime() >= new Date(timestampStart).getTime() &&
+          resource.block.timestamp.getTime() <= new Date(timestampEnd).getTime()
+        )
+        .slice(0, 100)
+        .map((resource) => {
+          const lock = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.LOCK).length
+          const abstain = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.ABSTAIN).length
+          const towards = contestedResources.filter(votedResource => resource.masternodeVote.index_values === votedResource.masternodeVote.index_values && votedResource.masternodeVote.choice === ChoiceEnum.TowardsIdentity).length
+          return {
+            contenders: null,
+            indexName: resource.masternodeVote.index_name,
+            resourceValue: JSON.parse(resource.masternodeVote.index_values),
+            dataContractIdentifier: dataContract.identifier,
+            prefundedVotingBalance: null,
+            documentTypeName: resource.document.document_type_name,
+            timestamp: resource.block.timestamp.toISOString(),
+            totalGasUsed: null,
+            totalVotesGasUsed: null,
+            totalCountVotes: towards + abstain + lock,
+            totalDocumentsGasUsed: null,
+            totalCountLock: lock,
+            totalCountAbstain: abstain,
+            totalCountTowardsIdentity: towards,
+            status: null,
+            endTimestamp: new Date(resource.block.timestamp.getTime() + CONTESTED_RESOURCE_VOTE_DEADLINE).toISOString(),
+            finished: true,
+            towardsIdentity: null
+          }
+        })
+
+      assert.ok(expectedResources.length > 0)
+      assert.deepEqual(body.resultSet, expectedResources)
+    })
   })
 
   describe('get contested resources status', async () => {
@@ -551,9 +794,9 @@ describe('Contested documents routes', () => {
       const { body } = await client.get('/contestedResources/stats')
 
       const expectedBody = {
-        totalContestedResources: 40,
+        totalContestedResources: 41,
         totalPendingContestedResources: 0,
-        totalVotesCount: 40,
+        totalVotesCount: 41,
         expiringContestedResource: null
       }
 
@@ -601,9 +844,9 @@ describe('Contested documents routes', () => {
       const { body } = await client.get('/contestedResources/stats')
 
       const expectedBody = {
-        totalContestedResources: 41,
+        totalContestedResources: 42,
         totalPendingContestedResources: 1,
-        totalVotesCount: 40,
+        totalVotesCount: 41,
         expiringContestedResource: {
           contenders: null,
           indexName: null,

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -2013,9 +2013,13 @@ Return set of contested resources
 
 * `page` cannot be less than 1
 * `limit` cannot be more than 100
+* `document_type_name` filter by document type name
+* `contract_id` filter by data contract identifier
+* `voting_finished` bool field, filter resources whose voting deadline has passed (`true`) or is still pending (`false`)
+* `timestamp_start` and `timestamp_end` timestamp start and end of the contested resource creation date
 
 ```
-GET /contestedResources?page=1&limit=10&order=asc
+GET /contestedResources?page=1&limit=10&order=asc&document_type_name=domain&contract_id=GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec&voting_finished=true&timestamp_start=2024-08-01T00:00:00.000Z&timestamp_end=2025-08-01T00:00:00.000Z
 
 {
     "resultSet": [
@@ -2038,7 +2042,9 @@ GET /contestedResources?page=1&limit=10&order=asc
             "totalCountAbstain": 0,
             "totalCountTowardsIdentity": 1,
             "status": null,
-            "endTimestamp": "2024-09-02T22:14:06.680Z"
+            "endTimestamp": "2024-09-02T22:14:06.680Z",
+            "finished": true,
+            "towardsIdentity": null
         },
         ...
     ],
@@ -2084,7 +2090,9 @@ GET /contestedResources/stats
         "totalCountAbstain": 0,
         "totalCountTowardsIdentity": 0,
         "status": null,
-        "endTimestamp": "2025-02-19T14:08:55.321Z"
+        "endTimestamp": "2025-02-19T14:08:55.321Z",
+        "finished": true,
+        "towardsIdentity": null
     }
 }
 ```


### PR DESCRIPTION
# Issue
By #791 api must contains filters for contested resources list.

# Things done
- Implemented support for filter in contested dao by: 
  - timestamp start/end
  - document type name
  - contract id
  - is voting finished?
 - Updated docs
 - Implemented new tests