### PR TITLE
feat (frontend): duplicated transactions

### DIFF
--- a/packages/frontend/src/app/transaction/[hash]/components/Transaction.js
+++ b/packages/frontend/src/app/transaction/[hash]/components/Transaction.js
@@ -18,12 +18,13 @@ import { CopyButton } from '../../../../components/ui/Buttons'
 import {
   TypeBadge,
   FeeMultiplier,
-  TransactionStatusBadge
+  TransactionStatusBadge,
+  DuplicatedTransactions
 } from '../../../../components/transactions'
 import { ErrorMessageBlock } from '../../../../components/Errors'
 import { useBreadcrumbs } from '../../../../contexts/BreadcrumbsContext'
 import { useDecodedSTQuery, useRateQuery, useTransactionQuery } from './hooks'
-import { useParams } from 'next/navigation'
+import { useParams, usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useActiveNetwork } from 'src/contexts'
 
 import './transaction.scss'
@@ -35,6 +36,25 @@ export const Transaction = () => {
   const transaction = useTransactionQuery()
   const decodedST = useDecodedSTQuery(transaction.data)
   const rate = useRateQuery()
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+
+  // Все вхождения tx (каноническая + дубли); выбранное определяется ?block=<hash>
+  const occurrences = transaction.data
+    ? [transaction.data, ...(transaction.data.duplicates ?? [])]
+    : []
+  const selectedBlockHash = searchParams.get('block')
+  const selected =
+    occurrences.find((o) => o?.blockHash === selectedBlockHash) || transaction.data
+
+  const handleSelectOccurrence = (blockHash) => {
+    if (!blockHash || blockHash === selected?.blockHash) {
+      router.replace(pathname, { scroll: false })
+    } else {
+      router.replace(`${pathname}?block=${blockHash}`, { scroll: false })
+    }
+  }
 
   useEffect(() => {
     setBreadcrumbs([
@@ -48,6 +68,14 @@ export const Transaction = () => {
     <PageDataContainer className={'TransactionPage'} title={'Transaction Info'}>
       {transaction.error && <ErrorMessageBlock h={'450px'} />}
 
+      {!transaction.error && transaction.data?.duplicates?.length > 0 && (
+        <DuplicatedTransactions
+          transaction={transaction.data}
+          selectedBlockHash={selected?.blockHash}
+          onSelect={handleSelectOccurrence}
+        />
+      )}
+
       {!transaction.error && (
         <div className={'TransactionPage__CommonInfo'}>
           <InfoLine
@@ -57,7 +85,7 @@ export const Transaction = () => {
             title={'Timestamp'}
             value={
               <DateBlock
-                timestamp={transaction.data?.timestamp}
+                timestamp={selected?.timestamp}
                 showTime={true}
               />
             }
@@ -74,7 +102,7 @@ export const Transaction = () => {
                 ellipsis={false}
                 styles={['highlight-both']}
               >
-                {transaction.data?.hash}
+                {selected?.hash}
               </Identifier>
             }
             loading={transaction.loading}
@@ -86,18 +114,18 @@ export const Transaction = () => {
             title={'Block Hash'}
             value={
               <ValueCard
-                link={`/block/${transaction.data?.blockHash}`}
+                link={`/block/${selected?.blockHash}`}
                 className={'TransactionPage__BlockHash'}
               >
                 <ValueCard className={'TransactionPage__BlockHeight'}>
-                  Height: {transaction.data?.blockHeight}
+                  Height: {selected?.blockHeight}
                 </ValueCard>
                 <Identifier
                   copyButton={true}
                   ellipsis={false}
                   styles={['highlight-both']}
                 >
-                  {transaction.data?.blockHash}
+                  {selected?.blockHash}
                 </Identifier>
               </ValueCard>
             }
@@ -110,7 +138,7 @@ export const Transaction = () => {
               'TransactionPage__InfoLine TransactionPage__InfoLine--Index'
             }
             title={'Index'}
-            value={transaction.data?.index}
+            value={selected?.index}
             loading={transaction.loading}
             error={transaction.error}
           />
@@ -120,7 +148,7 @@ export const Transaction = () => {
               'TransactionPage__InfoLine TransactionPage__InfoLine--Type'
             }
             title={'Type'}
-            value={<TypeBadge type={transaction.data?.type} />}
+            value={<TypeBadge type={selected?.type} />}
             loading={transaction.loading}
             error={transaction.error}
           />
@@ -132,10 +160,10 @@ export const Transaction = () => {
             title={'Status'}
             value={
               <div className={'TransactionPage__StatusContainer'}>
-                <TransactionStatusBadge status={transaction.data?.status} />
-                {transaction.data?.error && (
+                <TransactionStatusBadge status={selected?.status} />
+                {selected?.error && (
                   <ValueContainer className={'TransactionPage__ErrorContainer'}>
-                    {transaction.data.error}
+                    {selected.error}
                   </ValueContainer>
                 )}
               </div>
@@ -151,7 +179,7 @@ export const Transaction = () => {
             title={'Owner'}
             value={
               <ValueCard
-                link={`/identity/${transaction.data?.owner?.identifier}`}
+                link={`/identity/${selected?.owner?.identifier}`}
               >
                 <Identifier
                   avatar={true}
@@ -159,7 +187,7 @@ export const Transaction = () => {
                   ellipsis={false}
                   styles={['highlight-both']}
                 >
-                  {transaction.data?.owner?.identifier}
+                  {selected?.owner?.identifier}
                 </Identifier>
               </ValueCard>
             }
@@ -174,8 +202,8 @@ export const Transaction = () => {
             title={'Raw Transaction'}
             value={
               <ValueCard className={'TransactionPage__RawTransaction'}>
-                {transaction.data?.data}
-                <CopyButton text={transaction.data?.data} />
+                {selected?.data}
+                <CopyButton text={selected?.data} />
               </ValueCard>
             }
             loading={transaction.loading}
@@ -188,7 +216,7 @@ export const Transaction = () => {
             }
             title={'Gas Used'}
             value={
-              <CreditsBlock credits={transaction.data?.gasUsed} rate={rate} />
+              <CreditsBlock credits={selected?.gasUsed} rate={rate} />
             }
             loading={transaction.loading}
             error={transaction.error}

--- a/packages/frontend/src/app/transaction/[hash]/components/Transaction.js
+++ b/packages/frontend/src/app/transaction/[hash]/components/Transaction.js
@@ -40,7 +40,7 @@ export const Transaction = () => {
   const pathname = usePathname()
   const searchParams = useSearchParams()
 
-  // Все вхождения tx (каноническая + дубли); выбранное определяется ?block=<hash>
+  // Occurrences = canonical + duplicates; the selected one is driven by ?block=
   const occurrences = transaction.data
     ? [transaction.data, ...(transaction.data.duplicates ?? [])]
     : []

--- a/packages/frontend/src/components/search/SearchResultsList.js
+++ b/packages/frontend/src/components/search/SearchResultsList.js
@@ -1,7 +1,14 @@
 import SearchResultsListItem from './SearchResultsListItem'
 import './SearchResultsList.scss'
 import { Grid, GridItem } from '@chakra-ui/react'
-import { categoryMap, singularCategoryNames, pluralCategoryNames, modifierMap } from './constants'
+import { categoryMap, entityTypes, singularCategoryNames, pluralCategoryNames, modifierMap } from './constants'
+
+// Разворачиваем каждую транзакцию в [каноническая, ...duplicates], чтобы каждое
+// вхождение (включая FAIL-дубли из вложенного поля duplicates) стало отдельной строкой.
+const expandOccurrences = (entity) => [
+  entity,
+  ...(entity?.duplicates ?? []).map((duplicate) => ({ ...duplicate, isDuplicate: true }))
+]
 
 const COLUMN_TITLES = {
   [categoryMap.validators]: ['Identity', 'Balance'],
@@ -19,11 +26,15 @@ function ListCategory ({ type, data, onItemClick }) {
 
   if (!titles) return null
 
+  const displayData = categoryMap[type] === entityTypes.transaction
+    ? data.flatMap(expandOccurrences)
+    : data
+
   return (
     <div className={'SearchResultsList__Category'}>
       <Grid className={`SearchResultsList__ColumnTitles SearchResultsList__ColumnTitles--${modifierMap[categoryMap[type]] || ''}`}>
         <GridItem className={'SearchResultsList__ColumnTitle'}>
-          {data?.length} {data?.length > 1 ? pluralCategoryNames[type] : singularCategoryNames[categoryMap[type]]} FOUND
+          {displayData?.length} {displayData?.length > 1 ? pluralCategoryNames[type] : singularCategoryNames[categoryMap[type]]} FOUND
         </GridItem>
         {titles.map((title, i) => (
           <GridItem key={i} className={'SearchResultsList__ColumnTitle'}>
@@ -33,7 +44,7 @@ function ListCategory ({ type, data, onItemClick }) {
         <GridItem/>
       </Grid>
       <div>
-        {data?.map((entity, i) => (
+        {displayData?.map((entity, i) => (
           <SearchResultsListItem
             entity={entity}
             entityType={categoryMap[type]}

--- a/packages/frontend/src/components/search/SearchResultsList.js
+++ b/packages/frontend/src/components/search/SearchResultsList.js
@@ -3,8 +3,7 @@ import './SearchResultsList.scss'
 import { Grid, GridItem } from '@chakra-ui/react'
 import { categoryMap, entityTypes, singularCategoryNames, pluralCategoryNames, modifierMap } from './constants'
 
-// Разворачиваем каждую транзакцию в [каноническая, ...duplicates], чтобы каждое
-// вхождение (включая FAIL-дубли из вложенного поля duplicates) стало отдельной строкой.
+// Flatten each tx into its occurrences so duplicates render as their own rows
 const expandOccurrences = (entity) => [
   entity,
   ...(entity?.duplicates ?? []).map((duplicate) => ({ ...duplicate, isDuplicate: true }))

--- a/packages/frontend/src/components/search/items/TransactionSearchItem.js
+++ b/packages/frontend/src/components/search/items/TransactionSearchItem.js
@@ -5,8 +5,7 @@ import { BaseSearchItem, BaseSearchItemContent } from './BaseSearchItem'
 import { TransactionStatusBadge } from '../../transactions'
 
 export function TransactionSearchItem ({ transaction, className, onClick }) {
-  // Дубль-вхождение ведёт на ту же транзакцию с выбранным блоком (master-detail ?block=),
-  // каноническое — на обычную страницу транзакции.
+  // Duplicate rows deep-link to the same tx with that occurrence preselected (?block=)
   const href = transaction?.isDuplicate
     ? `/transaction/${transaction?.hash}?block=${transaction?.blockHash}`
     : `/transaction/${transaction?.hash}`

--- a/packages/frontend/src/components/search/items/TransactionSearchItem.js
+++ b/packages/frontend/src/components/search/items/TransactionSearchItem.js
@@ -5,9 +5,15 @@ import { BaseSearchItem, BaseSearchItemContent } from './BaseSearchItem'
 import { TransactionStatusBadge } from '../../transactions'
 
 export function TransactionSearchItem ({ transaction, className, onClick }) {
+  // Дубль-вхождение ведёт на ту же транзакцию с выбранным блоком (master-detail ?block=),
+  // каноническое — на обычную страницу транзакции.
+  const href = transaction?.isDuplicate
+    ? `/transaction/${transaction?.hash}?block=${transaction?.blockHash}`
+    : `/transaction/${transaction?.hash}`
+
   return (
     <BaseSearchItem
-      href={`/transaction/${transaction?.hash}`}
+      href={href}
       className={`${className || ''}`}
       gridClassModifier={'Transaction'}
       onClick={onClick}

--- a/packages/frontend/src/components/transactions/DuplicatedTransactions.js
+++ b/packages/frontend/src/components/transactions/DuplicatedTransactions.js
@@ -1,0 +1,134 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+import { Button } from '@chakra-ui/react'
+import { Identifier, TimeDelta, NotActive } from '../data'
+import TypeBadge from './TypeBadge'
+import BatchTypeBadge from './BatchTypeBadge'
+import TransactionStatusBadge from './TransactionStatusBadge'
+import { TransactionsIcon, ChevronIcon } from '../ui/icons'
+
+import './DuplicatedTransactions.scss'
+
+const VISIBLE_COUNT = 3
+
+function TypeBadgeCell ({ occurrence }) {
+  if (occurrence?.batchType) {
+    return (
+      <BatchTypeBadge
+        className={'DuplicatedTransactions__TypeBadge'}
+        batchType={occurrence.batchType?.replace(/[\\""]/g, '')}
+      />
+    )
+  }
+
+  if (occurrence?.type !== undefined && occurrence?.type !== null) {
+    return <TypeBadge className={'DuplicatedTransactions__TypeBadge'} type={occurrence.type}/>
+  }
+
+  return <NotActive/>
+}
+
+function OccurrenceRow ({ occurrence, selected, onSelect }) {
+  const handleSelect = () => onSelect?.(occurrence?.blockHash)
+
+  return (
+    <div
+      role={'button'}
+      tabIndex={0}
+      aria-pressed={selected}
+      onClick={handleSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleSelect()
+        }
+      }}
+      className={`DuplicatedTransactions__Row ${selected ? 'DuplicatedTransactions__Row--Selected' : ''}`}
+    >
+      <div className={'DuplicatedTransactions__Main'}>
+        <TransactionsIcon className={'DuplicatedTransactions__Icon'}/>
+        <Identifier ellipsis={true} styles={['highlight-both']}>{occurrence?.hash}</Identifier>
+      </div>
+
+      <div className={'DuplicatedTransactions__Height'}>
+        {occurrence?.blockHeight != null
+          ? <span className={'DuplicatedTransactions__HeightChip'}>Height: {occurrence.blockHeight}</span>
+          : <NotActive/>
+        }
+      </div>
+
+      <div className={'DuplicatedTransactions__Type'}>
+        <TypeBadgeCell occurrence={occurrence}/>
+      </div>
+
+      <div className={'DuplicatedTransactions__Time'}>
+        {occurrence?.timestamp
+          ? <TimeDelta endDate={new Date(occurrence.timestamp)}/>
+          : <NotActive/>
+        }
+      </div>
+
+      <div className={'DuplicatedTransactions__Status'}>
+        {occurrence?.status
+          ? <TransactionStatusBadge status={occurrence.status}/>
+          : <NotActive/>
+        }
+      </div>
+
+      <div className={'DuplicatedTransactions__Action'}>
+        <Link
+          href={`/block/${occurrence?.blockHash}`}
+          onClick={(e) => e.stopPropagation()}
+          className={'DuplicatedTransactions__ArrowLink'}
+        >
+          <Button className={'DuplicatedTransactions__ArrowButton'} size={'xxs'} variant={'blue'}>
+            <ChevronIcon w={'0.5rem'} h={'0.5rem'}/>
+          </Button>
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+function DuplicatedTransactions ({ transaction, selectedBlockHash, onSelect }) {
+  const [showAll, setShowAll] = useState(false)
+  const duplicates = transaction?.duplicates
+
+  if (!Array.isArray(duplicates) || duplicates.length === 0) return null
+
+  const occurrences = [transaction, ...duplicates]
+  const visibleOccurrences = showAll ? occurrences : occurrences.slice(0, VISIBLE_COUNT)
+  const hasMore = occurrences.length > VISIBLE_COUNT
+
+  return (
+    <div className={'DuplicatedTransactions'}>
+      <div className={'DuplicatedTransactions__Title'}>Duplicated Transactions</div>
+      <div className={'DuplicatedTransactions__List'}>
+        {visibleOccurrences.map((occurrence, i) => (
+          <OccurrenceRow
+            key={`${occurrence?.blockHash || 'selected'}-${i}`}
+            occurrence={occurrence}
+            selected={occurrence?.blockHash === selectedBlockHash}
+            onSelect={onSelect}
+          />
+        ))}
+      </div>
+
+      {hasMore && (
+        <Button
+          onClick={() => setShowAll(!showAll)}
+          className={'DuplicatedTransactions__ShowMoreButton'}
+          variant={showAll ? 'gray' : 'blue'}
+          size={'sm'}
+        >
+          {showAll ? 'Show less' : 'Show more'}
+          <ChevronIcon ml={'4px'} h={'10px'} w={'10px'} transform={`rotate(${showAll ? '-90deg' : '90deg'})`}/>
+        </Button>
+      )}
+    </div>
+  )
+}
+
+export default DuplicatedTransactions

--- a/packages/frontend/src/components/transactions/DuplicatedTransactions.js
+++ b/packages/frontend/src/components/transactions/DuplicatedTransactions.js
@@ -3,6 +3,7 @@
 import { useState } from 'react'
 import Link from 'next/link'
 import { Button } from '@chakra-ui/react'
+import { WarningTwoIcon } from '@chakra-ui/icons'
 import { Identifier, TimeDelta, NotActive } from '../data'
 import TypeBadge from './TypeBadge'
 import BatchTypeBadge from './BatchTypeBadge'
@@ -105,6 +106,13 @@ function DuplicatedTransactions ({ transaction, selectedBlockHash, onSelect }) {
   return (
     <div className={'DuplicatedTransactions'}>
       <div className={'DuplicatedTransactions__Title'}>Duplicated Transactions</div>
+      <div className={'DuplicatedTransactions__Notice'}>
+        <WarningTwoIcon className={'DuplicatedTransactions__NoticeIcon'}/>
+        <span>
+          This transaction was included in more than one block. The duplicate occurrences
+          failed, the canonical transaction is valid.
+        </span>
+      </div>
       <div className={'DuplicatedTransactions__List'}>
         {visibleOccurrences.map((occurrence, i) => (
           <OccurrenceRow

--- a/packages/frontend/src/components/transactions/DuplicatedTransactions.js
+++ b/packages/frontend/src/components/transactions/DuplicatedTransactions.js
@@ -109,8 +109,7 @@ function DuplicatedTransactions ({ transaction, selectedBlockHash, onSelect }) {
       <div className={'DuplicatedTransactions__Notice'}>
         <WarningTwoIcon className={'DuplicatedTransactions__NoticeIcon'}/>
         <span>
-          This transaction was included in more than one block. The duplicate occurrences
-          failed, the canonical transaction is valid.
+          This transaction was included in more than one block
         </span>
       </div>
       <div className={'DuplicatedTransactions__List'}>

--- a/packages/frontend/src/components/transactions/DuplicatedTransactions.scss
+++ b/packages/frontend/src/components/transactions/DuplicatedTransactions.scss
@@ -12,6 +12,25 @@
     margin-bottom: 14px;
   }
 
+  &__Notice {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    margin-bottom: 14px;
+    padding: 10px 14px;
+    border-radius: 8px;
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    color: #f49a58;
+    background-color: rgba(244, 154, 88, .2);
+  }
+
+  &__NoticeIcon {
+    flex-shrink: 0;
+    margin-top: 2px;
+    color: #f49a58;
+  }
+
   &__List {
     display: flex;
     flex-direction: column;

--- a/packages/frontend/src/components/transactions/DuplicatedTransactions.scss
+++ b/packages/frontend/src/components/transactions/DuplicatedTransactions.scss
@@ -41,11 +41,11 @@
   &__Row {
     display: grid;
     grid-template-columns:
-      minmax(0, 1fr)   // hash (eats space → кластер прижат вправо)
+      minmax(0, 1fr)   // hash — eats remaining space
       auto             // height
       auto             // type
-      90px             // time (фикс → выравнивается построчно)
-      92px             // status (фикс → SUCCESS/FAIL не смещают колонки)
+      90px             // time — fixed width keeps rows aligned
+      92px             // status — fixed width so SUCCESS/FAIL doesn't shift columns
       2rem;            // arrow
     align-items: center;
     gap: 16px;

--- a/packages/frontend/src/components/transactions/DuplicatedTransactions.scss
+++ b/packages/frontend/src/components/transactions/DuplicatedTransactions.scss
@@ -1,0 +1,140 @@
+@import '../../styles/variables.scss';
+
+.DuplicatedTransactions {
+  margin-bottom: 20px;
+
+  &__Title {
+    font-family: $font-heading;
+    font-size: 0.75rem;
+    letter-spacing: .4px;
+    text-transform: uppercase;
+    font-weight: 700;
+    margin-bottom: 14px;
+  }
+
+  &__List {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    container-type: inline-size;
+  }
+
+  &__Row {
+    display: grid;
+    grid-template-columns:
+      minmax(0, 1fr)   // hash (eats space → кластер прижат вправо)
+      auto             // height
+      auto             // type
+      90px             // time (фикс → выравнивается построчно)
+      92px             // status (фикс → SUCCESS/FAIL не смещают колонки)
+      2rem;            // arrow
+    align-items: center;
+    gap: 16px;
+    padding: 10px 16px;
+    border-radius: 8px;
+    background-color: var(--chakra-colors-gray-900);
+    border: 1px solid transparent;
+    cursor: pointer;
+    transition: border-color .1s ease-in-out, background-color .1s ease-in-out;
+
+    &:hover {
+      border-color: $color-brand-normal;
+    }
+
+    &--Selected {
+      background-color: var(--chakra-colors-gray-800);
+      border-color: $color-brand-normal;
+    }
+  }
+
+  &__Main {
+    display: flex;
+    align-items: center;
+    min-width: 0;
+    overflow: hidden;
+  }
+
+  &__Icon {
+    flex-shrink: 0;
+    margin-right: 8px;
+    width: 1rem;
+    height: 1rem;
+    color: var(--chakra-colors-gray-250);
+  }
+
+  &__Height {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  &__HeightChip {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 0.625rem;
+    white-space: nowrap;
+    color: var(--chakra-colors-gray-250);
+    background-color: var(--chakra-colors-gray-800);
+  }
+
+  &__Type {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  &__Time {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    font-size: 0.75rem;
+    white-space: nowrap;
+    color: var(--chakra-colors-gray-250);
+  }
+
+  &__Status {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  &__Action {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+  }
+
+  &__ArrowLink {
+    display: inline-flex;
+  }
+
+  &__ArrowButton {
+    width: 1.5rem;
+    height: 1.5rem;
+    min-width: auto;
+  }
+
+  &__ShowMoreButton {
+    width: 100%;
+    margin-top: 8px;
+  }
+
+  @container (max-width: 720px) {
+    &__Row {
+      grid-template-columns: minmax(0, 1fr) auto auto;
+      grid-template-areas:
+        'main main action'
+        'height type time'
+        'status status status';
+      row-gap: 8px;
+    }
+
+    &__Main { grid-area: main; }
+    &__Height { grid-area: height; justify-content: flex-start; }
+    &__Type { grid-area: type; justify-content: center; }
+    &__Time { grid-area: time; justify-content: flex-end; }
+    &__Status { grid-area: status; justify-content: flex-start; }
+    &__Action { grid-area: action; }
+  }
+}

--- a/packages/frontend/src/components/transactions/index.js
+++ b/packages/frontend/src/components/transactions/index.js
@@ -7,6 +7,7 @@ import TransactionStatusBadge from './TransactionStatusBadge'
 import VoteIndexValues from './VoteIndexValues'
 import BatchTypeBadge from './BatchTypeBadge'
 import StatusIcon from './StatusIcon'
+import DuplicatedTransactions from './DuplicatedTransactions'
 
 export {
   TransitionCard,
@@ -17,5 +18,6 @@ export {
   TransactionStatusBadge,
   VoteIndexValues,
   BatchTypeBadge,
-  StatusIcon
+  StatusIcon,
+  DuplicatedTransactions
 }


### PR DESCRIPTION
Surfaces the backend `duplicates` field (state transitions that landed in more than one block; duplicate occurrences are `FAIL`, the canonical one keeps its real status) across the transaction UI:

- **Transaction page — Duplicated Transactions section.** Lists every occurrence (canonical + duplicates) with hash, block height, type, time and a SUCCESS/FAIL badge. Selecting one rebinds the details panel and syncs to the URL (`?block=<hash>`); the arrow links to the block. `SHOW MORE` for long lists.
- **Transaction page — warning notice.** An amber notice under the section header makes the duplication explicit (included in more than one block; the duplicate occurrences failed, the canonical transaction is valid).
- **Global search.** Searching a hash with duplicates now lists each occurrence as its own row (count reads "N transactions found"), each with its SUCCESS/FAIL badge and time; duplicate rows deep-link to `/transaction/<hash>?block=<blockHash>`.

No new API calls — all data comes from the existing `duplicates` field.