### PR TITLE
feat(identity): clean up documents tab filters, columns and counts

### DIFF
--- a/packages/frontend/src/app/identity/[identifier]/Identity.js
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.js
@@ -157,9 +157,9 @@ function Identity ({ identifier }) {
       <InfoContainer styles={['tabs']} className={'IdentityPage__ListContainer'}>
         <Tabs onChange={setActiveTab} index={activeTab}>
           <TabList>
-            <Tab>Transactions {identity.data?.totalTxs !== undefined
-              ? <span className={`Tabs__TabItemsCount ${identity.data?.totalTxs === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
-                  {identity.data?.totalTxs}
+            <Tab>Transactions {(transactions.data?.pagination?.total ?? identity.data?.totalTxs) !== undefined
+              ? <span className={`Tabs__TabItemsCount ${(transactions.data?.pagination?.total ?? identity.data?.totalTxs) === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
+                  {Math.max(transactions.data?.pagination?.total ?? identity.data?.totalTxs, 0)}
                 </span>
               : ''}
             </Tab>
@@ -169,9 +169,9 @@ function Identity ({ identifier }) {
                 </span>
               : ''}
             </Tab>
-            <Tab>Documents {identity.data?.totalDocuments !== undefined
-              ? <span className={`Tabs__TabItemsCount ${identity.data?.totalDocuments === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
-                  {identity.data?.totalDocuments}
+            <Tab>Documents {(documents.data?.pagination?.total ?? identity.data?.totalDocuments) !== undefined
+              ? <span className={`Tabs__TabItemsCount ${(documents.data?.pagination?.total ?? identity.data?.totalDocuments) === 0 ? 'Tabs__TabItemsCount--Empty' : ''}`}>
+                  {Math.max(documents.data?.pagination?.total ?? identity.data?.totalDocuments, 0)}
                 </span>
               : ''}
             </Tab>

--- a/packages/frontend/src/app/identity/[identifier]/Identity.js
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.js
@@ -234,6 +234,8 @@ function Identity ({ identifier }) {
                 ? <DocumentsList
                     documents={documents.data?.resultSet}
                     showDataContract={true}
+                    showAction={false}
+                    showGas={false}
                     pagination={{
                       onPageChange: pagination => paginationHandler(setDocuments, pagination.selected),
                       pageCount: Math.ceil(documents.data?.pagination?.total / pageSize) || 1,

--- a/packages/frontend/src/app/identity/[identifier]/Identity.js
+++ b/packages/frontend/src/app/identity/[identifier]/Identity.js
@@ -227,7 +227,7 @@ function Identity ({ identifier }) {
             <TabPanel>
               <DocumentsFilter
                 onFilterChange={docFiltersChangeHandler}
-                excludeFilters={['owner', 'revision']}
+                excludeFilters={['owner', 'revision', 'transition_type']}
                 className={'IdentityPage__DocumentsFilter'}
               />
               {!documents.error

--- a/packages/frontend/src/components/documents/DocumentsList.js
+++ b/packages/frontend/src/components/documents/DocumentsList.js
@@ -12,23 +12,29 @@ export default function DocumentsList ({
   pagination,
   loading,
   itemsCount = 10,
-  showDataContract = false
+  showDataContract = false,
+  showAction = true,
+  showGas = true
 }) {
   const headerExtraClass = {
     default: '',
     light: 'DocumentsList__ColumnTitles--Light'
   }
 
+  const compact = !showAction && !showGas
+
   return (
     <div className={'DocumentsList'}>
-      <div className={'DocumentsList__Table'}>
+      <div className={`DocumentsList__Table${compact ? ' DocumentsList__Table--Compact' : ''}`}>
       <Grid className={`DocumentsList__ColumnTitles ${headerExtraClass?.[headerStyles] || ''}`}>
         <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--Timestamp'}>
           Time
         </GridItem>
-        <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--TransitionType'}>
-          Action
-        </GridItem>
+        {showAction &&
+          <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--TransitionType'}>
+            Action
+          </GridItem>
+        }
         <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--DocumentType'}>
           Type
         </GridItem>
@@ -41,9 +47,11 @@ export default function DocumentsList ({
         <GridItem className={`DocumentsList__ColumnTitle DocumentsList__ColumnTitle--${showDataContract ? 'DataContract' : 'Owner'}`}>
           {showDataContract ? 'Data Contract' : 'Owner'}
         </GridItem>
-        <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--Gas'}>
-          Gas
-        </GridItem>
+        {showGas &&
+          <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--Gas'}>
+            Gas
+          </GridItem>
+        }
         <GridItem className={'DocumentsList__ColumnTitle DocumentsList__ColumnTitle--Status'}>
           Status
         </GridItem>
@@ -52,7 +60,7 @@ export default function DocumentsList ({
       {!loading
         ? <>
           {documents?.map((document, key) =>
-            <DocumentsListItem document={document} showDataContract={showDataContract} key={key}/>
+            <DocumentsListItem document={document} showDataContract={showDataContract} showAction={showAction} showGas={showGas} key={key}/>
           )}
           {documents?.length === 0 &&
             <EmptyListMessage>There are no documents created yet.</EmptyListMessage>

--- a/packages/frontend/src/components/documents/DocumentsList.scss
+++ b/packages/frontend/src/components/documents/DocumentsList.scss
@@ -13,6 +13,10 @@
     > *:not(.DocumentsList__ColumnTitles):not(.DocumentsListItem) {
       grid-column: 1 / -1;
     }
+
+    &--Compact {
+      @include docs.ColumnsMasterCompact();
+    }
   }
 
   &__ColumnTitles {

--- a/packages/frontend/src/components/documents/DocumentsListItem.js
+++ b/packages/frontend/src/components/documents/DocumentsListItem.js
@@ -7,7 +7,7 @@ import { useRouter } from 'next/navigation'
 import { findActiveAlias } from '../../util'
 import './DocumentsListItem.scss'
 
-function DocumentsListItem ({ document, showDataContract = false }) {
+function DocumentsListItem ({ document, showDataContract = false, showAction = true, showGas = true }) {
   const activeAlias = findActiveAlias(document?.owner?.aliases)
   const router = useRouter()
 
@@ -17,12 +17,14 @@ function DocumentsListItem ({ document, showDataContract = false }) {
         <TimeDelta endDate={document?.timestamp}/>
       </GridItem>
 
-      <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--TransitionType'}>
-        {document?.transitionType
-          ? <BatchTypeBadge batchType={document.transitionType}/>
-          : <NotActive/>
-        }
-      </GridItem>
+      {showAction &&
+        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--TransitionType'}>
+          {document?.transitionType
+            ? <BatchTypeBadge batchType={document.transitionType}/>
+            : <NotActive/>
+          }
+        </GridItem>
+      }
 
       <GridItem
         className={'DocumentsListItem__Column DocumentsListItem__Column--DocumentType'}
@@ -78,9 +80,11 @@ function DocumentsListItem ({ document, showDataContract = false }) {
           </GridItem>
       }
 
-      <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Gas'}>
-        {Number.isFinite(document?.gasUsed) ? document.gasUsed.toLocaleString() : <NotActive/>}
-      </GridItem>
+      {showGas &&
+        <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Gas'}>
+          {Number.isFinite(document?.gasUsed) ? document.gasUsed.toLocaleString() : <NotActive/>}
+        </GridItem>
+      }
 
       <GridItem className={'DocumentsListItem__Column DocumentsListItem__Column--Status'}>
         {document?.deleted

--- a/packages/frontend/src/components/documents/_variables.scss
+++ b/packages/frontend/src/components/documents/_variables.scss
@@ -31,6 +31,31 @@
   }
 }
 
+// Identity Documents tab: same tracks as ColumnsMaster, minus Action and Gas.
+@mixin ColumnsMasterCompact () {
+  grid-template-columns:
+    70px               // time
+    fit-content(220px) // type
+    50px               // rev
+    minmax(0, 1fr)     // identifier
+    minmax(0, 1fr)     // data contract
+    80px;              // status
+
+  @container (max-width: 64rem) {
+    grid-template-columns:
+      70px fit-content(220px) 50px minmax(0, 1fr) minmax(0, 1fr) 80px;
+  }
+
+  @container (max-width: 48rem) {
+    grid-template-columns:
+      70px fit-content(200px) 50px minmax(0, 1fr) 80px;
+  }
+
+  @container (max-width: 22rem) {
+    grid-template-columns: 70px minmax(0, 1fr);
+  }
+}
+
 // Header / row: a grid item that spans all master columns and re-uses the
 // master tracks via subgrid.
 @mixin SubColumns () {


### PR DESCRIPTION
## What

Follow-up cleanup of the identity **Documents** tab (`/identity/{id}?tab=documents`), addressing tech-lead feedback after #792.

### Filters
- Show **Type / Status / Date** filters; hide **Action** (`transition_type`) — the backend dropped it in #799 ("Removed batch type for latest action").
- `Status` (`deleted`) and `Date` (`timestamp_start`/`timestamp_end`) start narrowing once **#799** is merged; the frontend already sends those params under the matching names. `Type` (`document_type_name`) works today.

### Columns
- Remove **Action** (no data after #799) and **Gas** (`gas_used` not returned) from the identity tab.
- Keep **Status** (real data, filterable via #799). Result: Time, Type, Rev, Identifier, Data Contract, Status.
- Implemented via new `showAction` / `showGas` props (default `true`) + a compact 6-track subgrid variant so column alignment stays intact. The `/dataContract/{id}` documents table is untouched (keeps all 8 columns).

### Tab counts (bugfix)
- The **Documents** and **Transactions** tab counts were sourced from static identity totals and didn't change when a filter was applied. They now read `pagination.total` from the filtered response (mirroring the Tokens tab), with a fallback to the static total before first load. Verified live: Type filter → count 1558 → 1543.

## Depends on / pairs with
- Backend **#799** (`feat/documents-by-identity-filters`) — Status/Date filters and any future Gas data light up once it merges. Action removal here is coordinated with #799.

## Test plan
- `/identity/{id}?tab=documents`: filter bar shows Type/Status/Date; table has no Action/Gas; subgrid stays aligned across container breakpoints; applying Type updates the Documents count.
- `/dataContract/{id}` documents tab: unchanged (8 columns incl. Action/Gas).
- `npm run lint` — clean (no new warnings).
