### PR TITLE
Bump dash-platform-sdk to dev.16

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,7 +18,7 @@
     "@use-gesture/react": "^10.3.1",
     "class-variance-authority": "^0.7.1",
     "d3": "^7.9.0",
-    "dash-platform-sdk": "1.4.0-dev.13",
+    "dash-platform-sdk": "1.4.0-dev.16",
     "express": "^4.18.2",
     "framer-motion": "^12.23.24",
     "keen-slider": "^6.8.6",


### PR DESCRIPTION
### Problem
Contract deploy on the frontend (`/dataContract/create`) failed with:

```
grovedb: data corruption error: unable to decode proof: UnexpectedVariant { type_name: "GroveDBProof", allowed: Range { min: 0, max: 0 }, found: 1 }
```

The bundled `pshenmic-dpp` (via `dash-platform-sdk`) was too old and couldn't decode the new GroveDBProof **v1** format now returned by testnet.

### Fix
Bump `packages/frontend` `dash-platform-sdk` `1.4.0-dev.13 → 1.4.0-dev.16`, which pulls `pshenmic-dpp 2.0.0-dev.19` (supports proof v1). The lockfile already pinned dev.16/dev.19, so this only aligns the manifest with `package-lock.json`.

### How tested
Local: deployed a data contract on testnet via `/dataContract/create` — succeeds, no GroveDBProof error.