### PR TITLE
Identity create from shield

### DIFF
--- a/packages/indexer/Cargo.lock
+++ b/packages/indexer/Cargo.lock
@@ -1872,20 +1872,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "postgres"
-version = "0.19.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c48ece1c6cda0db61b058c1721378da76855140e9214339fa1317decacb176"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "futures-util",
- "log",
- "tokio",
- "tokio-postgres",
-]
-
-[[package]]
 name = "postgres-protocol"
 version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2077,12 +2063,13 @@ dependencies = [
  "async-trait",
  "cfg-if",
  "log",
- "postgres",
  "regex",
  "serde",
  "siphasher",
  "thiserror 1.0.69",
  "time",
+ "tokio",
+ "tokio-postgres",
  "toml 0.8.23",
  "url",
  "walkdir",

--- a/packages/indexer/Cargo.toml
+++ b/packages/indexer/Cargo.toml
@@ -17,7 +17,7 @@ async-trait = { version = "0.1"}
 anyhow = { version = "1.0"}
 base64 = "0.21.2"
 deadpool-postgres = "0.10.5"
-refinery = { version = "0.8.10", features = ["postgres"] }
+refinery = { version = "0.8.10", features = ["tokio-postgres"] }
 sha256 = "1.4.0"
 dotenv = "0.15.0"
 chrono = { version = "0.4.37", features = ["serde"] }

--- a/packages/indexer/Dockerfile
+++ b/packages/indexer/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /app
 COPY Cargo.lock /app
 COPY Cargo.toml /app
 COPY src /app/src
+COPY migrations /app/migrations
 RUN cargo build
 
 FROM alpine:3.20 as indexer

--- a/packages/indexer/src/main.rs
+++ b/packages/indexer/src/main.rs
@@ -1,4 +1,6 @@
+use std::env;
 use dotenv::dotenv;
+use crate::processor::psql::PostgresDAO;
 
 mod decoder;
 mod entities;
@@ -11,9 +13,49 @@ mod utils;
 extern crate chrono;
 extern crate core;
 
+mod embedded {
+    refinery::embed_migrations!("./migrations");
+}
+
 #[tokio::main]
 async fn main() {
     dotenv().ok(); // This line loads the environment variables from the ".env" file
+
+    let args: Vec<String> = env::args().collect();
+
+    if args.len() > 1 {
+        let arg = args.get(1).unwrap();
+
+        match arg.as_str() {
+            "drop_db" => {
+                let pool = PostgresDAO::create_pool();
+                let client = pool.get().await.expect("Failed to get a database connection");
+
+                client
+                    .batch_execute("DROP SCHEMA public CASCADE; CREATE SCHEMA public;")
+                    .await
+                    .expect("Failed to drop the database schema");
+
+                println!("Database schema dropped");
+
+                return;
+            }
+            "migrate" => {
+                let pool = PostgresDAO::create_pool();
+                let mut client = pool.get().await.expect("Failed to get a database connection");
+
+                let report = embedded::migrations::runner()
+                    .run_async(&mut **client)
+                    .await
+                    .expect("Failed to run migrations");
+
+                println!("Applied {} migrations", report.applied_migrations().len());
+
+                return;
+            }
+            _ => {}
+        }
+    }
 
     let indexer = indexer::Indexer::new().await;
 

--- a/packages/indexer/src/processor/psql/dao/mod.rs
+++ b/packages/indexer/src/processor/psql/dao/mod.rs
@@ -23,6 +23,15 @@ pub struct PostgresDAO {
 
 impl PostgresDAO {
     pub fn new(network: Network) -> PostgresDAO {
+        let connection_pool = PostgresDAO::create_pool();
+
+        PostgresDAO {
+            connection_pool,
+            network,
+        }
+    }
+
+    pub fn create_pool() -> Pool {
         let mut cfg = Config::new();
 
         let postgres_host = env::var("POSTGRES_HOST").expect("You've not set the POSTGRES_HOST");
@@ -43,11 +52,6 @@ impl PostgresDAO {
             recycling_method: RecyclingMethod::Fast,
         });
 
-        let connection_pool = cfg.create_pool(Some(Runtime::Tokio1), NoTls).unwrap();
-
-        PostgresDAO {
-            connection_pool,
-            network,
-        }
+        cfg.create_pool(Some(Runtime::Tokio1), NoTls).unwrap()
     }
 }

--- a/packages/indexer/src/processor/psql/handlers/handle_identity.rs
+++ b/packages/indexer/src/processor/psql/handlers/handle_identity.rs
@@ -7,6 +7,8 @@ use deadpool_postgres::Transaction;
 use dpp::identity::state_transition::AssetLockProved;
 use dpp::prelude::AssetLockProof;
 use dpp::state_transition::identity_create_from_addresses_transition::IdentityCreateFromAddressesTransition;
+use dpp::state_transition::identity_create_from_shielded_pool_transition::accessors::IdentityCreateFromShieldedPoolTransitionAccessorsV0;
+use dpp::state_transition::identity_create_from_shielded_pool_transition::IdentityCreateFromShieldedPoolTransition;
 use dpp::state_transition::identity_create_transition::IdentityCreateTransition;
 use dpp::state_transition::identity_credit_transfer_to_addresses_transition::IdentityCreditTransferToAddressesTransition;
 use dpp::state_transition::identity_credit_transfer_transition::IdentityCreditTransferTransition;
@@ -156,6 +158,38 @@ impl PSQLProcessor {
 
         self.dao
             .create_identity(identity, Some(st_hash.clone()), sql_transaction)
+            .await
+            .unwrap();
+    }
+
+    pub async fn handle_identity_create_from_shielded_pool(
+        &self,
+        state_transition: IdentityCreateFromShieldedPoolTransition,
+        st_hash: String,
+        sql_transaction: &Transaction<'_>,
+    ) -> () {
+        let identifier = state_transition.identity_id();
+
+        let identity = Identity {
+            identifier,
+            owner: identifier,
+            revision: 0u64,
+            balance: Some(state_transition.denomination()),
+            is_system: false,
+        };
+
+        let transfer = Transfer {
+            sender: None,
+            recipient: Some(identifier),
+            amount: state_transition.denomination(),
+        };
+
+        self.dao
+            .create_identity(identity, Some(st_hash.clone()), sql_transaction)
+            .await
+            .unwrap();
+        self.dao
+            .create_transfer(transfer, st_hash.clone(), sql_transaction)
             .await
             .unwrap();
     }

--- a/packages/indexer/src/processor/psql/handlers/handle_st.rs
+++ b/packages/indexer/src/processor/psql/handlers/handle_st.rs
@@ -369,7 +369,15 @@ impl PSQLProcessor {
             StateTransition::Unshield(_) => {}
             StateTransition::ShieldFromAssetLock(_) => {}
             StateTransition::ShieldedWithdrawal(_) => {}
-            StateTransition::IdentityCreateFromShieldedPool(_) => {}
+            StateTransition::IdentityCreateFromShieldedPool(st) => {
+                self.handle_identity_create_from_shielded_pool(st, st_hash, sql_transaction)
+                    .await;
+
+                println!(
+                    "Processed IdentityCreateFromShieldedPool at block hash {}",
+                    block_hash
+                );
+            }
         }
     }
 }

--- a/packages/indexer/src/processor/psql/mod.rs
+++ b/packages/indexer/src/processor/psql/mod.rs
@@ -3,7 +3,7 @@ mod dao;
 use crate::decoder::decoder::StateTransitionDecoder;
 use crate::entities::data_contract::DataContract;
 use crate::entities::document::Document;
-use crate::processor::psql::dao::PostgresDAO;
+pub use crate::processor::psql::dao::PostgresDAO;
 use dashcore_rpc::Client;
 use data_contracts::SystemDataContract;
 use deadpool_postgres::{PoolError, Transaction};


### PR DESCRIPTION
# Issue
Currently indexer doesn't handle IdentityCreateFromShieldedPool state transition type. That's mean that we get error when identity from shield create transition

# Things done
- Impllemented `handle_identity_create_from_shielded_pool`
- Implemented `drop_db` and `migrate` args for indexer (`cargo run drop_db && cargo run migrate && cargo run`)