### PR TITLE
Add trigger on tag for `Build and push packages` CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build and push packages
 
 on:
   push:
+    tags:
+      - '*'
     branches:
       - 'develop'
   pull_request:


### PR DESCRIPTION
# Issue
After update of CI for `Build and push packages` was disabled trigger on tags

# Things done
- Added trigger on tags