### PR TITLE
Add info for pending epoch

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -190,6 +190,12 @@ already-completed epochs. For the current (in-progress) epoch they are `null`.
 * epoch.totalCreatedStorageFees - total storage fees created in the epoch (credits)
 * epoch.coreBlockRewards - core block rewards for the epoch
 
+For the current (in-progress) epoch, live values are computed from the indexed
+data instead. For already-completed epochs they are `null`.
+
+* pendingBlocksInEpoch - number of blocks produced in the epoch so far
+* pendingEpochReward - fees collected in the epoch so far (credits)
+
 
 ```
 HTTP /epoch/2492
@@ -228,7 +234,9 @@ HTTP /epoch/2492
   },
   "totalVotesCount": 12,
   "totalVotesGasUsed": 120000000,
-  "totalTxCount": 49
+  "totalTxCount": 49,
+  "pendingBlocksInEpoch": null,
+  "pendingEpochReward": null
 }
 ```
 ---

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -1346,6 +1346,15 @@ Response codes:
 ---
 ### Identity by Identifier
 Return identity by given identifier
+
+Every endpoint that returns aliases uses the same alias entry shape:
+
+* contested - whether the name matches the DPNS contested-name pattern
+* status - alias state:
+  * `ok` - the identity owns the alias
+  * `pending` - the masternode vote for the contested name is still in progress
+  * `locked` - the contested name was locked or won by another identity
+  * `unknown` - the name was contested, but dapi doesn't provide contested vote state
 ```
 GET /identity/EP1g5AGP8QGYMXXUYdmSvhbVxggNURDbvpckF39mTxs3
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -18,7 +18,7 @@
     "bs58": "^6.0.0",
     "cbor": "^9.0.2",
     "dash-core-sdk": "1.1.0-dev.2",
-    "dash-platform-sdk": "1.5.0-dev.2",
+    "dash-platform-sdk": "1.5.0-dev.7",
     "dotenv": "^16.3.1",
     "fastify": "^4.21.0",
     "fastify-metrics": "^11.0.0",

--- a/packages/api/src/dao/EpochDAO.js
+++ b/packages/api/src/dao/EpochDAO.js
@@ -81,38 +81,56 @@ module.exports = class EpochDAO {
       .limit(1)
       .as('epochInfo')
 
-    const [row] = await this.knex(bestValidator)
-      .orderBy('rating', 'desc')
-      .limit(1)
-      .select(
-        'validator as best_validator',
-        this.knex(epochInfo).select('total_tx_count').as('total_tx_count'),
-        this.knex(epochInfo).select('total_collected_fees').as('total_collected_fees'),
-        this.knex(epochInfo).select('tps').as('tps'),
-        this.knex(votesSubquery).select('index_values').as('top_voted_resource'),
-        this.knex(votes)
-          .count('* as yes')
-          .where('choice', '=', ChoiceEnum.TowardsIdentity)
-          .as('resource_votes_yes'),
-        this.knex(votes)
-          .count('* as abstain')
-          .where('choice', '=', ChoiceEnum.ABSTAIN)
-          .as('resource_votes_abstain'),
-        this.knex(votes)
-          .count('* as lock')
-          .where('choice', '=', ChoiceEnum.LOCK)
-          .as('resource_votes_lock'),
-        this.knex(votersSubquery).select('voter_identity_id').limit(1).as('voter_identity_id'),
-        this.knex(votersSubquery).select('voter_yes').limit(1).as('voter_yes'),
-        this.knex(votersSubquery).select('voter_abstain').limit(1).as('voter_abstain'),
-        this.knex(votersSubquery).select('voter_lock').limit(1).as('voter_lock'),
-        this.knex(votesBaseSubquery)
+    const isInProgressEpoch = epoch.totalBlocksInEpoch === null && epoch.endTime > Date.now()
+
+    const columns = [
+      this.knex(bestValidator)
+        .select('validator')
+        .orderBy('rating', 'desc')
+        .limit(1)
+        .as('best_validator'),
+      this.knex(epochInfo).select('total_tx_count').as('total_tx_count'),
+      this.knex(epochInfo).select('total_collected_fees').as('total_collected_fees'),
+      this.knex(epochInfo).select('tps').as('tps'),
+      this.knex(votesSubquery).select('index_values').as('top_voted_resource'),
+      this.knex(votes)
+        .count('* as yes')
+        .where('choice', '=', ChoiceEnum.TowardsIdentity)
+        .as('resource_votes_yes'),
+      this.knex(votes)
+        .count('* as abstain')
+        .where('choice', '=', ChoiceEnum.ABSTAIN)
+        .as('resource_votes_abstain'),
+      this.knex(votes)
+        .count('* as lock')
+        .where('choice', '=', ChoiceEnum.LOCK)
+        .as('resource_votes_lock'),
+      this.knex(votersSubquery).select('voter_identity_id').limit(1).as('voter_identity_id'),
+      this.knex(votersSubquery).select('voter_yes').limit(1).as('voter_yes'),
+      this.knex(votersSubquery).select('voter_abstain').limit(1).as('voter_abstain'),
+      this.knex(votersSubquery).select('voter_lock').limit(1).as('voter_lock'),
+      this.knex(votesBaseSubquery)
+        .count('*')
+        .as('total_votes'),
+      this.knex(votesBaseSubquery)
+        .sum('gas_used')
+        .as('total_votes_gas_used')
+    ]
+
+    if (isInProgressEpoch) {
+      columns.push(
+        this.knex('blocks')
           .count('*')
-          .as('total_votes'),
-        this.knex(votesBaseSubquery)
+          .where('height', '>=', Number(epoch.firstBlockHeight))
+          .as('pending_blocks_in_epoch'),
+        this.knex('state_transitions')
           .sum('gas_used')
-          .as('total_votes_gas_used')
+          .where('block_height', '>=', Number(epoch.firstBlockHeight))
+          .as('pending_epoch_reward')
       )
+    }
+
+    const [row] = await this.knex.select(columns)
 
     return EpochData.fromObject({ epoch, ...row })
   }

--- a/packages/api/src/models/EpochData.js
+++ b/packages/api/src/models/EpochData.js
@@ -8,8 +8,10 @@ module.exports = class EpochData {
   totalVotesCount
   totalVotesGasUsed
   totalTxCount
+  pendingBlocksInEpoch
+  pendingEpochReward
 
-  constructor (epoch, tps, totalCollectedFees, bestValidator, topVotedResource, bestVoter, totalVotesCount, totalVotesGasUsed, totalTxCount) {
+  constructor (epoch, tps, totalCollectedFees, bestValidator, topVotedResource, bestVoter, totalVotesCount, totalVotesGasUsed, totalTxCount, pendingBlocksInEpoch, pendingEpochReward) {
     this.epoch = epoch ?? null
     this.tps = tps ?? null
     this.totalCollectedFees = totalCollectedFees ?? null
@@ -19,6 +21,8 @@ module.exports = class EpochData {
     this.totalVotesCount = totalVotesCount ?? null
     this.totalVotesGasUsed = totalVotesGasUsed ?? null
     this.totalTxCount = totalTxCount ?? null
+    this.pendingBlocksInEpoch = pendingBlocksInEpoch ?? null
+    this.pendingEpochReward = pendingEpochReward ?? null
   }
 
   /* eslint-disable camelcase */
@@ -37,7 +41,9 @@ module.exports = class EpochData {
     resource_votes_lock,
     total_votes,
     total_votes_gas_used,
-    total_tx_count
+    total_tx_count,
+    pending_blocks_in_epoch,
+    pending_epoch_reward
   }) {
     return new EpochData(
       epoch,
@@ -58,7 +64,9 @@ module.exports = class EpochData {
       },
       Number(total_votes ?? 0),
       Number(total_votes_gas_used ?? 0),
-      Number(total_tx_count ?? 0)
+      Number(total_tx_count ?? 0),
+      pending_blocks_in_epoch !== undefined ? Number(pending_blocks_in_epoch ?? 0) : null,
+      pending_epoch_reward !== undefined ? Number(pending_epoch_reward ?? 0) : null
     )
   }
 }

--- a/packages/api/src/utils.js
+++ b/packages/api/src/utils.js
@@ -1744,6 +1744,16 @@ const buildIndexBuffer = (name) => {
 const getAliasStateByVote = (aliasInfo, alias, identifier) => {
   let status = null
 
+  if (aliasInfo.unknownState) {
+    return Alias.fromObject({
+      alias: alias.alias ?? alias,
+      status: 'unknown',
+      contested: true,
+      timestamp: alias.timestamp ? new Date(alias.timestamp) : null,
+      txHash: alias.tx
+    })
+  }
+
   if (aliasInfo.contestedState === null) {
     return Alias.fromObject({
       alias: alias.alias,
@@ -1801,18 +1811,26 @@ const getAliasInfo = async (aliasText, sdk) => {
 
     const labelBuffer = buildIndexBuffer(normalizedLabel)
 
-    const contestedState = await sdk.contestedResources.getContestedResourceVoteState(
-      DataContractWASM.fromValue(dpnsContract, true),
-      'domain',
-      'parentNameAndLabel',
-      [
-        domainBuffer,
-        labelBuffer
-      ],
-      ContestedStateResultType.DOCUMENTS_AND_VOTE_TALLY
-    )
+    try {
+      const contestedState = await sdk.contestedResources.getContestedResourceVoteState(
+        DataContractWASM.fromValue(dpnsContract, true),
+        'domain',
+        'parentNameAndLabel',
+        [
+          domainBuffer,
+          labelBuffer
+        ],
+        ContestedStateResultType.DOCUMENTS_AND_VOTE_TALLY
+      )
 
-    return { alias: aliasText, contestedState }
+      return { alias: aliasText, contestedState }
+    } catch (e) {
+      if (e.message !== 'Vote state not found') {
+        throw e
+      }
+
+      return { alias: aliasText, contestedState: null, unknownState: true }
+    }
   }
 
   return { alias: aliasText, contestedState: null }

--- a/packages/api/test/integration/epochs.spec.js
+++ b/packages/api/test/integration/epochs.spec.js
@@ -160,9 +160,71 @@ describe('Epoch routes', () => {
         },
         totalVotesCount: 465,
         totalVotesGasUsed: masternodeVotesGas,
-        totalTxCount: identities.length + transactions.length
+        totalTxCount: identities.length + transactions.length,
+        pendingBlocksInEpoch: null,
+        pendingEpochReward: null
       }
       assert.deepEqual(body, expectedBlock)
+    })
+
+    it('should return live block count for the epoch in progress', async () => {
+      const startTime = Date.now() - 900000
+
+      mock.method(NodeController.prototype, 'getEpochsInfo', () => [
+        {
+          number: 1,
+          firstBlockHeight: 21,
+          firstCoreBlockHeight: 1,
+          startTime,
+          feeMultiplier: 1
+        }
+      ])
+      mock.method(NodeController.prototype, 'getFinalizedEpochsInfo', () => {
+        throw new Error('Epoch is not finalized yet')
+      })
+
+      const { body } = await client.get('/epoch/1')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const expectedEpoch = {
+        epoch: {
+          number: 1,
+          firstBlockHeight: '21',
+          firstCoreBlockHeight: 1,
+          startTime,
+          feeMultiplier: '1',
+          endTime: startTime + 3600000,
+          totalBlocksInEpoch: null,
+          totalProcessingFees: null,
+          totalDistributedStorageFees: null,
+          totalCreatedStorageFees: null,
+          coreBlockRewards: null
+        },
+        tps: 0,
+        totalCollectedFees: 0,
+        bestValidator: null,
+        bestVoter: {
+          totalCountAbstain: 0,
+          totalCountTowardsIdentity: 0,
+          totalCountLock: 0,
+          identifier: null
+        },
+        topVotedResource: {
+          totalCountAbstain: 0,
+          totalCountTowardsIdentity: 0,
+          totalCountLock: 0,
+          resourceValue: null
+        },
+        totalVotesCount: 0,
+        totalVotesGasUsed: 0,
+        totalTxCount: 0,
+        pendingBlocksInEpoch: 10,
+        pendingEpochReward: transactions
+          .filter((transaction) => transaction.block_height >= 21)
+          .reduce((acc, transaction) => acc + transaction.gas_used, 0)
+      }
+      assert.deepEqual(body, expectedEpoch)
     })
 
     it('should return error if not valid date', async () => {

--- a/packages/api/test/integration/identities.spec.js
+++ b/packages/api/test/integration/identities.spec.js
@@ -268,6 +268,47 @@ describe('Identities routes', () => {
       assert.deepEqual(body, expectedIdentity)
     })
 
+    it('should return identity when contested vote state is not found', async (t) => {
+      const block = await fixtures.block(knex, { timestamp: new Date(0) })
+      const owner = await fixtures.identity(knex, { block_hash: block.hash, block_height: block.height })
+
+      const transaction = await fixtures.transaction(knex, {
+        block_hash: block.hash,
+        block_height: block.height,
+        type: StateTransitionEnum.IDENTITY_CREATE,
+        owner: owner.identifier,
+        data: ''
+      })
+      const identity = await fixtures.identity(knex, {
+        block_hash: block.hash,
+        block_height: block.height,
+        state_transition_hash: transaction.hash
+      })
+      const alias = await fixtures.identity_alias(knex,
+        {
+          alias: 'test.dash',
+          identity,
+          state_transition_hash: transaction.hash
+        }
+      )
+
+      t.mock.method(ContestedResourcesController.prototype, 'getContestedResourceVoteState', async () => {
+        throw new Error('Vote state not found')
+      })
+
+      const { body } = await client.get(`/identity/${identity.identifier}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.deepEqual(body.aliases, [{
+        alias: alias.alias,
+        contested: true,
+        status: 'unknown',
+        timestamp: '1970-01-01T00:00:00.000Z',
+        txHash: alias.state_transition_hash
+      }])
+    })
+
     it('should return 404 when identity not found', async () => {
       await client.get('/identity/Cxo56ta5EMrWok8yp2Gpzm8cjBoa3mGYKZaAp9yqD3gW')
         .expect(404)

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -1313,6 +1313,15 @@ Response codes:
 ---
 ### Identity by Identifier
 Return identity by given identifier
+
+Every endpoint that returns aliases uses the same alias entry shape:
+
+* contested - whether the name matches the DPNS contested-name pattern
+* status - alias state:
+  * `ok` - the identity owns the alias
+  * `pending` - the masternode vote for the contested name is still in progress
+  * `locked` - the contested name was locked or won by another identity
+  * `unknown` - the name was contested, but dapi doesn't provide contested vote state
 ```
 GET /identity/EP1g5AGP8QGYMXXUYdmSvhbVxggNURDbvpckF39mTxs3
 

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -144,6 +144,7 @@ If you want to get the last epoch don't set epoch index
 
 * tps - Transactions per second
 * totalCollectedFees - total number or fees spent per epoch
+* totalTxCount - total number of transactions in the epoch
 * bestValidator - validator with most validated blocks
 * epoch number can be null
 
@@ -155,6 +156,12 @@ already-completed epochs. For the current (in-progress) epoch they are `null`.
 * epoch.totalDistributedStorageFees - total storage fees distributed in the epoch (credits)
 * epoch.totalCreatedStorageFees - total storage fees created in the epoch (credits)
 * epoch.coreBlockRewards - core block rewards for the epoch
+
+For the current (in-progress) epoch, live values are computed from the indexed
+data instead. For already-completed epochs they are `null`.
+
+* pendingBlocksInEpoch - number of blocks produced in the epoch so far
+* pendingEpochReward - fees collected in the epoch so far (credits)
 
 
 ```
@@ -193,7 +200,10 @@ HTTP /epoch/2492
     "totalCountLock": 2
   },
   "totalVotesCount": 12,
-  "totalVotesGasUsed": 120000000
+  "totalVotesGasUsed": 120000000,
+  "totalTxCount": 49,
+  "pendingBlocksInEpoch": null,
+  "pendingEpochReward": null
 }
 ```
 ---


### PR DESCRIPTION
# Issue
Currently API doesn't provide info about blocks and rewards for current(pending) epoch. 
Also exist [issue](https://github.com/dashpay/platform/issues/4128) with contested vote states which broke identities

# Things done
- Added pending info for epoch info
- Updated aliases flow
- Implemented new tests
- Updated docs