### PR TITLE
Expand epoch info

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -46,10 +46,12 @@ Reference:
 * [Block by hash](#block-by-hash)
 * [Blocks by validator](#blocks-by-validator)
 * [Blocks](#blocks)
+* [Average Block Time History](#average-block-time-history)
 * [Validators](#validators)
 * [Validator by ProTxHash](#validator-by-protxhash)
 * [Validator by Masternode Identifier](#validator-by-masternode-identifier)
 * [Validator Rewards Statistic](#validator-rewards-stats-by-protxhash)
+* [Validator Income Statistic](#validator-income-stats-by-protxhash)
 * [Validator Blocks Statistic](#validator-stats-by-protxhash)
 * [Transaction by hash](#transaction-by-hash)
 * [Transactions](#transactions)
@@ -59,6 +61,7 @@ Reference:
 * [Data Contracts](#data-contracts)
 * [Data Contract Transactions](#data-contract-transactions)
 * [Data Contracts Rating](#data-contracts-rating)
+* [Active Data Contracts](#active-data-contracts)
 * [Document by Identifier](#document-by-identifier)
 * [RAW Document by Identifier](#raw-document-by-identifier)
 * [Document Revisions](#document-revisions)
@@ -196,6 +199,8 @@ data instead. For already-completed epochs they are `null`.
 * pendingBlocksInEpoch - number of blocks produced in the epoch so far
 * pendingEpochReward - fees collected in the epoch so far (credits)
 
+`avgBlockTime` is the average time between consecutive blocks in the epoch in milliseconds, or `null` when the epoch contains less than two blocks.
+
 
 ```
 HTTP /epoch/2492
@@ -235,6 +240,11 @@ HTTP /epoch/2492
   "totalVotesCount": 12,
   "totalVotesGasUsed": 120000000,
   "totalTxCount": 49,
+  "totalCreatedDocumentsCount": 14,
+  "totalDeletedDocumentsCount": 2,
+  "totalRegisteredNamesCount": 5,
+  "totalContestedDocumentsCount": 3,
+  "avgBlockTime": 933,
   "pendingBlocksInEpoch": null,
   "pendingEpochReward": null
 }
@@ -361,6 +371,31 @@ GET /blocks?epoch_index_min=1000&epoch_index_max=1200&height_min=2000&height_max
 }
 ```
 ---
+### Average Block Time History
+Return a series data for the average block time chart. `avgBlockTime` is the average time between consecutive blocks in the interval in milliseconds, or `null` when the interval contains less than two blocks
+
+* `timestamp_start` lower interval threshold in ISO string
+* `timestamp_end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /blocks/avgBlockTime/history?timestamp_start=2024-01-01T00:00:00&timestamp_end=2025-01-01T00:00:00
+[
+    {
+        "timestamp": "2024-06-23T13:51:44.154Z",
+        "data": {
+          "avgBlockTime": 5210
+        }
+    }, ...
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check start/end values
+500: Internal Server Error
+```
+---
 ### Validators
 Return all validators with pagination info.
 * Valid `order` values are `asc` or `desc`
@@ -373,6 +408,8 @@ Return all validators with pagination info.
 * `last_proposed_block_height_min` and `last_proposed_block_height_min` minimum and maximum last proposed blocks height
 * `last_proposed_block_timestamp_start` and `last_proposed_block_timestamp_end` timestamp start and end for last proposed blocks
 * `last_proposed_block_hash` hash of last proposed block
+* `geoIpInfo` contains the node location resolved from its service IP with the [DB-IP City Lite](https://db-ip.com) database; it is `null` when the service address has no IPv4 host, and its fields are `null` when the IP is not present in the database
+* the DB-IP City Lite database is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/): any page displaying `geoIpInfo` data must include an attribution link back to DB-IP.com, e.g. `<a href='https://db-ip.com'>IP Geolocation by DB-IP</a>`
 ```
 GET /validators?blocks_proposed_min=1&blocks_proposed_max=9999999&last_proposed_block_height_min=190458&last_proposed_block_height_max=197458&last_proposed_block_timestamp_start=2025-10-11T02:46:09.433Z&last_proposed_block_timestamp_end=2025-10-12T02:46:09.433Z&last_proposed_block_hash=9151C25609D85610C416450B4648CCB4671E373452EA8FA21AC0DF77D03039E1&is_active=true&limit=10&page=1&order=asc&owner=PJUBWbXWmzEYCs99rAAbnCiHRzrnhKLQrXbmSsuPBYB
 
@@ -439,7 +476,14 @@ GET /validators?blocks_proposed_min=1&blocks_proposed_max=9999999&last_proposed_
             "withdrawalsCount": null,
             "lastWithdrawal": null,
             "lastWithdrawalTime": null,
-            "endpoints": null
+            "endpoints": null,
+            "geoIpInfo": {
+                "ipv4": "52.24.124.162",
+                "countryCode": "US",
+                "city": "Boardman",
+                "latitude": 45.8399,
+                "longitude": -119.7009
+            }
         }
     ]
 }
@@ -448,6 +492,8 @@ GET /validators?blocks_proposed_min=1&blocks_proposed_max=9999999&last_proposed_
 ### Validator by ProTxHash
 Get validator by ProTxHash.
 * `lastProposedBlockHeader` field is nullable
+* `geoIpInfo` contains the node location resolved from its service IP with the [DB-IP City Lite](https://db-ip.com) database; it is `null` when the service address has no IPv4 host, and its fields are `null` when the IP is not present in the database
+* the DB-IP City Lite database is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/): any page displaying `geoIpInfo` data must include an attribution link back to DB-IP.com, e.g. `<a href='https://db-ip.com'>IP Geolocation by DB-IP</a>`
 ```
 GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
@@ -525,6 +571,13 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
       "status": 'ERROR',
       "message": null
     }
+  },
+  "geoIpInfo": {
+    "ipv4": "35.164.23.245",
+    "countryCode": "US",
+    "city": "Boardman",
+    "latitude": 45.8399,
+    "longitude": -119.7009
   }
 }
 ```
@@ -609,6 +662,13 @@ GET /validator/identity/8tsWRSwsTM5AXv4ViCF9gu39kzjbtfFDM6rCyL2RcFzd
       "status": 'ERROR',
       "message": null
     }
+  },
+  "geoIpInfo": {
+    "ipv4": "35.164.23.245",
+    "countryCode": "US",
+    "city": "Boardman",
+    "latitude": 45.8399,
+    "longitude": -119.7009
   }
 }
 ```
@@ -627,6 +687,25 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/
         "timestamp": "2024-06-23T13:51:44.154Z",
         "data": {
             "reward": 34000000
+        }
+    },...
+]
+```
+---
+### Validator income stats by ProTxHash
+Return a series data for the validator income chart. Income per interval is estimated as the validator share of collected fees, proportional to the number of blocks it proposed (matching the platform fee pool distribution between epoch proposers)
+
+* `timestamp_start` lower interval threshold in ISO string
+* `timestamp_end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/income/stats?timestamp_start=2024-01-01T00:00:00&timestamp_end=2025-01-01T00:00:00
+[
+    {
+        "timestamp": "2024-06-23T13:51:44.154Z",
+        "data": {
+            "income": 17000000
         }
     },...
 ]
@@ -1177,6 +1256,44 @@ GET /dataContracts/rating?timestamp_start=2025-08-18T21:13:57.191Z&timestamp_end
 Response codes:
 ```
 200: OK
+500: Internal Server Error
+```
+---
+### Active Data Contracts
+Return data contracts that had state transitions within a time range, ordered by their
+transitions count in that range, paged. Unlike the rating endpoint, contracts without
+activity in the range are not included
+
+* `timestamp_start` lower interval threshold (defaults to one hour ago)
+* `timestamp_end` upper interval threshold (defaults to now)
+* `limit` cannot be more than 100
+* `page` cannot be less than 1
+* Valid `order` values are `asc` or `desc`
+```
+GET /dataContracts/active?timestamp_start=2025-01-01T00:00:00.000Z&timestamp_end=2025-01-02T00:00:00.000Z&page=1&limit=10&order=desc
+
+{
+    "resultSet": [
+        {
+            "identifier": "465jdPpFCZefhb4g2k2FpCcrKpPYhJJskDqbGFsKu6wb",
+            "transitionsCount": 26
+        },
+        {
+            "identifier": "GWghYQoDFEb3osEfigrF7CKdZLWauxC7TwM4jsJyqa23",
+            "transitionsCount": 21
+        }, ...
+    ],
+    "pagination": {
+        "page": 1,
+        "limit": 10,
+        "total": 14
+    }
+}
+```
+Response codes:
+```
+200: OK
+400: Bad timestamp range
 500: Internal Server Error
 ```
 ---
@@ -2058,11 +2175,69 @@ Response codes:
 500: Internal Server Error
 ```
 ___
+### Transactions Input history
+Return a series data for the chart of the total amount entering the platform from the core chain (identity create, identity top up, address funding from asset lock and shield-from-asset-lock transitions)
+
+* `timestamp_start` lower interval threshold in ISO string
+* `timestamp_end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /transactions/input/history?timestamp_start=2024-01-01T00:00:00&timestamp_end=2025-01-01T00:00:00
+[
+    {
+        "timestamp": "2024-04-22T08:45:20.911Z",
+        "data": {
+          "amount": 100000000,
+          "blockHeight": 64060,
+          "blockHash": "4A1F6B5238032DDAC55009A28797D909DB4288D5B5EC14B86DEC6EA8F25EC71A"
+        }
+    }, ...
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check start/end values
+500: Internal Server Error
+```
+___
+### Transactions Output history
+Return a series data for the chart of the total amount leaving the platform to the core chain (identity credit withdrawal, address credit withdrawal and shielded withdrawal transitions)
+
+* `timestamp_start` lower interval threshold in ISO string
+* `timestamp_end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /transactions/output/history?timestamp_start=2024-01-01T00:00:00&timestamp_end=2025-01-01T00:00:00
+[
+    {
+        "timestamp": "2024-04-22T08:45:20.911Z",
+        "data": {
+          "amount": 50000000,
+          "blockHeight": 64333,
+          "blockHash": "507659D9BE2FF76A031F4219061F3D2D39475A7FA4B24F25AEFDB34CD4DF2A57"
+        }
+    }, ...
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check start/end values
+500: Internal Server Error
+```
+___
 ### Transactions Statistic
 Return the count of state transitions grouped by transaction type.
 
+Optionally accepts a time interval. Without parameters the statistic is calculated over all time.
+
+* `timestamp_start` and `timestamp_end` must be set together
+
 ```
-GET /transactions/statistic
+GET /transactions/statistic?timestamp_start=2024-10-01T00:00:00.000Z&timestamp_end=2024-11-01T00:00:00.000Z
 [
     {
         "transactionType": "DATA_CONTRACT_CREATE",
@@ -2077,6 +2252,7 @@ GET /transactions/statistic
 Response codes:
 ```
 200: OK
+400: Invalid input, check start/end values
 500: Internal Server Error
 ```
 ___

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2263,6 +2263,7 @@ Return an aggregate overview of the shielded pool.
 * `totalShieldedOut` — total credits moved out of the pool (`UNSHIELD` + `SHIELDED_WITHDRAWAL` + `IDENTITY_CREATE_FROM_SHIELDED_POOL`), as a string
 * `poolBalance` — `totalShieldedIn` − `totalShieldedOut`, an estimate of the current shielded pool size, as a string
 * `transitionsCount` — total number of shielded transitions
+* `notesCount` — total count of notes (leaves) in the shielded notes commitment tree, fetched from the platform; `null` when unavailable
 * `types` — per-type breakdown with `count` and summed `amount` (string)
 
 Note: `SHIELDED_TRANSFER` stays inside the pool and is counted in `types`/`transitionsCount` but excluded from `totalShieldedIn`/`totalShieldedOut`.
@@ -2274,6 +2275,7 @@ GET /transactions/shielded/statistic
     "totalShieldedOut": "150000000",
     "poolBalance": "150000000",
     "transitionsCount": 6,
+    "notesCount": 14,
     "types": [
         {
             "transactionType": "SHIELD",

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -192,6 +192,7 @@ already-completed epochs. For the current (in-progress) epoch they are `null`.
 * epoch.totalDistributedStorageFees - total storage fees distributed in the epoch (credits)
 * epoch.totalCreatedStorageFees - total storage fees created in the epoch (credits)
 * epoch.coreBlockRewards - core block rewards for the epoch
+* epoch.blockProposers - block proposers of the finalized epoch, each `{ proposer, count }` where `proposer` is the validator ProTxHash (hex) and `count` is the number of blocks it proposed
 
 For the current (in-progress) epoch, live values are computed from the indexed
 data instead. For already-completed epochs they are `null`.
@@ -217,7 +218,13 @@ HTTP /epoch/2492
     "totalProcessingFees": "1897008860",
     "totalDistributedStorageFees": "0",
     "totalCreatedStorageFees": "13860000000",
-    "coreBlockRewards": "1932735784"
+    "coreBlockRewards": "1932735784",
+    "blockProposers": [
+      {
+        "proposer": "87075234AC47353B42BB97CE46330CB67CD4648C01F0B2393D7E729B0D678918",
+        "count": 3742
+      }
+    ]
   },
   "tps": 0.0140315750528904,
   "totalCollectedFees": 1897008860,

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@dashevo/dashd-rpc": "github:owl352/dashd-rpc",
     "@fastify/cors": "^8.3.0",
+    "@ip-location-db/dbip-city-mmdb": "latest",
     "@scure/base": "^1.1.5",
     "bs58": "^6.0.0",
     "cbor": "^9.0.2",
@@ -23,6 +24,7 @@
     "fastify": "^4.21.0",
     "fastify-metrics": "^11.0.0",
     "knex": "^2.5.1",
+    "mmdb-lib": "^3.0.2",
     "node-fetch": "^2.6.11",
     "pg": "^8.11.3"
   },

--- a/packages/api/src/constants.js
+++ b/packages/api/src/constants.js
@@ -12,6 +12,8 @@ module.exports = {
   DPNS_CONTRACT: 'GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec',
   WITHDRAWAL_CONTRACT: '4fJLR2GYTPFdomuTVvNy3VRrvWgvkKPzqehEBpNf2nk6',
   NETWORK: process.env.NETWORK ?? 'testnet',
+  GEOIP_PROVIDER: '@ip-location-db/dbip-city-mmdb',
+  GEOIP_TABLE_NAME: 'dbip-city-ipv4.mmdb',
   get genesisTime () {
     if (!genesisTime || isNaN(genesisTime)) {
       return TenderdashRPC.getBlockByHeight(1).then((blockInfo) => {

--- a/packages/api/src/controllers/BlocksController.js
+++ b/packages/api/src/controllers/BlocksController.js
@@ -1,4 +1,6 @@
 const BlocksDAO = require('../dao/BlocksDAO')
+const { calculateInterval, iso8601duration } = require('../utils')
+const Intervals = require('../enums/IntervalsEnum')
 const { EPOCH_CHANGE_TIME, NETWORK } = require('../constants')
 const DashCoreRPC = require('../dashcoreRpc')
 const TenderdashRPC = require('../tenderdashRpc')
@@ -72,6 +74,40 @@ class BlocksController {
     }
 
     response.send(block)
+  }
+
+  getAvgBlockTimeHistory = async (request, response) => {
+    const {
+      timestamp_start: timestampStart = new Date().getTime() - 3600000,
+      timestamp_end: timestampEnd = new Date().getTime(),
+      intervalsCount = null
+    } = request.query
+
+    if (!timestampStart || !timestampEnd) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
+
+    if (timestampStart > timestampEnd) {
+      return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
+    }
+
+    const intervalInMs =
+      Math.ceil(
+        (new Date(timestampEnd).getTime() - new Date(timestampStart).getTime()) / Number(intervalsCount ?? NaN) / 1000
+      ) * 1000
+
+    const interval = intervalsCount
+      ? iso8601duration(intervalInMs)
+      : calculateInterval(new Date(timestampStart), new Date(timestampEnd))
+
+    const timeSeries = await this.blocksDAO.getAvgBlockTimeHistorySeries(
+      new Date(timestampStart),
+      new Date(timestampEnd),
+      interval,
+      isNaN(intervalInMs) ? Intervals[interval] : intervalInMs
+    )
+
+    response.send(timeSeries)
   }
 
   getBlocks = async (request, response) => {

--- a/packages/api/src/controllers/DataContractsController.js
+++ b/packages/api/src/controllers/DataContractsController.js
@@ -95,6 +95,30 @@ class DataContractsController {
     response.send(transactions)
   }
 
+  getActiveDataContracts = async (request, response) => {
+    const {
+      timestamp_start: start = new Date().getTime() - 3600000,
+      timestamp_end: end = new Date().getTime(),
+      page = 1,
+      limit = 10,
+      order = 'asc'
+    } = request.query
+
+    if (start && end && new Date(start).getTime() >= new Date(end).getTime()) {
+      return response.status(400).send('Bad timestamp range')
+    }
+
+    const dataContracts = await this.dataContractsDAO.getActiveDataContracts(
+      new Date(start),
+      new Date(end),
+      Number(page ?? 1),
+      Number(limit ?? 10),
+      order
+    )
+
+    response.send(dataContracts)
+  }
+
   getDataContractTrends = async (request, response) => {
     const {
       page = 1,

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -417,7 +417,12 @@ class TransactionsController {
   getShieldedStatistic = async (request, response) => {
     const info = await this.transactionsDAO.getShieldedStatistic()
 
-    response.send(info)
+    const notesCount = await this.sdk.shielded.getShieldedNotesCount()
+
+    response.send({
+      ...info,
+      notesCount: notesCount !== undefined ? Number(notesCount) : null
+    })
   }
 }
 

--- a/packages/api/src/controllers/TransactionsController.js
+++ b/packages/api/src/controllers/TransactionsController.js
@@ -325,8 +325,91 @@ class TransactionsController {
     response.send(timeSeries)
   }
 
+  getInputHistorySeries = async (request, response) => {
+    const {
+      timestamp_start: start = new Date().getTime() - 3600000,
+      timestamp_end: end = new Date().getTime(),
+      intervalsCount = null
+    } = request.query
+
+    if (!start || !end) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
+
+    if (start > end) {
+      return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
+    }
+
+    const intervalInMs =
+      Math.ceil(
+        (new Date(end).getTime() - new Date(start).getTime()) / Number(intervalsCount ?? NaN) / 1000
+      ) * 1000
+
+    const interval = intervalsCount
+      ? iso8601duration(intervalInMs)
+      : calculateInterval(new Date(start), new Date(end))
+
+    const timeSeries = await this.transactionsDAO.getFundsFlowHistorySeries(
+      new Date(start),
+      new Date(end),
+      interval,
+      isNaN(intervalInMs) ? Intervals[interval] : intervalInMs,
+      true
+    )
+
+    response.send(timeSeries)
+  }
+
+  getOutputHistorySeries = async (request, response) => {
+    const {
+      timestamp_start: start = new Date().getTime() - 3600000,
+      timestamp_end: end = new Date().getTime(),
+      intervalsCount = null
+    } = request.query
+
+    if (!start || !end) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
+
+    if (start > end) {
+      return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
+    }
+
+    const intervalInMs =
+      Math.ceil(
+        (new Date(end).getTime() - new Date(start).getTime()) / Number(intervalsCount ?? NaN) / 1000
+      ) * 1000
+
+    const interval = intervalsCount
+      ? iso8601duration(intervalInMs)
+      : calculateInterval(new Date(start), new Date(end))
+
+    const timeSeries = await this.transactionsDAO.getFundsFlowHistorySeries(
+      new Date(start),
+      new Date(end),
+      interval,
+      isNaN(intervalInMs) ? Intervals[interval] : intervalInMs,
+      false
+    )
+
+    response.send(timeSeries)
+  }
+
   getTransactionStatistic = async (request, response) => {
-    const info = await this.transactionsDAO.getTransactionStatistic()
+    const {
+      timestamp_start: timestampStart = null,
+      timestamp_end: timestampEnd = null
+    } = request.query
+
+    if ((timestampStart && !timestampEnd) || (!timestampStart && timestampEnd)) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
+
+    if (new Date(timestampStart).getTime() > new Date(timestampEnd).getTime()) {
+      return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
+    }
+
+    const info = await this.transactionsDAO.getTransactionStatistic(timestampStart, timestampEnd)
 
     response.send(info)
   }

--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -3,6 +3,7 @@ const TenderdashRPC = require('../tenderdashRpc')
 const Validator = require('../models/Validator')
 const DashCoreRPC = require('../dashcoreRpc')
 const ProTxInfo = require('../models/ProTxInfo')
+const GeoIP = require('../geoip')
 const { checkTcpConnect, calculateInterval, iso8601duration } = require('../utils')
 const Epoch = require('../models/Epoch')
 const { base58 } = require('@scure/base')
@@ -44,6 +45,8 @@ class ValidatorsController {
       const identifier = validator.proTxHash ? base58.encode(Buffer.from(validator.proTxHash, 'hex')) : null
       const identityBalance = identifier ? await this.sdk.identities.getIdentityBalance(identifier) : null
 
+      const [serviceHost] = proTxInfo?.state?.service?.match(/^\d+\.\d+\.\d+\.\d+/) ?? [null]
+
       validatorInfo = Validator.fromObject(
         {
           ...validator,
@@ -51,7 +54,8 @@ class ValidatorsController {
           proTxInfo: ProTxInfo.fromObject(proTxInfo),
           identity: identifier,
           identityBalance: String(identityBalance),
-          epochInfo
+          epochInfo,
+          geoIpInfo: serviceHost ? GeoIP.lookup(serviceHost) : null
         }
       )
 
@@ -157,13 +161,16 @@ class ValidatorsController {
       } else {
         const proTxInfo = await DashCoreRPC.getProTxInfo(proTxHash)
 
+        const [serviceHost] = proTxInfo?.state?.service?.match(/^\d+\.\d+\.\d+\.\d+/) ?? [null]
+
         validatorInfo = Validator.fromObject(
           {
             proTxHash,
             isActive: activeValidators.some(activeValidator =>
               activeValidator.pro_tx_hash === proTxHash),
             proTxInfo: ProTxInfo.fromObject(proTxInfo),
-            epochInfo
+            epochInfo,
+            geoIpInfo: serviceHost ? GeoIP.lookup(serviceHost) : null
           }
         )
 
@@ -208,6 +215,8 @@ class ValidatorsController {
           const identifier = validator.proTxHash ? base58.encode(Buffer.from(validator.proTxHash, 'hex')) : null
           const identityBalance = identifier ? await this.sdk.identities.getIdentityBalance(identifier) : null
 
+          const [serviceHost] = proTxInfo?.state?.service?.match(/^\d+\.\d+\.\d+\.\d+/) ?? [null]
+
           validatorInfo = Validator.fromObject(
             {
               ...validator,
@@ -216,7 +225,8 @@ class ValidatorsController {
               proTxInfo: ProTxInfo.fromObject(proTxInfo),
               identity: identifier,
               identityBalance: String(identityBalance),
-              epochInfo
+              epochInfo,
+              geoIpInfo: serviceHost ? GeoIP.lookup(serviceHost) : null
             }
           )
 
@@ -261,6 +271,42 @@ class ValidatorsController {
       hash,
       new Date(start),
       new Date(end),
+      interval,
+      isNaN(intervalInMs) ? Intervals[interval] : intervalInMs
+    )
+
+    response.send(stats)
+  }
+
+  getValidatorIncomeStatsByProTxHash = async (request, response) => {
+    const { hash } = request.params
+    const {
+      timestamp_start: timestampStart = new Date().getTime() - 3600000,
+      timestamp_end: timestampEnd = new Date().getTime(),
+      intervalsCount = null
+    } = request.query
+
+    if (!timestampStart || !timestampEnd) {
+      return response.status(400).send({ message: 'start and end must be set' })
+    }
+
+    if (timestampStart > timestampEnd) {
+      return response.status(400).send({ message: 'start timestamp cannot be more than end timestamp' })
+    }
+
+    const intervalInMs =
+      Math.ceil(
+        (new Date(timestampEnd).getTime() - new Date(timestampStart).getTime()) / Number(intervalsCount ?? NaN) / 1000
+      ) * 1000
+
+    const interval = intervalsCount
+      ? iso8601duration(intervalInMs)
+      : calculateInterval(new Date(timestampStart), new Date(timestampEnd))
+
+    const stats = await this.validatorsDAO.getValidatorIncomeStatsByProTxHash(
+      hash,
+      new Date(timestampStart),
+      new Date(timestampEnd),
       interval,
       isNaN(intervalInMs) ? Intervals[interval] : intervalInMs
     )

--- a/packages/api/src/dao/BlocksDAO.js
+++ b/packages/api/src/dao/BlocksDAO.js
@@ -1,5 +1,6 @@
 const Block = require('../models/Block')
 const PaginatedResultSet = require('../models/PaginatedResultSet')
+const SeriesData = require('../models/SeriesData')
 const { getAliasFromDocument, getAliasDocumentForIdentifiers } = require('../utils')
 const Transaction = require('../models/Transaction')
 const StateTransitionEnum = require('../enums/StateTransitionEnum')
@@ -287,6 +288,35 @@ module.exports = class BlockDAO {
     }))
 
     return new PaginatedResultSet(resultSet, page, limit, totalCount)
+  }
+
+  getAvgBlockTimeHistorySeries = async (start, end, interval, intervalInMs) => {
+    const startSql = `'${new Date(start.getTime() + intervalInMs).toISOString()}'::timestamptz`
+
+    const endSql = `'${new Date(end.getTime()).toISOString()}'::timestamptz`
+
+    const ranges = this.knex
+      .from(this.knex.raw(`generate_series(${startSql}, ${endSql}, '${interval}'::interval) date_to`))
+      .select('date_to', this.knex.raw(`LAG(date_to, 1, '${start.toISOString()}'::timestamptz) over (order by date_to asc) date_from`))
+
+    const rows = await this.knex.with('ranges', ranges)
+      .select('date_from')
+      .select(
+        this.knex('blocks')
+          .whereRaw('blocks.timestamp > date_from and blocks.timestamp <= date_to')
+          .select(this.knex.raw('CASE WHEN count(*) > 1 THEN round(extract(epoch from max(timestamp) - min(timestamp)) * 1000 / (count(*) - 1)) ELSE NULL END'))
+          .as('avg_block_time')
+      )
+      .from('ranges')
+
+    return rows
+      .map(row => ({
+        timestamp: row.date_from,
+        data: {
+          avgBlockTime: row.avg_block_time !== null ? parseInt(row.avg_block_time) : null
+        }
+      }))
+      .map(({ timestamp, data }) => new SeriesData(timestamp, data))
   }
 
   getLastBlock = async () => {

--- a/packages/api/src/dao/DataContractsDAO.js
+++ b/packages/api/src/dao/DataContractsDAO.js
@@ -440,6 +440,42 @@ module.exports = class DataContractsDAO {
     return rows.map(row => DataContract.fromRow(row))
   }
 
+  getActiveDataContracts = async (start, end, page, limit, order) => {
+    const fromRank = (page - 1) * limit
+
+    const rankedSubquery = this.knex('data_contract_transitions')
+      .select('data_contract_identifier')
+      .count()
+      .whereRaw('blocks.timestamp >= ? and blocks.timestamp <= ?', [start, end])
+      .andWhereRaw('data_contract_identifier is not null')
+      .leftJoin('state_transitions', 'data_contract_transitions.state_transition_id', 'state_transitions.id')
+      .leftJoin('blocks', 'state_transitions.block_height', 'blocks.height')
+      .groupBy('data_contract_identifier')
+
+    const rows = await this.knex
+      .with('ranked_subquery', rankedSubquery)
+      .select('count as transitions_count', 'data_contract_identifier as identifier')
+      .select(
+        this.knex('ranked_subquery')
+          .select(this.knex.raw('count(*)'))
+          .limit(1)
+          .as('total_count')
+      )
+      .orderBy('transitions_count', order)
+      .limit(limit)
+      .offset(fromRank)
+      .from('ranked_subquery')
+
+    const totalCount = rows.length > 0 ? Number(rows[0].total_count) : 0
+
+    const resultSet = rows.map(row => ({
+      identifier: row.identifier,
+      transitionsCount: Number(row.transitions_count ?? 0)
+    }))
+
+    return new PaginatedResultSet(resultSet, page, limit, totalCount)
+  }
+
   getContractsTrends = async (startDate, endDate, page, limit, order) => {
     const fromRank = (page - 1) * limit
 

--- a/packages/api/src/dao/EpochDAO.js
+++ b/packages/api/src/dao/EpochDAO.js
@@ -1,5 +1,7 @@
 const EpochData = require('../models/EpochData')
 const ChoiceEnum = require('../enums/ChoiceEnum')
+const BatchEnum = require('../enums/BatchEnum')
+const { DPNS_CONTRACT } = require('../constants')
 
 module.exports = class EpochDAO {
   constructor (knex) {
@@ -45,6 +47,15 @@ module.exports = class EpochDAO {
       .leftJoin('state_transitions', 'state_transition_hash', 'state_transitions.hash')
       .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
       .as('resource_votes')
+
+    const documentsSubquery = this.knex('documents')
+      .select('documents.transition_type', 'documents.document_type_name', 'documents.prefunded_voting_balance', 'data_contracts.identifier as data_contract_identifier')
+      .leftJoin('data_contracts', 'data_contracts.id', 'documents.data_contract_id')
+      .leftJoin('state_transitions', 'state_transitions.hash', 'documents.state_transition_hash')
+      .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
+      .where('blocks.timestamp', '>', new Date(epoch.startTime).toISOString())
+      .andWhere('blocks.timestamp', '<=', epochEnd.toISOString())
+      .as('epoch_documents')
 
     const bestValidator = this.knex('blocks')
       .select('validator')
@@ -114,7 +125,31 @@ module.exports = class EpochDAO {
         .as('total_votes'),
       this.knex(votesBaseSubquery)
         .sum('gas_used')
-        .as('total_votes_gas_used')
+        .as('total_votes_gas_used'),
+      this.knex(documentsSubquery)
+        .count('*')
+        .where('transition_type', '=', BatchEnum.DOCUMENT_CREATE)
+        .as('total_created_documents_count'),
+      this.knex(documentsSubquery)
+        .count('*')
+        .where('transition_type', '=', BatchEnum.DOCUMENT_DELETE)
+        .as('total_deleted_documents_count'),
+      this.knex(documentsSubquery)
+        .count('*')
+        .where('transition_type', '=', BatchEnum.DOCUMENT_CREATE)
+        .andWhere('document_type_name', '=', 'domain')
+        .andWhere('data_contract_identifier', '=', DPNS_CONTRACT)
+        .as('total_registered_names_count'),
+      this.knex(documentsSubquery)
+        .count('*')
+        .where('transition_type', '=', BatchEnum.DOCUMENT_CREATE)
+        .whereRaw('prefunded_voting_balance is not null')
+        .as('total_contested_documents_count'),
+      this.knex('blocks')
+        .select(this.knex.raw('CASE WHEN count(*) > 1 THEN round(extract(epoch from max(timestamp) - min(timestamp)) * 1000 / (count(*) - 1)) ELSE NULL END'))
+        .where('timestamp', '>', new Date(epoch.startTime).toISOString())
+        .andWhere('timestamp', '<=', epochEnd.toISOString())
+        .as('avg_block_time')
     ]
 
     if (isInProgressEpoch) {

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -506,11 +506,116 @@ module.exports = class TransactionsDAO {
       .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
   }
 
-  getTransactionStatistic = async () => {
-    const rows = await this.knex('state_transitions')
+  getFundsFlowHistorySeries = async (start, end, interval, intervalInMs, direction) => {
+    const startSql = `'${new Date(start.getTime() + intervalInMs).toISOString()}'::timestamptz`
+
+    const endSql = `'${new Date(end.getTime()).toISOString()}'::timestamptz`
+
+    // amounts of core-chain <-> platform value transitions live in three
+    // tables, each covering its own set of state transition types
+    const transferTypes = direction === true
+      ? [StateTransitionEnum.IDENTITY_CREATE, StateTransitionEnum.IDENTITY_TOP_UP]
+      : [StateTransitionEnum.IDENTITY_CREDIT_WITHDRAWAL]
+
+    const addressTransitionTypes = direction === true
+      ? [StateTransitionEnum.ADDRESS_FUNDING_FROM_ASSET_LOCK]
+      : [StateTransitionEnum.ADDRESS_CREDIT_WITHDRAWAL]
+
+    const shieldedTransitionTypes = direction === true
+      ? [StateTransitionEnum.SHIELD_FROM_ASSET_LOCK]
+      : [StateTransitionEnum.SHIELDED_WITHDRAWAL]
+
+    const ranges = this.knex
+      .from(this.knex.raw(`generate_series(${startSql}, ${endSql}, '${interval}'::interval) date_to`))
+      .select('date_to')
+      .select(
+        this.knex.raw(
+          'LAG(date_to, 1, ?::timestamptz) OVER (ORDER BY date_to ASC) AS date_from',
+          [start.toISOString()]
+        )
+      )
+
+    const subRanges = this.knex('ranges')
+      .select(this.knex.raw('min(date_from) as min_date'))
+      .select(this.knex.raw('max(date_to) as max_date'))
+      .limit(1)
+
+    const blocksSubquery = this.knex('blocks')
+      .with('sub_ranges', subRanges)
+      .whereRaw('blocks.timestamp > (SELECT min_date FROM sub_ranges) AND blocks.timestamp <= (SELECT max_date FROM sub_ranges)')
+      .as('blocks_sub')
+
+    const transfersFlows = this.knex('transfers')
+      .select('state_transitions.block_height', 'transfers.amount')
+      .leftJoin('state_transitions', 'transfers.state_transition_hash', 'state_transitions.hash')
+      .whereIn('state_transitions.type', transferTypes)
+
+    const addressFlows = this.knex('platform_address_transitions')
+      .select('state_transitions.block_height', 'platform_address_transitions.amount')
+      .leftJoin('state_transitions', 'platform_address_transitions.state_transition_id', 'state_transitions.id')
+      .whereIn('platform_address_transitions.state_transition_type', addressTransitionTypes)
+
+    const shieldedFlows = this.knex('shielded_transitions')
+      .select('state_transitions.block_height', 'shielded_transitions.amount')
+      .leftJoin('state_transitions', 'shielded_transitions.state_transition_id', 'state_transitions.id')
+      .whereIn('shielded_transitions.state_transition_type', shieldedTransitionTypes)
+
+    const flowsSubquery = transfersFlows
+      .unionAll([addressFlows, shieldedFlows], true)
+      .as('flows_subquery')
+
+    const dataSubquery = this.knex(blocksSubquery)
+      .leftJoin(flowsSubquery, 'flows_subquery.block_height', 'blocks_sub.height')
+      .select('blocks_sub.timestamp', 'flows_subquery.amount', 'blocks_sub.hash', 'blocks_sub.height')
+
+    const heightSubquery = this.knex.with('ranges', ranges)
+      .with(
+        'filtered_data',
+        dataSubquery
+      )
+      .select('date_from')
+      .select(this.knex.raw('sum(amount) as total_amount'))
+      .select(this.knex.raw('min(height) as block_height'))
+      .leftJoin('filtered_data', function () {
+        this.on('timestamp', '>', 'date_from').andOn('timestamp', '<=', 'date_to')
+      })
+      .from('ranges')
+      .groupBy('date_from')
+      .as('sub')
+
+    const rows = await this.knex(heightSubquery)
+      .select('total_amount', 'block_height', 'hash as block_hash', 'date_from')
+      .leftJoin('blocks', function () {
+        this.on('blocks.height', '=', 'block_height').andOnNotNull('block_height')
+      })
+
+    return rows
+      .map(row => ({
+        timestamp: new Date(row.date_from).toISOString(),
+        data: {
+          amount: parseInt(row.total_amount ?? 0),
+          blockHeight: row.block_height,
+          blockHash: row.block_hash
+        }
+      }))
+      .map(({ timestamp, data }) => new SeriesData(timestamp, data))
+      .sort((a, b) => new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime())
+  }
+
+  getTransactionStatistic = async (timestampStart, timestampEnd) => {
+    let query = this.knex('state_transitions')
       .select('type')
       .groupBy('type')
       .count()
+
+    if (timestampStart && timestampEnd) {
+      query = query
+        .leftJoin('blocks', 'blocks.hash', 'state_transitions.block_hash')
+        .where('blocks.timestamp', '>=', new Date(timestampStart).toISOString())
+        .andWhere('blocks.timestamp', '<=', new Date(timestampEnd).toISOString())
+    }
+
+    const rows = await query
 
     return rows.map(row => ({
       transactionType: StateTransitionEnum[row.type],

--- a/packages/api/src/dao/ValidatorsDAO.js
+++ b/packages/api/src/dao/ValidatorsDAO.js
@@ -204,14 +204,13 @@ module.exports = class ValidatorsDAO {
         }
       })
 
-    const blocksSubquery = this.knex('subquery')
+    const blocksSubquery = this.knex('blocks')
       .select(
-        'subquery.id as validator_id'
+        'blocks.validator_id as validator_id'
       )
       .select(this.knex.raw('MAX(height) AS max_height'))
       .select(this.knex.raw('count(height) as proposed_blocks_amount'))
-      .groupBy('subquery.id')
-      .leftJoin('blocks', 'blocks.validator_id', 'subquery.id')
+      .groupBy('blocks.validator_id')
       .as('blocks_subquery')
 
     const joinedBlocksSubqeury = this.knex(blocksSubquery)
@@ -227,7 +226,8 @@ module.exports = class ValidatorsDAO {
       .with('blocks_subquery', joinedBlocksSubqeury)
       .select(
         'block_hash', 'latest_height', 'latest_timestamp', 'l1_locked_height',
-        'app_version', 'block_version', 'app_hash', 'id', 'pro_tx_hash', 'proposed_blocks_amount'
+        'app_version', 'block_version', 'app_hash', 'id', 'pro_tx_hash',
+        this.knex.raw('COALESCE(proposed_blocks_amount, 0) as proposed_blocks_amount')
       )
       .leftJoin('blocks_subquery', 'subquery.id', 'blocks_subquery.validator_id')
       .whereRaw(filtersQuery, filtersBindings)
@@ -288,6 +288,62 @@ module.exports = class ValidatorsDAO {
           blocksCount: parseInt(row.blocks_count)
         }
       }))
+      .map(({ timestamp, data }) => new SeriesData(timestamp, data))
+  }
+
+  getValidatorIncomeStatsByProTxHash = async (proTxHash, start, end, interval, intervalInMs) => {
+    const startSql = `'${new Date(start.getTime()).toISOString()}'::timestamptz`
+
+    const endSql = `'${end.toISOString()}'::timestamptz`
+
+    const ranges = this.knex
+      .from(this.knex.raw(`generate_series(${startSql}, ${endSql}, '${interval}'::interval) date_to`))
+      .select('date_to', this.knex.raw(`LAG(date_to, 1, '${start.toISOString()}'::timestamptz) over (order by date_to asc) date_from`))
+
+    const rows = await this.knex.with('ranges', ranges)
+      .select('date_from')
+      .select(
+        this.knex('blocks')
+          .whereRaw('blocks.timestamp > date_from and blocks.timestamp <= date_to')
+          .whereILike('validator', proTxHash)
+          .count('*')
+          .as('proposed_blocks_count')
+      )
+      .select(
+        this.knex('blocks')
+          .whereRaw('blocks.timestamp > date_from and blocks.timestamp <= date_to')
+          .count('*')
+          .as('total_blocks_count')
+      )
+      .select(
+        this.knex('blocks')
+          .whereRaw('blocks.timestamp > date_from and blocks.timestamp <= date_to')
+          .sum('gas_used')
+          .leftJoin('state_transitions', 'state_transitions.block_hash', 'blocks.hash')
+          .as('collected_fees')
+      )
+      .from('ranges')
+
+    return rows
+      .slice(1)
+      .map(row => {
+        const proposedBlocksCount = parseInt(row.proposed_blocks_count ?? 0)
+        const totalBlocksCount = parseInt(row.total_blocks_count ?? 0)
+        const collectedFees = parseInt(row.collected_fees ?? 0)
+
+        // fees collected in an epoch are distributed between validators
+        // proportionally to the number of blocks they proposed
+        const income = totalBlocksCount > 0
+          ? Math.floor(collectedFees * proposedBlocksCount / totalBlocksCount)
+          : 0
+
+        return {
+          timestamp: row.date_from,
+          data: {
+            income
+          }
+        }
+      })
       .map(({ timestamp, data }) => new SeriesData(timestamp, data))
   }
 

--- a/packages/api/src/geoip.js
+++ b/packages/api/src/geoip.js
@@ -1,0 +1,47 @@
+const { readFileSync } = require('fs')
+const { resolve } = require('path')
+const { Reader } = require('mmdb-lib')
+const { GEOIP_PROVIDER, GEOIP_TABLE_NAME } = require('./constants')
+
+const cacheStorage = {}
+
+let reader
+
+function getReader () {
+  if (!reader) {
+    const mmdbPath = resolve(
+      require.resolve(`${GEOIP_PROVIDER}/package.json`),
+      '..',
+      GEOIP_TABLE_NAME
+    )
+
+    reader = new Reader(readFileSync(mmdbPath), {
+      cache: {
+        get: (key) => cacheStorage[key],
+        set: (key, value) => (cacheStorage[key] = value)
+      }
+    })
+  }
+
+  return reader
+}
+
+class GeoIP {
+  static lookup (ipv4) {
+    if (!ipv4) {
+      throw new Error('you must specify a valid IP address')
+    }
+
+    const response = getReader().get(ipv4)
+
+    return {
+      ipv4,
+      countryCode: response?.country_code ?? null,
+      city: response?.city ?? null,
+      latitude: response?.latitude ?? null,
+      longitude: response?.longitude ?? null
+    }
+  }
+}
+
+module.exports = GeoIP

--- a/packages/api/src/models/Epoch.js
+++ b/packages/api/src/models/Epoch.js
@@ -12,8 +12,9 @@ module.exports = class Epoch {
   totalDistributedStorageFees
   totalCreatedStorageFees
   coreBlockRewards
+  blockProposers
 
-  constructor (number, firstBlockHeight, firstCoreBlockHeight, startTime, feeMultiplier, endTime, totalBlocksInEpoch, totalProcessingFees, totalDistributedStorageFees, totalCreatedStorageFees, coreBlockRewards) {
+  constructor (number, firstBlockHeight, firstCoreBlockHeight, startTime, feeMultiplier, endTime, totalBlocksInEpoch, totalProcessingFees, totalDistributedStorageFees, totalCreatedStorageFees, coreBlockRewards, blockProposers) {
     this.number = number ?? null
     this.firstBlockHeight = firstBlockHeight ?? null
     this.firstCoreBlockHeight = firstCoreBlockHeight ?? null
@@ -25,6 +26,7 @@ module.exports = class Epoch {
     this.totalDistributedStorageFees = totalDistributedStorageFees ?? null
     this.totalCreatedStorageFees = totalCreatedStorageFees ?? null
     this.coreBlockRewards = coreBlockRewards ?? null
+    this.blockProposers = blockProposers ?? null
   }
 
   static fromObject ({ number, firstBlockHeight, firstCoreBlockHeight, startTime, feeMultiplier, nextEpoch, finalizedEpochInfo }) {
@@ -47,7 +49,13 @@ module.exports = class Epoch {
       finalizedEpochInfo ? String(finalizedEpochInfo.totalProcessingFees) : null,
       finalizedEpochInfo ? String(finalizedEpochInfo.totalDistributedStorageFees) : null,
       finalizedEpochInfo ? String(finalizedEpochInfo.totalCreatedStorageFees) : null,
-      finalizedEpochInfo ? String(finalizedEpochInfo.coreBlockRewards) : null
+      finalizedEpochInfo ? String(finalizedEpochInfo.coreBlockRewards) : null,
+      finalizedEpochInfo
+        ? (finalizedEpochInfo.blockProposers ?? []).map(blockProposer => ({
+            proposer: (typeof blockProposer.proposer === 'string' ? blockProposer.proposer : blockProposer.proposer.hex()).toUpperCase(),
+            count: Number(blockProposer.count)
+          }))
+        : null
     )
   }
 }

--- a/packages/api/src/models/EpochData.js
+++ b/packages/api/src/models/EpochData.js
@@ -8,10 +8,15 @@ module.exports = class EpochData {
   totalVotesCount
   totalVotesGasUsed
   totalTxCount
+  totalCreatedDocumentsCount
+  totalDeletedDocumentsCount
+  totalRegisteredNamesCount
+  totalContestedDocumentsCount
+  avgBlockTime
   pendingBlocksInEpoch
   pendingEpochReward
 
-  constructor (epoch, tps, totalCollectedFees, bestValidator, topVotedResource, bestVoter, totalVotesCount, totalVotesGasUsed, totalTxCount, pendingBlocksInEpoch, pendingEpochReward) {
+  constructor (epoch, tps, totalCollectedFees, bestValidator, topVotedResource, bestVoter, totalVotesCount, totalVotesGasUsed, totalTxCount, totalCreatedDocumentsCount, totalDeletedDocumentsCount, totalRegisteredNamesCount, totalContestedDocumentsCount, avgBlockTime, pendingBlocksInEpoch, pendingEpochReward) {
     this.epoch = epoch ?? null
     this.tps = tps ?? null
     this.totalCollectedFees = totalCollectedFees ?? null
@@ -21,6 +26,11 @@ module.exports = class EpochData {
     this.totalVotesCount = totalVotesCount ?? null
     this.totalVotesGasUsed = totalVotesGasUsed ?? null
     this.totalTxCount = totalTxCount ?? null
+    this.totalCreatedDocumentsCount = totalCreatedDocumentsCount ?? null
+    this.totalDeletedDocumentsCount = totalDeletedDocumentsCount ?? null
+    this.totalRegisteredNamesCount = totalRegisteredNamesCount ?? null
+    this.totalContestedDocumentsCount = totalContestedDocumentsCount ?? null
+    this.avgBlockTime = avgBlockTime ?? null
     this.pendingBlocksInEpoch = pendingBlocksInEpoch ?? null
     this.pendingEpochReward = pendingEpochReward ?? null
   }
@@ -42,6 +52,11 @@ module.exports = class EpochData {
     total_votes,
     total_votes_gas_used,
     total_tx_count,
+    total_created_documents_count,
+    total_deleted_documents_count,
+    total_registered_names_count,
+    total_contested_documents_count,
+    avg_block_time,
     pending_blocks_in_epoch,
     pending_epoch_reward
   }) {
@@ -65,6 +80,11 @@ module.exports = class EpochData {
       Number(total_votes ?? 0),
       Number(total_votes_gas_used ?? 0),
       Number(total_tx_count ?? 0),
+      Number(total_created_documents_count ?? 0),
+      Number(total_deleted_documents_count ?? 0),
+      Number(total_registered_names_count ?? 0),
+      Number(total_contested_documents_count ?? 0),
+      avg_block_time !== null && avg_block_time !== undefined ? Number(avg_block_time) : null,
       pending_blocks_in_epoch !== undefined ? Number(pending_blocks_in_epoch ?? 0) : null,
       pending_epoch_reward !== undefined ? Number(pending_epoch_reward ?? 0) : null
     )

--- a/packages/api/src/models/Validator.js
+++ b/packages/api/src/models/Validator.js
@@ -16,6 +16,7 @@ module.exports = class Validator {
   lastWithdrawal
   lastWithdrawalTime
   endpoints
+  geoIpInfo
 
   constructor (
     proTxHash,
@@ -31,7 +32,8 @@ module.exports = class Validator {
     identity,
     identityBalance,
     epochInfo,
-    endpoints
+    endpoints,
+    geoIpInfo
   ) {
     this.proTxHash = proTxHash ?? null
     this.isActive = isActive ?? null
@@ -47,6 +49,7 @@ module.exports = class Validator {
     this.lastWithdrawal = lastWithdrawal ?? null
     this.lastWithdrawalTime = lastWithdrawalTime ?? null
     this.endpoints = endpoints ?? null
+    this.geoIpInfo = geoIpInfo ?? null
   }
 
   static fromRow ({
@@ -105,7 +108,8 @@ module.exports = class Validator {
     identity,
     identityBalance,
     epochInfo,
-    endpoints
+    endpoints,
+    geoIpInfo
   }) {
     return new Validator(
       proTxHash,
@@ -121,7 +125,8 @@ module.exports = class Validator {
       identity,
       identityBalance,
       epochInfo,
-      endpoints
+      endpoints,
+      geoIpInfo
     )
   }
 }

--- a/packages/api/src/routes.js
+++ b/packages/api/src/routes.js
@@ -96,6 +96,14 @@ module.exports = ({
       }
     },
     {
+      path: '/blocks/avgBlockTime/history',
+      method: 'GET',
+      handler: blocksController.getAvgBlockTimeHistory,
+      schema: {
+        querystring: { $ref: 'timeInterval#' }
+      }
+    },
+    {
       path: '/transactions',
       method: 'GET',
       handler: transactionsController.getTransactions,
@@ -182,6 +190,14 @@ module.exports = ({
       path: '/dataContracts/rating',
       method: 'GET',
       handler: dataContractsController.getDataContractTrends,
+      schema: {
+        querystring: { $ref: 'paginationOptions#' }
+      }
+    },
+    {
+      path: '/dataContracts/active',
+      method: 'GET',
+      handler: dataContractsController.getActiveDataContracts,
       schema: {
         querystring: { $ref: 'paginationOptions#' }
       }
@@ -484,6 +500,20 @@ module.exports = ({
       }
     },
     {
+      path: '/validator/:hash/income/stats',
+      method: 'GET',
+      handler: validatorsController.getValidatorIncomeStatsByProTxHash,
+      schema: {
+        params: {
+          type: 'object',
+          properties: {
+            hash: { $ref: 'hash#' }
+          }
+        },
+        querystring: { $ref: 'timeInterval#' }
+      }
+    },
+    {
       path: '/validator/:hash',
       method: 'GET',
       handler: validatorsController.getValidatorByProTxHash,
@@ -771,9 +801,28 @@ module.exports = ({
       }
     },
     {
+      path: '/transactions/input/history',
+      method: 'GET',
+      handler: transactionsController.getInputHistorySeries,
+      schema: {
+        querystring: { $ref: 'timeInterval#' }
+      }
+    },
+    {
+      path: '/transactions/output/history',
+      method: 'GET',
+      handler: transactionsController.getOutputHistorySeries,
+      schema: {
+        querystring: { $ref: 'timeInterval#' }
+      }
+    },
+    {
       path: '/transactions/statistic',
       method: 'GET',
-      handler: transactionsController.getTransactionStatistic
+      handler: transactionsController.getTransactionStatistic,
+      schema: {
+        querystring: { $ref: 'timeInterval#' }
+      }
     },
     {
       path: '/transactions/shielded/statistic',

--- a/packages/api/test/integration/blocks.spec.js
+++ b/packages/api/test/integration/blocks.spec.js
@@ -736,4 +736,64 @@ describe('Blocks routes', () => {
       assert.deepEqual(expectedBlocks, body.resultSet)
     })
   })
+
+  describe('getAvgBlockTimeHistory()', async () => {
+    let start
+    let end
+
+    before(async () => {
+      // isolated time window so blocks seeded by other suites don't interfere
+      start = new Date('2031-01-01T00:00:00.000Z')
+      end = new Date('2031-01-01T01:00:00.000Z')
+
+      let height = 4000
+
+      const createBlock = async (minuteOffset) => {
+        await fixtures.block(knex, {
+          height: height++,
+          timestamp: new Date(start.getTime() + minuteOffset * 60000)
+        })
+      }
+
+      // first interval: three blocks one minute apart
+      await createBlock(1)
+      await createBlock(2)
+      await createBlock(3)
+
+      // second interval: two blocks two minutes apart
+      await createBlock(8)
+      await createBlock(10)
+
+      // third interval: a single block, block time is not defined
+      await createBlock(14)
+    })
+
+    it('should return average block time series', async () => {
+      const { body } = await client.get(`/blocks/avgBlockTime/history?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}&intervalsCount=10`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const intervalMs = 360000
+
+      const expectedSeries = []
+
+      for (let i = 0; i < 10; i++) {
+        const avgBlockTime = i === 0 ? 60000 : i === 1 ? 120000 : null
+
+        expectedSeries.push({
+          timestamp: new Date(start.getTime() + intervalMs * i).toISOString(),
+          data: {
+            avgBlockTime
+          }
+        })
+      }
+
+      assert.deepEqual(expectedSeries, body)
+    })
+
+    it('should return error when start is after end', async () => {
+      await client.get(`/blocks/avgBlockTime/history?timestamp_start=${end.toISOString()}&timestamp_end=${start.toISOString()}`)
+        .expect(400)
+    })
+  })
 })

--- a/packages/api/test/integration/data.contracts.spec.js
+++ b/packages/api/test/integration/data.contracts.spec.js
@@ -1544,4 +1544,110 @@ describe('DataContracts routes', () => {
       assert.deepEqual(body.resultSet, expected)
     })
   })
+
+  describe('getActiveDataContracts()', () => {
+    let activeDataContracts
+    let start
+    let end
+
+    before(async () => {
+      activeDataContracts = []
+
+      // isolated time window so data seeded by other suites don't interfere
+      start = new Date('2031-01-01T00:00:00.000Z')
+      end = new Date('2031-01-02T00:00:00.000Z')
+
+      let height = 100000
+
+      // contract k gets (k + 1) transitions inside the range
+      // (1 from data contract create + k document transitions)
+      for (let k = 1; k <= 5; k++) {
+        const block = await fixtures.block(knex, {
+          height: height++,
+          timestamp: new Date(start.getTime() + k * 60000)
+        })
+
+        const identity = await fixtures.identity(knex, {
+          block_hash: block.hash,
+          block_height: block.height
+        })
+
+        const dataContractTransaction = await fixtures.transaction(knex, {
+          block_hash: block.hash,
+          block_height: block.height,
+          type: StateTransitionEnum.DATA_CONTRACT_CREATE,
+          owner: identity.identifier
+        })
+
+        const dataContract = await fixtures.dataContract(knex, {
+          owner: identity.identifier,
+          state_transition_hash: dataContractTransaction.hash
+        })
+
+        for (let j = 0; j < k; j++) {
+          const documentTransaction = await fixtures.transaction(knex, {
+            block_hash: block.hash,
+            block_height: block.height,
+            type: StateTransitionEnum.BATCH,
+            owner: identity.identifier,
+            index: j + 1
+          })
+
+          await fixtures.document(knex, {
+            owner: identity.identifier,
+            data_contract_id: dataContract.id,
+            state_transition_hash: documentTransaction.hash
+          })
+        }
+
+        activeDataContracts.push({
+          identifier: dataContract.identifier,
+          transitionsCount: k + 1
+        })
+      }
+
+      // contract with activity outside of the range must not appear
+      const block = await fixtures.block(knex, {
+        height: height++,
+        timestamp: new Date(end.getTime() + 60000)
+      })
+
+      const identity = await fixtures.identity(knex, {
+        block_hash: block.hash,
+        block_height: block.height
+      })
+
+      const dataContractTransaction = await fixtures.transaction(knex, {
+        block_hash: block.hash,
+        block_height: block.height,
+        type: StateTransitionEnum.DATA_CONTRACT_CREATE,
+        owner: identity.identifier
+      })
+
+      await fixtures.dataContract(knex, {
+        owner: identity.identifier,
+        state_transition_hash: dataContractTransaction.hash
+      })
+    })
+
+    it('should return active data contracts ordered by transitions count desc', async () => {
+      const { body } = await client.get(`/dataContracts/active?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}&order=desc&page=1&limit=10`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.pagination.total, activeDataContracts.length)
+      assert.equal(body.pagination.page, 1)
+      assert.equal(body.pagination.limit, 10)
+
+      const expectedDataContracts = [...activeDataContracts]
+        .sort((a, b) => b.transitionsCount - a.transitionsCount)
+
+      assert.deepEqual(body.resultSet, expectedDataContracts)
+    })
+
+    it('should return error for bad timestamp range', async () => {
+      await client.get(`/dataContracts/active?timestamp_start=${end.toISOString()}&timestamp_end=${start.toISOString()}`)
+        .expect(400)
+    })
+  })
 })

--- a/packages/api/test/integration/epochs.spec.js
+++ b/packages/api/test/integration/epochs.spec.js
@@ -57,7 +57,11 @@ describe('Epoch routes', () => {
         totalProcessingFees: 1000n,
         totalDistributedStorageFees: 2000n,
         totalCreatedStorageFees: 3000n,
-        coreBlockRewards: 4000n
+        coreBlockRewards: 4000n,
+        blockProposers: [
+          { proposer: { hex: () => 'a1b2c3' }, count: 20n },
+          { proposer: { hex: () => 'd4e5f6' }, count: 10n }
+        ]
       }])
     app = await server.start()
     client = supertest(app.server)
@@ -193,7 +197,11 @@ describe('Epoch routes', () => {
           totalProcessingFees: '1000',
           totalDistributedStorageFees: '2000',
           totalCreatedStorageFees: '3000',
-          coreBlockRewards: '4000'
+          coreBlockRewards: '4000',
+          blockProposers: [
+            { proposer: 'A1B2C3', count: 20 },
+            { proposer: 'D4E5F6', count: 10 }
+          ]
         },
         tps: (identities.length + transactions.length) / 1800,
         totalCollectedFees: transactions.reduce((acc, tx) => acc + tx.gas_used, 0),
@@ -256,7 +264,8 @@ describe('Epoch routes', () => {
           totalProcessingFees: null,
           totalDistributedStorageFees: null,
           totalCreatedStorageFees: null,
-          coreBlockRewards: null
+          coreBlockRewards: null,
+          blockProposers: null
         },
         tps: 0,
         totalCollectedFees: 0,

--- a/packages/api/test/integration/epochs.spec.js
+++ b/packages/api/test/integration/epochs.spec.js
@@ -7,6 +7,7 @@ const fixtures = require('../utils/fixtures')
 const { getKnex } = require('../../src/utils')
 const tenderdashRpc = require('../../src/tenderdashRpc')
 const { NodeController } = require('dash-platform-sdk/src/node')
+const { DPNS_CONTRACT } = require('../../src/constants')
 
 describe('Epoch routes', () => {
   let app
@@ -19,6 +20,10 @@ describe('Epoch routes', () => {
   let validator
   let dataContracts
   let documents
+  let deletedDocuments
+  let contestedDocuments
+  let dpnsContract
+  let registeredNames
   let masternodeVotes
   let masternodeVotesGas
 
@@ -64,6 +69,9 @@ describe('Epoch routes', () => {
     identities = []
     dataContracts = []
     documents = []
+    deletedDocuments = []
+    contestedDocuments = []
+    registeredNames = []
     masternodeVotes = []
     masternodeVotesGas = 0
 
@@ -90,8 +98,52 @@ describe('Epoch routes', () => {
       })
       const document = await fixtures.document(knex, {
         owner: identity.identifier,
-        data_contract_id: dataContract.id
+        data_contract_id: dataContract.id,
+        state_transition_hash: transaction.hash
       })
+
+      if (i % 5 === 0) {
+        const deletedDocument = await fixtures.document(knex, {
+          owner: identity.identifier,
+          data_contract_id: dataContract.id,
+          state_transition_hash: transaction.hash,
+          transition_type: 2,
+          deleted: true
+        })
+
+        deletedDocuments.push(deletedDocument)
+      }
+
+      if (i === 1) {
+        dpnsContract = await fixtures.dataContract(knex, {
+          owner: identity.identifier,
+          identifier: DPNS_CONTRACT
+        })
+      }
+
+      if (i % 3 === 0) {
+        const nameDocument = await fixtures.document(knex, {
+          owner: identity.identifier,
+          data_contract_id: dpnsContract.id,
+          state_transition_hash: transaction.hash,
+          document_type_name: 'domain'
+        })
+
+        documents.push(nameDocument)
+        registeredNames.push(nameDocument)
+      }
+
+      if (i % 4 === 0) {
+        const contestedDocument = await fixtures.document(knex, {
+          owner: identity.identifier,
+          data_contract_id: dataContract.id,
+          state_transition_hash: transaction.hash,
+          prefunded_voting_balance: JSON.stringify({ parentNameAndLabel: 20000000000 })
+        })
+
+        documents.push(contestedDocument)
+        contestedDocuments.push(contestedDocument)
+      }
 
       const masternodeVotesPart = []
 
@@ -161,6 +213,11 @@ describe('Epoch routes', () => {
         totalVotesCount: 465,
         totalVotesGasUsed: masternodeVotesGas,
         totalTxCount: identities.length + transactions.length,
+        totalCreatedDocumentsCount: documents.length,
+        totalDeletedDocumentsCount: deletedDocuments.length,
+        totalRegisteredNamesCount: registeredNames.length,
+        totalContestedDocumentsCount: contestedDocuments.length,
+        avgBlockTime: 60000,
         pendingBlocksInEpoch: null,
         pendingEpochReward: null
       }
@@ -219,6 +276,11 @@ describe('Epoch routes', () => {
         totalVotesCount: 0,
         totalVotesGasUsed: 0,
         totalTxCount: 0,
+        totalCreatedDocumentsCount: 0,
+        totalDeletedDocumentsCount: 0,
+        totalRegisteredNamesCount: 0,
+        totalContestedDocumentsCount: 0,
+        avgBlockTime: null,
         pendingBlocksInEpoch: 10,
         pendingEpochReward: transactions
           .filter((transaction) => transaction.block_height >= 21)

--- a/packages/api/test/integration/main.spec.js
+++ b/packages/api/test/integration/main.spec.js
@@ -984,7 +984,8 @@ describe('Other routes', () => {
           totalProcessingFees: null,
           totalDistributedStorageFees: null,
           totalCreatedStorageFees: null,
-          coreBlockRewards: null
+          coreBlockRewards: null,
+          blockProposers: null
         },
         identitiesCount: 1,
         transactionsCount: 51,

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -1555,6 +1555,53 @@ describe('Transaction routes', () => {
         expectedStatistic
       )
     })
+
+    it('should return transaction count grouped by type in the given interval', async () => {
+      const start = new Date(transactions[5].block.timestamp)
+      const end = new Date(transactions[15].block.timestamp)
+
+      const { body } = await client.get(`/transactions/statistic?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const countsByType = transactions
+        .filter(({ block }) =>
+          new Date(block.timestamp).getTime() >= start.getTime() &&
+          new Date(block.timestamp).getTime() <= end.getTime()
+        )
+        .reduce((acc, { transaction }) => {
+          acc[transaction.type] = (acc[transaction.type] ?? 0) + 1
+          return acc
+        }, {})
+
+      const expectedStatistic = Object.entries(countsByType)
+        .map(([type, count]) => ({ transactionType: StateTransitionEnum[type], count }))
+        .sort((a, b) => a.transactionType.localeCompare(b.transactionType))
+
+      assert.deepEqual(
+        body.sort((a, b) => a.transactionType.localeCompare(b.transactionType)),
+        expectedStatistic
+      )
+    })
+
+    it('should return error if only one of start and end is set', async () => {
+      const { body } = await client.get(`/transactions/statistic?timestamp_start=${new Date().toISOString()}`)
+        .expect(400)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.message, 'start and end must be set')
+    })
+
+    it('should return error if start timestamp is more than end timestamp', async () => {
+      const start = new Date()
+      const end = new Date(start.getTime() - 3600000)
+
+      const { body } = await client.get(`/transactions/statistic?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}`)
+        .expect(400)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.message, 'start timestamp cannot be more than end timestamp')
+    })
   })
 
   describe('getShieldHistorySeries() / getUnshieldHistorySeries()', async () => {
@@ -1631,6 +1678,137 @@ describe('Transaction routes', () => {
 
     it('should return error when start is after end', async () => {
       await client.get(`/transactions/shield/history?timestamp_start=${end.toISOString()}&timestamp_end=${start.toISOString()}`)
+        .expect(400)
+    })
+  })
+
+  describe('getInputHistorySeries() / getOutputHistorySeries()', async () => {
+    let start
+    let end
+    let inputAmount
+    let outputAmount
+
+    before(async () => {
+      start = new Date('2031-01-01T00:00:00.000Z')
+      end = new Date('2031-01-01T01:00:00.000Z')
+
+      inputAmount = 0
+      outputAmount = 0
+
+      let height = 2000
+      let minuteOffset = 3
+
+      // spread transitions across the window so they fall into different
+      // intervals of the resulting series
+      const createTransaction = async (type) => {
+        const block = await fixtures.block(knex, {
+          height: height++,
+          timestamp: new Date(start.getTime() + (minuteOffset += 5) * 60000)
+        })
+
+        return fixtures.transaction(knex, {
+          block_hash: block.hash,
+          block_height: block.height,
+          type,
+          owner: identity.identifier
+        })
+      }
+
+      // transitions with amounts in the transfers table
+      const transferTypes = {
+        [StateTransitionEnum.IDENTITY_CREATE]: true,
+        [StateTransitionEnum.IDENTITY_TOP_UP]: true,
+        [StateTransitionEnum.IDENTITY_CREDIT_WITHDRAWAL]: false
+      }
+
+      for (const [type, isInput] of Object.entries(transferTypes)) {
+        const transaction = await createTransaction(Number(type))
+
+        await fixtures.transfer(knex, {
+          amount: 100000000,
+          sender: isInput ? null : identity.identifier,
+          recipient: isInput ? identity.identifier : null,
+          state_transition_hash: transaction.hash
+        })
+
+        if (isInput) {
+          inputAmount += 100000000
+        } else {
+          outputAmount += 100000000
+        }
+      }
+
+      // transitions with amounts in the platform_address_transitions table
+      const platformAddress = await fixtures.platformAddress(knex, {})
+
+      const addressTypes = {
+        [StateTransitionEnum.ADDRESS_FUNDING_FROM_ASSET_LOCK]: true,
+        [StateTransitionEnum.ADDRESS_CREDIT_WITHDRAWAL]: false
+      }
+
+      for (const [type, isInput] of Object.entries(addressTypes)) {
+        const transaction = await createTransaction(Number(type))
+
+        await fixtures.platformAddressTransition(knex, {
+          sender_id: isInput ? null : platformAddress.id,
+          recipient_id: isInput ? platformAddress.id : null,
+          state_transition_id: transaction.id,
+          state_transition_type: Number(type),
+          amount: 70000000
+        })
+
+        if (isInput) {
+          inputAmount += 70000000
+        } else {
+          outputAmount += 70000000
+        }
+      }
+
+      // transitions with amounts in the shielded_transitions table
+      const shieldedTypes = {
+        [StateTransitionEnum.SHIELD_FROM_ASSET_LOCK]: true,
+        [StateTransitionEnum.SHIELDED_WITHDRAWAL]: false
+      }
+
+      for (const [type, isInput] of Object.entries(shieldedTypes)) {
+        const transaction = await createTransaction(Number(type))
+
+        await fixtures.shieldedTransition(knex, {
+          state_transition_id: transaction.id,
+          state_transition_type: Number(type),
+          amount: 50000000
+        })
+
+        if (isInput) {
+          inputAmount += 50000000
+        } else {
+          outputAmount += 50000000
+        }
+      }
+    })
+
+    it('should return input amount series', async () => {
+      const { body } = await client.get(`/transactions/input/history?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}&intervalsCount=10`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const totalAmount = body.reduce((acc, point) => acc + point.data.amount, 0)
+
+      assert.equal(totalAmount, inputAmount)
+    })
+
+    it('should return output amount series', async () => {
+      const { body } = await client.get(`/transactions/output/history?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}&intervalsCount=10`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const totalAmount = body.reduce((acc, point) => acc + point.data.amount, 0)
+
+      assert.equal(totalAmount, outputAmount)
+    })
+
+    it('should return error when start is after end', async () => {
+      await client.get(`/transactions/input/history?timestamp_start=${end.toISOString()}&timestamp_end=${start.toISOString()}`)
         .expect(400)
     })
   })

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -9,6 +9,7 @@ const tenderdashRpc = require('../../src/tenderdashRpc')
 const { IdentifierWASM } = require('pshenmic-dpp')
 const BatchTypeEnum = require('../../src/enums/BatchEnum')
 const { DocumentsController } = require('dash-platform-sdk/src/documents')
+const { ShieldedController } = require('dash-platform-sdk/src/shielded')
 
 describe('Transaction routes', () => {
   let app
@@ -1828,6 +1829,8 @@ describe('Transaction routes', () => {
       // start from a clean shielded pool so the aggregate is deterministic
       await knex.raw('DELETE FROM shielded_transitions')
 
+      mock.method(ShieldedController.prototype, 'getShieldedNotesCount', async () => 12n)
+
       let height = 2000
 
       for (const [type, amount] of Object.entries(amounts)) {
@@ -1864,6 +1867,7 @@ describe('Transaction routes', () => {
       assert.equal(body.totalShieldedOut, String(expectedOut))
       assert.equal(body.poolBalance, String(expectedIn - expectedOut))
       assert.equal(body.transitionsCount, Object.keys(amounts).length)
+      assert.equal(body.notesCount, 12)
       assert.equal(body.types.length, Object.keys(amounts).length)
 
       const shieldType = body.types.find(type => type.transactionType === 'SHIELD')

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -9,6 +9,7 @@ const { getKnex, checkTcpConnect } = require('../../src/utils')
 const BlockHeader = require('../../src/models/BlockHeader')
 const tenderdashRpc = require('../../src/tenderdashRpc')
 const DashCoreRPC = require('../../src/dashcoreRpc')
+const GeoIP = require('../../src/geoip')
 const ServiceNotAvailableError = require('../../src/errors/ServiceNotAvailableError')
 const Epoch = require('../../src/models/Epoch')
 const { base58 } = require('@scure/base')
@@ -33,6 +34,7 @@ describe('Validators routes', () => {
 
   let dashCoreRpcResponse
   let endpoints
+  let geoIpInfo
 
   let epochInfo
   let fullEpochInfo
@@ -67,6 +69,14 @@ describe('Validators routes', () => {
         status: 'ERR_OUT_OF_RANGE',
         message: 'The value of "msecs" is out of range. It must be a non-negative finite number. Received NaN'
       }
+    }
+
+    geoIpInfo = {
+      ipv4: '255.255.255.255',
+      countryCode: 'US',
+      city: 'Boardman',
+      latitude: 45.8399,
+      longitude: -119.7009
     }
 
     dashCoreRpcResponse = {
@@ -195,6 +205,8 @@ describe('Validators routes', () => {
 
     mock.method(DashCoreRPC, 'getProTxInfo', async () => dashCoreRpcResponse)
 
+    mock.method(GeoIP, 'lookup', () => geoIpInfo)
+
     mock.method(NodeController.prototype, 'getEpochsInfo', epochInfo)
 
     mock.method(IdentitiesController.prototype, 'getIdentityBalance', async () => 0)
@@ -240,7 +252,8 @@ describe('Validators routes', () => {
         withdrawalsCount: 5,
         lastWithdrawal: transactions[transactions.length - 1].hash,
         lastWithdrawalTime: timestamp.toISOString(),
-        endpoints
+        endpoints,
+        geoIpInfo
       }
 
       assert.deepEqual(body, expectedValidator)
@@ -292,7 +305,8 @@ describe('Validators routes', () => {
         withdrawalsCount: 5,
         lastWithdrawal: transactions[transactions.length - 2].hash,
         lastWithdrawalTime: timestamp.toISOString(),
-        endpoints
+        endpoints,
+        geoIpInfo
       }
 
       assert.deepEqual(body, expectedValidator)
@@ -337,7 +351,8 @@ describe('Validators routes', () => {
         withdrawalsCount: 5,
         lastWithdrawal: transactions[transactions.length - 1].hash,
         lastWithdrawalTime: timestamp.toISOString(),
-        endpoints
+        endpoints,
+        geoIpInfo
       }
 
       assert.deepEqual(body, expectedValidator)
@@ -388,7 +403,8 @@ describe('Validators routes', () => {
         withdrawalsCount: 5,
         lastWithdrawal: transactions[transactions.length - 2].hash,
         lastWithdrawalTime: timestamp.toISOString(),
-        endpoints
+        endpoints,
+        geoIpInfo
       }
 
       assert.deepEqual(body, expectedValidator)
@@ -454,7 +470,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -510,7 +527,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -567,7 +585,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -625,7 +644,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -687,7 +707,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -745,7 +766,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -803,7 +825,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -859,7 +882,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -938,7 +962,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1005,7 +1030,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1072,7 +1098,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1128,7 +1155,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1190,7 +1218,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1247,7 +1276,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1306,7 +1336,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1365,7 +1396,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1424,7 +1456,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1483,7 +1516,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1543,7 +1577,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1601,7 +1636,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1662,7 +1698,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1704,7 +1741,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1749,7 +1787,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1793,7 +1832,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1837,7 +1877,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1881,7 +1922,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1938,7 +1980,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -1994,7 +2037,8 @@ describe('Validators routes', () => {
               withdrawalsCount: null,
               lastWithdrawal: null,
               lastWithdrawalTime: null,
-              endpoints: null
+              endpoints: null,
+              geoIpInfo
             }
           })
 
@@ -2213,6 +2257,94 @@ describe('Validators routes', () => {
 
     it('should return error on wrong bounds', async () => {
       await client.get(`/validator/${validators[0].pro_tx_hash}/stats?timestamp_start=2025-01-02T00:00:00&timestamp_end=2024-01-08T00:00:00`)
+        .expect(400)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+    })
+  })
+
+  describe('getValidatorIncomeStatsByProTxHash()', async () => {
+    let start
+    let end
+    let validatorA
+    let validatorB
+
+    before(async () => {
+      // isolated time window so blocks seeded by other suites don't interfere
+      start = new Date('2031-01-01T00:00:00.000Z')
+      end = new Date('2031-01-01T01:00:00.000Z')
+
+      validatorA = await fixtures.validator(knex)
+      validatorB = await fixtures.validator(knex)
+
+      let height = 3000
+
+      const createBlockWithGas = async (validator, minuteOffset, gasUsed) => {
+        const block = await fixtures.block(knex, {
+          validator: validator.pro_tx_hash,
+          height: height++,
+          timestamp: new Date(start.getTime() + minuteOffset * 60000)
+        })
+
+        if (gasUsed !== null) {
+          await fixtures.transaction(knex, {
+            block_hash: block.hash,
+            block_height: block.height,
+            type: IDENTITY_CREDIT_WITHDRAWAL,
+            owner: identities[0].identifier,
+            gas_used: gasUsed
+          })
+        }
+      }
+
+      // first interval: both validators propose, fees split pro-rata by blocks
+      await createBlockWithGas(validatorA, 2, 1000)
+      await createBlockWithGas(validatorB, 4, 3000)
+
+      // second interval: only validatorA proposes
+      await createBlockWithGas(validatorA, 8, 600)
+
+      // third interval: only validatorB proposes, no income for validatorA
+      await createBlockWithGas(validatorB, 14, 500)
+    })
+
+    it('should return income stats by proTxHash', async () => {
+      const { body } = await client.get(`/validator/${validatorA.pro_tx_hash}/income/stats?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}&intervalsCount=10`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      const intervalMs = 360000
+
+      const expectedStats = []
+
+      for (let i = 0; i < 10; i++) {
+        // validatorA proposed 1 of 2 blocks in the first interval and the
+        // only block in the second one
+        const income = i === 0 ? 2000 : i === 1 ? 600 : 0
+
+        expectedStats.push({
+          timestamp: new Date(start.getTime() + intervalMs * i).toISOString(),
+          data: {
+            income
+          }
+        })
+      }
+
+      assert.deepEqual(expectedStats, body)
+    })
+
+    it('should return zero income series for validator without blocks', async () => {
+      const validator = await fixtures.validator(knex)
+
+      const { body } = await client.get(`/validator/${validator.pro_tx_hash}/income/stats?timestamp_start=${start.toISOString()}&timestamp_end=${end.toISOString()}&intervalsCount=10`)
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
+
+      assert.equal(body.length, 10)
+      assert.ok(body.every((point) => point.data.income === 0))
+    })
+
+    it('should return error on wrong bounds', async () => {
+      await client.get(`/validator/${validatorA.pro_tx_hash}/income/stats?timestamp_start=2025-01-02T00:00:00&timestamp_end=2024-01-08T00:00:00`)
         .expect(400)
         .expect('Content-Type', 'application/json; charset=utf-8')
     })

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -159,6 +159,7 @@ already-completed epochs. For the current (in-progress) epoch they are `null`.
 * epoch.totalDistributedStorageFees - total storage fees distributed in the epoch (credits)
 * epoch.totalCreatedStorageFees - total storage fees created in the epoch (credits)
 * epoch.coreBlockRewards - core block rewards for the epoch
+* epoch.blockProposers - block proposers of the finalized epoch, each `{ proposer, count }` where `proposer` is the validator ProTxHash (hex) and `count` is the number of blocks it proposed
 
 For the current (in-progress) epoch, live values are computed from the indexed
 data instead. For already-completed epochs they are `null`.
@@ -184,7 +185,13 @@ HTTP /epoch/2492
     "totalProcessingFees": "1897008860",
     "totalDistributedStorageFees": "0",
     "totalCreatedStorageFees": "13860000000",
-    "coreBlockRewards": "1932735784"
+    "coreBlockRewards": "1932735784",
+    "blockProposers": [
+      {
+        "proposer": "87075234AC47353B42BB97CE46330CB67CD4648C01F0B2393D7E729B0D678918",
+        "count": 3742
+      }
+    ]
   },
   "tps": 0.0140315750528904,
   "totalCollectedFees": 1897008860,
@@ -2796,7 +2803,7 @@ DOCUMENT TRANSITION
 }
 ```
 ```json lines
-TOKEN TRANSITION 
+TOKEN TRANSITION
 
 {
   "type": 1,
@@ -2826,176 +2833,176 @@ TOKEN TRANSITION
 IDENTITY_CREATE with chainLock
 
 {
-    "type": 2,
-    "typeString": "IDENTITY_CREATE",
+  "type": 2,
+  "typeString": "IDENTITY_CREATE",
+  "fundingAddress": null,
+  "assetLockProof": {
+    "coreChainLockedHeight": 1138871,
+    "type": "chainLock",
+    "fundingAmount": null,
+    "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
+    "vout": 0,
     "fundingAddress": null,
-    "assetLockProof": {
-      "coreChainLockedHeight": 1138871,
-      "type": "chainLock",
-      "fundingAmount": null,
-      "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
-      "vout": 0,
-      "fundingAddress": null,
-      "instantLock": null
+    "instantLock": null
+  },
+  "userFeeIncrease": 0,
+  "identityId": "awCc9STLEgw8pJozBq24QzGK5Th9mow7V3EjjY9M7aG",
+  "signature": "2015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f2141",
+  "raw": "0300010000020000000014b23f76cac0218f7637c924e45212bb260cff29250001fc001160b72021007051d2207c45d7592bb7e3e5b4b006a29cfe1899aea8abf00c50ee8a40860000412015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f214108b1737186062205ee3a5f7e19454121b648e0806c7bc1e8bc073c38217a28e1",
+  "publicKeys": [
+    {
+      "contractBounds": null,
+      "id": 0,
+      "type": "ECDSA_SECP256K1",
+      "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
+      "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "MASTER",
+      "readOnly": false,
+      "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
     },
-    "userFeeIncrease": 0,
-    "identityId": "awCc9STLEgw8pJozBq24QzGK5Th9mow7V3EjjY9M7aG",
-    "signature": "2015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f2141",
-    "raw": "0300010000020000000014b23f76cac0218f7637c924e45212bb260cff29250001fc001160b72021007051d2207c45d7592bb7e3e5b4b006a29cfe1899aea8abf00c50ee8a40860000412015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f214108b1737186062205ee3a5f7e19454121b648e0806c7bc1e8bc073c38217a28e1",
-    "publicKeys": [
-        {
-            "contractBounds": null,
-            "id": 0,
-            "type": "ECDSA_SECP256K1",
-            "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
-            "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "MASTER",
-            "readOnly": false,
-            "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
-        },
-        {
-            "contractBounds": null,
-            "id": 1,
-            "type": "ECDSA_SECP256K1",
-            "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
-            "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "HIGH",
-            "readOnly": false,
-            "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
-        },
-        {
-            "contractBounds": null,
-            "id": 2,
-            "type": "ECDSA_SECP256K1",
-            "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
-            "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "CRITICAL",
-            "readOnly": false,
-            "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
-        }
-    ]
+    {
+      "contractBounds": null,
+      "id": 1,
+      "type": "ECDSA_SECP256K1",
+      "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
+      "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "HIGH",
+      "readOnly": false,
+      "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
+    },
+    {
+      "contractBounds": null,
+      "id": 2,
+      "type": "ECDSA_SECP256K1",
+      "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
+      "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "CRITICAL",
+      "readOnly": false,
+      "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
+    }
+  ]
 }
 ```
 ```json lines
 IDENTITY_CREATE with instantLock
 
 {
-    "type": 2,
-    "typeString": "IDENTITY_CREATE",
-    "fundingAddress": "yV1ZYoep5FFSBxKWM24JUwKfnAkFHnXXV7",
-    "assetLockProof": {
-        "coreChainLockedHeight": null,
-        "type": "instantSend",
-        "fundingAmount": 34999000,
-        "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
-        "vout": 0,
-        "fundingAddress": "yeMdYXBPum8RmHvrq5SsYE9zNYhMEimbUY",
-        "instantLock": 'AQEKM9t1ICNzvddKryjM4enKn0Y5amBn3o6DwDoC4uk5SAAAAAAdraxrxe5CKYujiUmN9V1mgT5gQ3Bz2TzaGCW+TN2J/JQP49yOk0uJ6el6ls9CmNo++yPYoX1Sx1lWEZTTAAAAhXiuCBXgzawuboxMAXDiXQpJCCPi417VE4mdcYPgTa0/Hd+RCHLAR6H+MXhqKazlGddI7AdWxxLZ94ZvQu+qIpe7G9XRRjQWeYwroIyc6MqQF5mKpvV0AUMYUNMXjCsq'
+  "type": 2,
+  "typeString": "IDENTITY_CREATE",
+  "fundingAddress": "yV1ZYoep5FFSBxKWM24JUwKfnAkFHnXXV7",
+  "assetLockProof": {
+    "coreChainLockedHeight": null,
+    "type": "instantSend",
+    "fundingAmount": 34999000,
+    "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
+    "vout": 0,
+    "fundingAddress": "yeMdYXBPum8RmHvrq5SsYE9zNYhMEimbUY",
+    "instantLock": 'AQEKM9t1ICNzvddKryjM4enKn0Y5amBn3o6DwDoC4uk5SAAAAAAdraxrxe5CKYujiUmN9V1mgT5gQ3Bz2TzaGCW+TN2J/JQP49yOk0uJ6el6ls9CmNo++yPYoX1Sx1lWEZTTAAAAhXiuCBXgzawuboxMAXDiXQpJCCPi417VE4mdcYPgTa0/Hd+RCHLAR6H+MXhqKazlGddI7AdWxxLZ94ZvQu+qIpe7G9XRRjQWeYwroIyc6MqQF5mKpvV0AUMYUNMXjCsq'
+  },
+  "userFeeIncrease": 0,
+  "identityId": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
+  "signature": "1fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f",
+  "raw": "03000400000000000000210258abe04886308feb52b8f3d64eace4913c9d049f4dda9a88a217e6ca6b89a107411f60451588fe72a067daaa0a1ee04279e77ce346128560129162386f76d51eccdc1d88704f2262fe173de57e5598010655d410da94ae2e1cf7086049878b08e966000100000200002103e6680bb560e40adb299a6b940d3dcbe2b08e6e1a64bc8f6bc9ec3d638655c3554120066559ccd6cea8ac2d366980f77a94cbfdfbd978803edbf4066f42bc53adcdb51956fb0d3c9cec2012583d17b66456094a8620109d6dae29dc562b2870592940000200000100002102326a8c19a1c58d30d142e113d0ddf381d95a6306f56c9ec4d3cb8c4823685b29411f5bb82721b58d92e67db9fb699ab939ccc4a6d5e2e498e80dfb8a3535c13f571923f045e645a898762f8305a4a2218bfedb060f8a8492c48ae9c96247ce17710b00030003010000210252a2d08f295871ec4b04cb0bcf7b2899b0b004702d9058982dd797141d527e78412044820dc7651186634326922eda85741bb3f9f005057d94b36845a7edc16ed1df4d5ccabd7e7f003e9c189847fbc06e943252640bc47963c42ae6c0d87b7b506b00c601014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b10100000077ba9d450b94520434c5d15339922aa7df81b51344b98588649a44752f1a355cd0d05ce3df52f3fb7fc6e64cc414fb7cd9d0ffc4d088e77d9e542fade30000008a8678665212af134cfa36ea40984009adca338efa3131667f5a62b489d2fb2713eb7eccd14dd83cc6679b597548feae18bdc393dae2ab2a50844220359d4b87c428507808dc8df62f56dabb8d1eae2c1859b9ca54b3b4820ebc8453f57c34f6ef03000800014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b1010000006a473044022070293df3b93c523373f1f86272c5dba7886ab41cfc50b0b89658c07d0825c16002201afdf3b31393c5b99373597042b4d651028e824fc12f802aa1be51cc165bcf1e012103d55244573359ad586597b9bb4dd31b8f145121b7c01146656bc26c4b99184a47ffffffff0240420f0000000000026a0049ac4c2e000000001976a91441bb9b42b9f0d589008b4a7f6a72a6bb342b386d88ac0000000024010140420f00000000001976a9145f573cd6a8570cb0b74c4b0ea15334e6bd6b34a788ac0000411fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f98b95bbff1488807c3a4ed36c5fde32f9a6f1e05a622938476652041669e4135",
+  "publicKeys": [
+    {
+      "contractBounds": null,
+      "id": 0,
+      "type": "ECDSA_SECP256K1",
+      "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
+      "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "MASTER",
+      "readOnly": false,
+      "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
     },
-    "userFeeIncrease": 0,
-    "identityId": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
-    "signature": "1fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f",
-    "raw": "03000400000000000000210258abe04886308feb52b8f3d64eace4913c9d049f4dda9a88a217e6ca6b89a107411f60451588fe72a067daaa0a1ee04279e77ce346128560129162386f76d51eccdc1d88704f2262fe173de57e5598010655d410da94ae2e1cf7086049878b08e966000100000200002103e6680bb560e40adb299a6b940d3dcbe2b08e6e1a64bc8f6bc9ec3d638655c3554120066559ccd6cea8ac2d366980f77a94cbfdfbd978803edbf4066f42bc53adcdb51956fb0d3c9cec2012583d17b66456094a8620109d6dae29dc562b2870592940000200000100002102326a8c19a1c58d30d142e113d0ddf381d95a6306f56c9ec4d3cb8c4823685b29411f5bb82721b58d92e67db9fb699ab939ccc4a6d5e2e498e80dfb8a3535c13f571923f045e645a898762f8305a4a2218bfedb060f8a8492c48ae9c96247ce17710b00030003010000210252a2d08f295871ec4b04cb0bcf7b2899b0b004702d9058982dd797141d527e78412044820dc7651186634326922eda85741bb3f9f005057d94b36845a7edc16ed1df4d5ccabd7e7f003e9c189847fbc06e943252640bc47963c42ae6c0d87b7b506b00c601014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b10100000077ba9d450b94520434c5d15339922aa7df81b51344b98588649a44752f1a355cd0d05ce3df52f3fb7fc6e64cc414fb7cd9d0ffc4d088e77d9e542fade30000008a8678665212af134cfa36ea40984009adca338efa3131667f5a62b489d2fb2713eb7eccd14dd83cc6679b597548feae18bdc393dae2ab2a50844220359d4b87c428507808dc8df62f56dabb8d1eae2c1859b9ca54b3b4820ebc8453f57c34f6ef03000800014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b1010000006a473044022070293df3b93c523373f1f86272c5dba7886ab41cfc50b0b89658c07d0825c16002201afdf3b31393c5b99373597042b4d651028e824fc12f802aa1be51cc165bcf1e012103d55244573359ad586597b9bb4dd31b8f145121b7c01146656bc26c4b99184a47ffffffff0240420f0000000000026a0049ac4c2e000000001976a91441bb9b42b9f0d589008b4a7f6a72a6bb342b386d88ac0000000024010140420f00000000001976a9145f573cd6a8570cb0b74c4b0ea15334e6bd6b34a788ac0000411fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f98b95bbff1488807c3a4ed36c5fde32f9a6f1e05a622938476652041669e4135",
-    "publicKeys": [
-        {
-            "contractBounds": null,
-            "id": 0,
-            "type": "ECDSA_SECP256K1",
-            "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
-            "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "MASTER",
-            "readOnly": false,
-            "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
-        },
-        {
-            "contractBounds": null,
-            "id": 1,
-            "type": "ECDSA_SECP256K1",
-            "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
-            "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "HIGH",
-            "readOnly": false,
-            "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
-        },
-        {
-            "contractBounds": null,
-            "id": 2,
-            "type": "ECDSA_SECP256K1",
-            "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
-            "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "CRITICAL",
-            "readOnly": false,
-            "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
-        }
-    ]
+    {
+      "contractBounds": null,
+      "id": 1,
+      "type": "ECDSA_SECP256K1",
+      "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
+      "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "HIGH",
+      "readOnly": false,
+      "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
+    },
+    {
+      "contractBounds": null,
+      "id": 2,
+      "type": "ECDSA_SECP256K1",
+      "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
+      "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "CRITICAL",
+      "readOnly": false,
+      "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
+    }
+  ]
 }
 ```
 ```json
 {
-    "type": 3,
-    "typeString": "IDENTITY_TOP_UP",
-    "assetLockProof": {
-        "coreChainLockedHeight": null,
-        "type": "instantSend",
-        "fundingAmount": 999000,
-        "txid": "7734f498c5b59f64f73070e0a5ec4fa113065da00358223cf888c3c27317ea64",
-        "vout": 0,
-        "fundingAddress": "yWxCwVRgqRmePNPJxezgus1T7xSv5q17SU"
-    },
-    "identityId": "4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF",
-    "amount": 300000000,
-    "signature": "810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710",
-    "raw": "040000c60101ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d5660000000064ea1773c2c388f83c225803a05d0613a14feca5e07030f7649fb5c598f43477940fe3dc8e934b89e9e97a96cf4298da3efb23d8a17d52c759561194d3000000a5e81597e94558618bf1464801188ecbc09c7a12e73489225c63684259f075f87aa3d47ea9bbbe1f9c314086ddc35a6d18b30ff4fe579855779f9268b8bf5c79760c7d8c56d34163931f016c2e3036852dd33a6b643dd59dc8c54199f34e3d2def0300080001ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d566000000006a4730440220339d4d894eb2ff9c193bd8c33cdb3030a8be18ddbf30d983e8286c08c6c4c7d90220181741d9eed3814ec077030c26c0b9fff63b9ef10e1e6ca1c87069b261b0127a0121034951bbd5d0d500942426507d4b84e6d88406300ed82009a8db087f493017786affffffff02e093040000000000026a0078aa0a00000000001976a914706db5d1e8fb5f925c6db64104f4b77f0c8b73d488ac00000000240101e0930400000000001976a91474a509b4f3b80ce818465dc0f9f66e2103d9178b88ac003012c19b98ec0033addb36cd64b7f510670f2a351a4304b5f6994144286efdac411f810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710"
+  "type": 3,
+  "typeString": "IDENTITY_TOP_UP",
+  "assetLockProof": {
+    "coreChainLockedHeight": null,
+    "type": "instantSend",
+    "fundingAmount": 999000,
+    "txid": "7734f498c5b59f64f73070e0a5ec4fa113065da00358223cf888c3c27317ea64",
+    "vout": 0,
+    "fundingAddress": "yWxCwVRgqRmePNPJxezgus1T7xSv5q17SU"
+  },
+  "identityId": "4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF",
+  "amount": 300000000,
+  "signature": "810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710",
+  "raw": "040000c60101ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d5660000000064ea1773c2c388f83c225803a05d0613a14feca5e07030f7649fb5c598f43477940fe3dc8e934b89e9e97a96cf4298da3efb23d8a17d52c759561194d3000000a5e81597e94558618bf1464801188ecbc09c7a12e73489225c63684259f075f87aa3d47ea9bbbe1f9c314086ddc35a6d18b30ff4fe579855779f9268b8bf5c79760c7d8c56d34163931f016c2e3036852dd33a6b643dd59dc8c54199f34e3d2def0300080001ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d566000000006a4730440220339d4d894eb2ff9c193bd8c33cdb3030a8be18ddbf30d983e8286c08c6c4c7d90220181741d9eed3814ec077030c26c0b9fff63b9ef10e1e6ca1c87069b261b0127a0121034951bbd5d0d500942426507d4b84e6d88406300ed82009a8db087f493017786affffffff02e093040000000000026a0078aa0a00000000001976a914706db5d1e8fb5f925c6db64104f4b77f0c8b73d488ac00000000240101e0930400000000001976a91474a509b4f3b80ce818465dc0f9f66e2103d9178b88ac003012c19b98ec0033addb36cd64b7f510670f2a351a4304b5f6994144286efdac411f810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710"
 }
 ```
 ```json
 {
-    "type": 4,
-    "typeString": "DATA_CONTRACT_UPDATE",
-    "internalConfig": {
-        "canBeDeleted": false,
-        "readonly": false,
-        "keepsHistory": false,
-        "documentsKeepHistoryContractDefault": false,
-        "documentsMutableContractDefault": true,
-        "documentsCanBeDeletedContractDefault": true,
-        "requiresIdentityDecryptionBoundedKey": null,
-        "requiresIdentityEncryptionBoundedKey": null
-    },
-    "tokens": [],
-    "groups": [],
-    "identityContractNonce": 6,
-    "signaturePublicKeyId": 2,
-    "signature": "1ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903",
-    "userFeeIncrease": 0,
-    "ownerId": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
-    "dataContractId": "AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18",
-    "dataContractIdentityNonce": "0",
-    "schema": {
-        "note": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "position": 0
-                },
-                "author": {
-                    "type": "string",
-                    "position": 1
-                }
-            },
-            "additionalProperties": false
+  "type": 4,
+  "typeString": "DATA_CONTRACT_UPDATE",
+  "internalConfig": {
+    "canBeDeleted": false,
+    "readonly": false,
+    "keepsHistory": false,
+    "documentsKeepHistoryContractDefault": false,
+    "documentsMutableContractDefault": true,
+    "documentsCanBeDeletedContractDefault": true,
+    "requiresIdentityDecryptionBoundedKey": null,
+    "requiresIdentityEncryptionBoundedKey": null
+  },
+  "tokens": [],
+  "groups": [],
+  "identityContractNonce": 6,
+  "signaturePublicKeyId": 2,
+  "signature": "1ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903",
+  "userFeeIncrease": 0,
+  "ownerId": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
+  "dataContractId": "AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18",
+  "dataContractIdentityNonce": "0",
+  "schema": {
+    "note": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "position": 0
+        },
+        "author": {
+          "type": "string",
+          "position": 1
         }
-    },
-    "version": 2,
-    "dataContractOwner": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
-    "raw": "010006008a4af217f340e9c4c95857496cf33b68eb6c712ac6d20a1eb7854d14afd9ffcf00000000000101000002e901dfc172a96ce3f7d334d6c0b69df3b01c86d30ff03a7c24f516838f94340d0001046e6f7465160312047479706512066f626a656374120a70726f70657274696573160212076d65737361676516021204747970651206737472696e671208706f736974696f6e02001206617574686f7216021204747970651206737472696e671208706f736974696f6e020112146164646974696f6e616c50726f7065727469657313000002411ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903"
+      },
+      "additionalProperties": false
+    }
+  },
+  "version": 2,
+  "dataContractOwner": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
+  "raw": "010006008a4af217f340e9c4c95857496cf33b68eb6c712ac6d20a1eb7854d14afd9ffcf00000000000101000002e901dfc172a96ce3f7d334d6c0b69df3b01c86d30ff03a7c24f516838f94340d0001046e6f7465160312047479706512066f626a656374120a70726f70657274696573160212076d65737361676516021204747970651206737472696e671208706f736974696f6e02001206617574686f7216021204747970651206737472696e671208706f736974696f6e020112146164646974696f6e616c50726f7065727469657313000002411ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903"
 }
 ```
 ```json
@@ -3007,28 +3014,28 @@ IDENTITY_CREATE with instantLock
   "identityId": "4NGALjtX2t3AXE3ZCqJiSmYuiWEY3ZPQNUBxNWWRrRSp",
   "revision": 2,
   "publicKeysToAdd": [
-      {
-          "contractBounds": null,
-          "id": 5,
-          "type": "ECDSA_HASH160",
-          "data": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
-          "publicKeyHash": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
-          "purpose": "AUTHENTICATION",
-          "securityLevel": "HIGH",
-          "readOnly": false,
-          "signature": ""
-      },
-      {
-          "contractBounds": null,
-          "id": 6,
-          "type": "ECDSA_SECP256K1",
-          "data": "026213380930c93c4b53f6ddbc5adc5f5165102d8f92f7d9a495a8f9c6e61b30f0",
-          "publicKeyHash": "d39eda042126256a372c388bd191532a7c9612ce",
-          "purpose": "AUTHENTICATION",
-          "securityLevel": "MASTER",
-          "readOnly": false,
-          "signature": "1faf8b0f16320d0f9e29c1db12ab0d3ec87974b19f6fc1189a988cd85503d79f844d3ff778678d7f4f3829891e8e8d0183456194d9fc76ed66e503154996eefe06"
-      }
+    {
+      "contractBounds": null,
+      "id": 5,
+      "type": "ECDSA_HASH160",
+      "data": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
+      "publicKeyHash": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "HIGH",
+      "readOnly": false,
+      "signature": ""
+    },
+    {
+      "contractBounds": null,
+      "id": 6,
+      "type": "ECDSA_SECP256K1",
+      "data": "026213380930c93c4b53f6ddbc5adc5f5165102d8f92f7d9a495a8f9c6e61b30f0",
+      "publicKeyHash": "d39eda042126256a372c388bd191532a7c9612ce",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "MASTER",
+      "readOnly": false,
+      "signature": "1faf8b0f16320d0f9e29c1db12ab0d3ec87974b19f6fc1189a988cd85503d79f844d3ff778678d7f4f3829891e8e8d0183456194d9fc76ed66e503154996eefe06"
+    }
   ],
   "publicKeyIdsToDisable": [],
   "signature": "1f341c8eb7b890f416c7a970406dd37da078dab5f2c4aa8dd18375516933b234873127965dd72ee28b7392fcd87e28c4bfef890791b58fa9c34bce9e96d6536cb1",
@@ -3038,54 +3045,54 @@ IDENTITY_CREATE with instantLock
 ```
 ```json
 {
-    "type": 6,
-    "typeString": "IDENTITY_CREDIT_WITHDRAWAL",
-    "outputAddress": "yifJkXaxe7oM1NgBDTaXnWa6kXZAazBfjk",
-    "userFeeIncrease": 0,
-    "senderId": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
-    "amount": 200000,
-    "identityNonce": 6,
-    "outputScript": "76a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac",
-    "coreFeePerByte": 5,
-    "signature": "20cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b",
-    "signaturePublicKeyId": 3,
-    "pooling": "Standard",
-    "raw": "05017199f1f68404c86ecf60d9cb93aef318fa0f2b08e59ffd176bdef43154ffde6bfc00030d400500011976a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac0600034120cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b"
+  "type": 6,
+  "typeString": "IDENTITY_CREDIT_WITHDRAWAL",
+  "outputAddress": "yifJkXaxe7oM1NgBDTaXnWa6kXZAazBfjk",
+  "userFeeIncrease": 0,
+  "senderId": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
+  "amount": 200000,
+  "identityNonce": 6,
+  "outputScript": "76a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac",
+  "coreFeePerByte": 5,
+  "signature": "20cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b",
+  "signaturePublicKeyId": 3,
+  "pooling": "Standard",
+  "raw": "05017199f1f68404c86ecf60d9cb93aef318fa0f2b08e59ffd176bdef43154ffde6bfc00030d400500011976a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac0600034120cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b"
 }
 ```
 ```json
 {
-    "type": 7,
-    "typeString": "IDENTITY_CREDIT_TRANSFER",
-    "identityNonce": 1,
-    "userFeeIncrease": 0,
-    "senderId": "24YEeZmpy1QNKronDT8enYWLXnfoxYK7hrHUdpWHxURg",
-    "recipientId": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
-    "amount": 21856638,
-    "signaturePublicKeyId": 3,
-    "signature": "1f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8",
-    "raw": "07000fc3bf4a26bff60f4f79a1f4b929ce4d4c5833d226c1c7f68758e71d7ae229db569fd4f616b3dedecbeef95352cf38f1fb04d232a0d20623bc195b0c3f721840fc014d817e010003411f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8"
+  "type": 7,
+  "typeString": "IDENTITY_CREDIT_TRANSFER",
+  "identityNonce": 1,
+  "userFeeIncrease": 0,
+  "senderId": "24YEeZmpy1QNKronDT8enYWLXnfoxYK7hrHUdpWHxURg",
+  "recipientId": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
+  "amount": 21856638,
+  "signaturePublicKeyId": 3,
+  "signature": "1f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8",
+  "raw": "07000fc3bf4a26bff60f4f79a1f4b929ce4d4c5833d226c1c7f68758e71d7ae229db569fd4f616b3dedecbeef95352cf38f1fb04d232a0d20623bc195b0c3f721840fc014d817e010003411f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8"
 }
 ```
 ```json
 {
-    "type": 8,
-    "typeString": "IDENTITY_CREDIT_TRANSFER",
-    "indexValues": [
-        "EgRkYXNo",
-        "EgN5MDE="
-    ],
-    "contractId": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
-    "modifiedDataIds": [
-        "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse"
-    ],
-    "ownerId": "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse",
-    "signature": "2019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d",
-    "documentTypeName": "domain",
-    "indexName": "parentNameAndLabel",
-    "choice": "Abstain",
-    "proTxHash": "ad4e38fc81da72d61b14238ee6e5b91915554e24d725718800692d3a863c910b",
-    "raw": "08005b246080ba64350685fe302d3d790f5bb238cb619920d46230c844f079944a233bb2df460e72e3d59e7fe1c082ab3a5bd9445dd0dd5c4894a6d9f0d9ed9404b5000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c021204646173681203793031010c00412019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d"
+  "type": 8,
+  "typeString": "IDENTITY_CREDIT_TRANSFER",
+  "indexValues": [
+    "EgRkYXNo",
+    "EgN5MDE="
+  ],
+  "contractId": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+  "modifiedDataIds": [
+    "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse"
+  ],
+  "ownerId": "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse",
+  "signature": "2019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d",
+  "documentTypeName": "domain",
+  "indexName": "parentNameAndLabel",
+  "choice": "Abstain",
+  "proTxHash": "ad4e38fc81da72d61b14238ee6e5b91915554e24d725718800692d3a863c910b",
+  "raw": "08005b246080ba64350685fe302d3d790f5bb238cb619920d46230c844f079944a233bb2df460e72e3d59e7fe1c082ab3a5bd9445dd0dd5c4894a6d9f0d9ed9404b5000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c021204646173681203793031010c00412019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d"
 }
 ```
 ```json
@@ -3138,72 +3145,72 @@ IDENTITY_CREATE with instantLock
 ```
 ```json
 {
-    "type": 13,
-    "typeString": "ADDRESS_FUNDING_FROM_ASSET_LOCK",
-    "assetLockProof": {
-        "coreChainLockedHeight": null,
-        "type": "instantSend",
-        "instantLock": "AQKflfCMay9YZSHo7Yy2u5l0vwE0obDfr8cqfShF9bqn/gEAAAD2vDZ5zvy1mcNCSF5jfsxQkw0veXBo6aJNE/13WYR7awEAAACJfGgEXp9GdjneIf96kXXJEn+b/Qix6fYXJ1hgqBQzH/y3yJZU0Ky99rsWgfhfdvFC4UBFsddngtq6TJgBAAAAix7+tMc2flwUVAB1uquM+dk5TF/nhmAnX9PmNHbUnIUTFWvpfXw7lnqpLERjGgKeF5ITbSsXcFU2TiKYWg7esh/DYYYrbdXBbJ6OoiLVQjjI60Em+1NK4nPycG9g6xOX",
-        "fundingAmount": "100000000",
-        "fundingCoreTx": "1f3314a860582717f6e9b108fd9b7f12c975917aff21de3976469f5e04687c89",
-        "vout": 0
-    },
-    "userFeeIncrease": 0,
-    "inputs": [],
-    "inputWitness": [],
-    "outputs": [
-        {
-            "platformAddress": {
-              "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
-              "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
-            },
-            "credits": "0"
-        }
-    ],
-    "feeStrategy": [
-        {
-            "type": "ReduceOutput",
-            "value": 0
-        }
-    ],
-    "signature": "202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f4064",
-    "raw": "0d0000ea01029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe01000000f6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b01000000897c68045e9f467639de21ff7a9175c9127f9bfd08b1e9f617275860a814331ffcb7c89654d0acbdf6bb1681f85f76f142e14045b1d76782daba4c98010000008b1efeb4c7367e5c14540075baab8cf9d9394c5fe78660275fd3e63476d49c8513156be97d7c3b967aa92c44631a029e1792136d2b177055364e22985a0edeb21fc361862b6dd5c16c9e8ea222d54238c8eb4126fb534ae273f2706f60eb1397fb018303000800029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe010000006b483045022100bbfbd824846523f7d2c6799b47a9dea88c0fb60dd433d0d8971abee63dd4966b022008dcee6d9780aa962d37cfed6ca54e256f6dba1190c01c7a58cc749709179f450121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aefffffffff6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b010000006a473044022074bd9c8c4ca4557cdf57017627b6b666c7586b674503f3f26ae8f1fed714d2510220295ea1d64c5745988e94c963972059d20171d0e0f92b07c31469bb622a468f3c0121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aeffffffff0200e1f50500000000026a00a008510b000000001976a914f84b203ee59814a41f1aa2379043ab3af98143f188ac0000000024010100e1f505000000001976a91469dccf851a2cb6c2f18ee1274e4fd1669af7685a88ac000001005022deda5da7414a3aa460705a5bb16b1282c97a000101000041202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f406400"
+  "type": 13,
+  "typeString": "ADDRESS_FUNDING_FROM_ASSET_LOCK",
+  "assetLockProof": {
+    "coreChainLockedHeight": null,
+    "type": "instantSend",
+    "instantLock": "AQKflfCMay9YZSHo7Yy2u5l0vwE0obDfr8cqfShF9bqn/gEAAAD2vDZ5zvy1mcNCSF5jfsxQkw0veXBo6aJNE/13WYR7awEAAACJfGgEXp9GdjneIf96kXXJEn+b/Qix6fYXJ1hgqBQzH/y3yJZU0Ky99rsWgfhfdvFC4UBFsddngtq6TJgBAAAAix7+tMc2flwUVAB1uquM+dk5TF/nhmAnX9PmNHbUnIUTFWvpfXw7lnqpLERjGgKeF5ITbSsXcFU2TiKYWg7esh/DYYYrbdXBbJ6OoiLVQjjI60Em+1NK4nPycG9g6xOX",
+    "fundingAmount": "100000000",
+    "fundingCoreTx": "1f3314a860582717f6e9b108fd9b7f12c975917aff21de3976469f5e04687c89",
+    "vout": 0
+  },
+  "userFeeIncrease": 0,
+  "inputs": [],
+  "inputWitness": [],
+  "outputs": [
+    {
+      "platformAddress": {
+        "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
+        "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
+      },
+      "credits": "0"
+    }
+  ],
+  "feeStrategy": [
+    {
+      "type": "ReduceOutput",
+      "value": 0
+    }
+  ],
+  "signature": "202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f4064",
+  "raw": "0d0000ea01029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe01000000f6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b01000000897c68045e9f467639de21ff7a9175c9127f9bfd08b1e9f617275860a814331ffcb7c89654d0acbdf6bb1681f85f76f142e14045b1d76782daba4c98010000008b1efeb4c7367e5c14540075baab8cf9d9394c5fe78660275fd3e63476d49c8513156be97d7c3b967aa92c44631a029e1792136d2b177055364e22985a0edeb21fc361862b6dd5c16c9e8ea222d54238c8eb4126fb534ae273f2706f60eb1397fb018303000800029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe010000006b483045022100bbfbd824846523f7d2c6799b47a9dea88c0fb60dd433d0d8971abee63dd4966b022008dcee6d9780aa962d37cfed6ca54e256f6dba1190c01c7a58cc749709179f450121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aefffffffff6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b010000006a473044022074bd9c8c4ca4557cdf57017627b6b666c7586b674503f3f26ae8f1fed714d2510220295ea1d64c5745988e94c963972059d20171d0e0f92b07c31469bb622a468f3c0121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aeffffffff0200e1f50500000000026a00a008510b000000001976a914f84b203ee59814a41f1aa2379043ab3af98143f188ac0000000024010100e1f505000000001976a91469dccf851a2cb6c2f18ee1274e4fd1669af7685a88ac000001005022deda5da7414a3aa460705a5bb16b1282c97a000101000041202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f406400"
 }
 ```
 ```json
 {
-    "type": 14,
-    "typeString": "ADDRESS_CREDIT_WITHDRAWAL",
-    "userFeeIncrease": 0,
-    "inputs": [
-        {
-            "platformAddress": {
-              "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
-              "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
-            },
-            "credits": "250000000000",
-            "nonce": "5"
-        }
-    ],
-    "inputWitness": [
-        {
-            "type": "P2PKH",
-            "value": {
-                "signature": "2097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
-            }
-        }
-    ],
-    "output": null,
-    "feeStrategy": [
-        {
-            "type": "DeductFromInput",
-            "value": 0
-        }
-    ],
-    "pooling": 0,
-    "outputAddress": "yT6NQzvH2h16ggSKNj2b2Wu3NMFiYVKXeB",
-    "outputScript": "76a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac",
-    "raw": "0e000100914e8a18eb34517b7a6a4432cf237f68c5f8332e05fd0000003a352944000001000001001976a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac000100412097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
+  "type": 14,
+  "typeString": "ADDRESS_CREDIT_WITHDRAWAL",
+  "userFeeIncrease": 0,
+  "inputs": [
+    {
+      "platformAddress": {
+        "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
+        "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
+      },
+      "credits": "250000000000",
+      "nonce": "5"
+    }
+  ],
+  "inputWitness": [
+    {
+      "type": "P2PKH",
+      "value": {
+        "signature": "2097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
+      }
+    }
+  ],
+  "output": null,
+  "feeStrategy": [
+    {
+      "type": "DeductFromInput",
+      "value": 0
+    }
+  ],
+  "pooling": 0,
+  "outputAddress": "yT6NQzvH2h16ggSKNj2b2Wu3NMFiYVKXeB",
+  "outputScript": "76a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac",
+  "raw": "0e000100914e8a18eb34517b7a6a4432cf237f68c5f8332e05fd0000003a352944000001000001001976a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac000100412097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
 }
 ```
 Response codes:

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -13,10 +13,12 @@ Reference:
 * [Block by hash](#block-by-hash)
 * [Blocks by validator](#blocks-by-validator)
 * [Blocks](#blocks)
+* [Average Block Time History](#average-block-time-history)
 * [Validators](#validators)
 * [Validator by ProTxHash](#validator-by-protxhash)
 * [Validator by Masternode Identifier](#validator-by-masternode-identifier)
 * [Validator Rewards Statistic](#validator-rewards-stats-by-protxhash)
+* [Validator Income Statistic](#validator-income-stats-by-protxhash)
 * [Validator Blocks Statistic](#validator-stats-by-protxhash)
 * [Transaction by hash](#transaction-by-hash)
 * [Transactions](#transactions)
@@ -26,6 +28,7 @@ Reference:
 * [Data Contracts](#data-contracts)
 * [Data Contract Transactions](#data-contract-transactions)
 * [Data Contracts Rating](#data-contracts-rating)
+* [Active Data Contracts](#active-data-contracts)
 * [Document by Identifier](#document-by-identifier)
 * [RAW Document by Identifier](#raw-document-by-identifier)
 * [Document Revisions](#document-revisions)
@@ -163,6 +166,8 @@ data instead. For already-completed epochs they are `null`.
 * pendingBlocksInEpoch - number of blocks produced in the epoch so far
 * pendingEpochReward - fees collected in the epoch so far (credits)
 
+`avgBlockTime` is the average time between consecutive blocks in the epoch in milliseconds, or `null` when the epoch contains less than two blocks.
+
 
 ```
 HTTP /epoch/2492
@@ -202,6 +207,11 @@ HTTP /epoch/2492
   "totalVotesCount": 12,
   "totalVotesGasUsed": 120000000,
   "totalTxCount": 49,
+  "totalCreatedDocumentsCount": 14,
+  "totalDeletedDocumentsCount": 2,
+  "totalRegisteredNamesCount": 5,
+  "totalContestedDocumentsCount": 3,
+  "avgBlockTime": 933,
   "pendingBlocksInEpoch": null,
   "pendingEpochReward": null
 }
@@ -328,6 +338,31 @@ GET /blocks?epoch_index_min=1000&epoch_index_max=1200&height_min=2000&height_max
 }
 ```
 ---
+### Average Block Time History
+Return a series data for the average block time chart. `avgBlockTime` is the average time between consecutive blocks in the interval in milliseconds, or `null` when the interval contains less than two blocks
+
+* `timestamp_start` lower interval threshold in ISO string
+* `timestamp_end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /blocks/avgBlockTime/history?timestamp_start=2024-01-01T00:00:00&timestamp_end=2025-01-01T00:00:00
+[
+    {
+        "timestamp": "2024-06-23T13:51:44.154Z",
+        "data": {
+          "avgBlockTime": 5210
+        }
+    }, ...
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check start/end values
+500: Internal Server Error
+```
+---
 ### Validators
 Return all validators with pagination info.
 * Valid `order` values are `asc` or `desc`
@@ -340,6 +375,8 @@ Return all validators with pagination info.
 * `last_proposed_block_height_min` and `last_proposed_block_height_min` minimum and maximum last proposed blocks height
 * `last_proposed_block_timestamp_start` and `last_proposed_block_timestamp_end` timestamp start and end for last proposed blocks
 * `last_proposed_block_hash` hash of last proposed block
+* `geoIpInfo` contains the node location resolved from its service IP with the [DB-IP City Lite](https://db-ip.com) database; it is `null` when the service address has no IPv4 host, and its fields are `null` when the IP is not present in the database
+* the DB-IP City Lite database is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/): any page displaying `geoIpInfo` data must include an attribution link back to DB-IP.com, e.g. `<a href='https://db-ip.com'>IP Geolocation by DB-IP</a>`
 ```
 GET /validators?blocks_proposed_min=1&blocks_proposed_max=9999999&last_proposed_block_height_min=190458&last_proposed_block_height_max=197458&last_proposed_block_timestamp_start=2025-10-11T02:46:09.433Z&last_proposed_block_timestamp_end=2025-10-12T02:46:09.433Z&last_proposed_block_hash=9151C25609D85610C416450B4648CCB4671E373452EA8FA21AC0DF77D03039E1&is_active=true&limit=10&page=1&order=asc&owner=PJUBWbXWmzEYCs99rAAbnCiHRzrnhKLQrXbmSsuPBYB
 
@@ -406,7 +443,14 @@ GET /validators?blocks_proposed_min=1&blocks_proposed_max=9999999&last_proposed_
             "withdrawalsCount": null,
             "lastWithdrawal": null,
             "lastWithdrawalTime": null,
-            "endpoints": null
+            "endpoints": null,
+            "geoIpInfo": {
+                "ipv4": "52.24.124.162",
+                "countryCode": "US",
+                "city": "Boardman",
+                "latitude": 45.8399,
+                "longitude": -119.7009
+            }
         }
     ]
 }
@@ -415,6 +459,8 @@ GET /validators?blocks_proposed_min=1&blocks_proposed_max=9999999&last_proposed_
 ### Validator by ProTxHash
 Get validator by ProTxHash.
 * `lastProposedBlockHeader` field is nullable
+* `geoIpInfo` contains the node location resolved from its service IP with the [DB-IP City Lite](https://db-ip.com) database; it is `null` when the service address has no IPv4 host, and its fields are `null` when the IP is not present in the database
+* the DB-IP City Lite database is licensed under [CC BY 4.0](https://creativecommons.org/licenses/by/4.0/): any page displaying `geoIpInfo` data must include an attribution link back to DB-IP.com, e.g. `<a href='https://db-ip.com'>IP Geolocation by DB-IP</a>`
 ```
 GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
 
@@ -492,6 +538,13 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0
       "status": 'ERROR',
       "message": null
     }
+  },
+  "geoIpInfo": {
+    "ipv4": "35.164.23.245",
+    "countryCode": "US",
+    "city": "Boardman",
+    "latitude": 45.8399,
+    "longitude": -119.7009
   }
 }
 ```
@@ -576,6 +629,13 @@ GET /validator/identity/8tsWRSwsTM5AXv4ViCF9gu39kzjbtfFDM6rCyL2RcFzd
       "status": 'ERROR',
       "message": null
     }
+  },
+  "geoIpInfo": {
+    "ipv4": "35.164.23.245",
+    "countryCode": "US",
+    "city": "Boardman",
+    "latitude": 45.8399,
+    "longitude": -119.7009
   }
 }
 ```
@@ -594,6 +654,25 @@ GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/
         "timestamp": "2024-06-23T13:51:44.154Z",
         "data": {
             "reward": 34000000
+        }
+    },...
+]
+```
+---
+### Validator income stats by ProTxHash
+Return a series data for the validator income chart. Income per interval is estimated as the validator share of collected fees, proportional to the number of blocks it proposed (matching the platform fee pool distribution between epoch proposers)
+
+* `timestamp_start` lower interval threshold in ISO string
+* `timestamp_end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /validator/F60A6BF9EC0794BB0CFD1E0F2217933F4B33EDE6FE810692BC275CA18148AEF0/income/stats?timestamp_start=2024-01-01T00:00:00&timestamp_end=2025-01-01T00:00:00
+[
+    {
+        "timestamp": "2024-06-23T13:51:44.154Z",
+        "data": {
+            "income": 17000000
         }
     },...
 ]
@@ -1144,6 +1223,44 @@ GET /dataContracts/rating?timestamp_start=2025-08-18T21:13:57.191Z&timestamp_end
 Response codes:
 ```
 200: OK
+500: Internal Server Error
+```
+---
+### Active Data Contracts
+Return data contracts that had state transitions within a time range, ordered by their
+transitions count in that range, paged. Unlike the rating endpoint, contracts without
+activity in the range are not included
+
+* `timestamp_start` lower interval threshold (defaults to one hour ago)
+* `timestamp_end` upper interval threshold (defaults to now)
+* `limit` cannot be more than 100
+* `page` cannot be less than 1
+* Valid `order` values are `asc` or `desc`
+```
+GET /dataContracts/active?timestamp_start=2025-01-01T00:00:00.000Z&timestamp_end=2025-01-02T00:00:00.000Z&page=1&limit=10&order=desc
+
+{
+    "resultSet": [
+        {
+            "identifier": "465jdPpFCZefhb4g2k2FpCcrKpPYhJJskDqbGFsKu6wb",
+            "transitionsCount": 26
+        },
+        {
+            "identifier": "GWghYQoDFEb3osEfigrF7CKdZLWauxC7TwM4jsJyqa23",
+            "transitionsCount": 21
+        }, ...
+    ],
+    "pagination": {
+        "page": 1,
+        "limit": 10,
+        "total": 14
+    }
+}
+```
+Response codes:
+```
+200: OK
+400: Bad timestamp range
 500: Internal Server Error
 ```
 ---
@@ -2025,11 +2142,69 @@ Response codes:
 500: Internal Server Error
 ```
 ___
+### Transactions Input history
+Return a series data for the chart of the total amount entering the platform from the core chain (identity create, identity top up, address funding from asset lock and shield-from-asset-lock transitions)
+
+* `timestamp_start` lower interval threshold in ISO string
+* `timestamp_end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /transactions/input/history?timestamp_start=2024-01-01T00:00:00&timestamp_end=2025-01-01T00:00:00
+[
+    {
+        "timestamp": "2024-04-22T08:45:20.911Z",
+        "data": {
+          "amount": 100000000,
+          "blockHeight": 64060,
+          "blockHash": "4A1F6B5238032DDAC55009A28797D909DB4288D5B5EC14B86DEC6EA8F25EC71A"
+        }
+    }, ...
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check start/end values
+500: Internal Server Error
+```
+___
+### Transactions Output history
+Return a series data for the chart of the total amount leaving the platform to the core chain (identity credit withdrawal, address credit withdrawal and shielded withdrawal transitions)
+
+* `timestamp_start` lower interval threshold in ISO string
+* `timestamp_end` upper interval threshold in ISO string
+* `intervalsCount` intervals count in response ( _optional_ )
+
+```
+GET /transactions/output/history?timestamp_start=2024-01-01T00:00:00&timestamp_end=2025-01-01T00:00:00
+[
+    {
+        "timestamp": "2024-04-22T08:45:20.911Z",
+        "data": {
+          "amount": 50000000,
+          "blockHeight": 64333,
+          "blockHash": "507659D9BE2FF76A031F4219061F3D2D39475A7FA4B24F25AEFDB34CD4DF2A57"
+        }
+    }, ...
+]
+```
+Response codes:
+```
+200: OK
+400: Invalid input, check start/end values
+500: Internal Server Error
+```
+___
 ### Transactions Statistic
 Return the count of state transitions grouped by transaction type.
 
+Optionally accepts a time interval. Without parameters the statistic is calculated over all time.
+
+* `timestamp_start` and `timestamp_end` must be set together
+
 ```
-GET /transactions/statistic
+GET /transactions/statistic?timestamp_start=2024-10-01T00:00:00.000Z&timestamp_end=2024-11-01T00:00:00.000Z
 [
     {
         "transactionType": "DATA_CONTRACT_CREATE",
@@ -2044,6 +2219,7 @@ GET /transactions/statistic
 Response codes:
 ```
 200: OK
+400: Invalid input, check start/end values
 500: Internal Server Error
 ```
 ___
@@ -2618,7 +2794,7 @@ DOCUMENT TRANSITION
 }
 ```
 ```json lines
-TOKEN TRANSITION 
+TOKEN TRANSITION
 
 {
   "type": 1,
@@ -2648,176 +2824,176 @@ TOKEN TRANSITION
 IDENTITY_CREATE with chainLock
 
 {
-    "type": 2,
-    "typeString": "IDENTITY_CREATE",
+  "type": 2,
+  "typeString": "IDENTITY_CREATE",
+  "fundingAddress": null,
+  "assetLockProof": {
+    "coreChainLockedHeight": 1138871,
+    "type": "chainLock",
+    "fundingAmount": null,
+    "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
+    "vout": 0,
     "fundingAddress": null,
-    "assetLockProof": {
-      "coreChainLockedHeight": 1138871,
-      "type": "chainLock",
-      "fundingAmount": null,
-      "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
-      "vout": 0,
-      "fundingAddress": null,
-      "instantLock": null
+    "instantLock": null
+  },
+  "userFeeIncrease": 0,
+  "identityId": "awCc9STLEgw8pJozBq24QzGK5Th9mow7V3EjjY9M7aG",
+  "signature": "2015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f2141",
+  "raw": "0300010000020000000014b23f76cac0218f7637c924e45212bb260cff29250001fc001160b72021007051d2207c45d7592bb7e3e5b4b006a29cfe1899aea8abf00c50ee8a40860000412015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f214108b1737186062205ee3a5f7e19454121b648e0806c7bc1e8bc073c38217a28e1",
+  "publicKeys": [
+    {
+      "contractBounds": null,
+      "id": 0,
+      "type": "ECDSA_SECP256K1",
+      "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
+      "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "MASTER",
+      "readOnly": false,
+      "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
     },
-    "userFeeIncrease": 0,
-    "identityId": "awCc9STLEgw8pJozBq24QzGK5Th9mow7V3EjjY9M7aG",
-    "signature": "2015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f2141",
-    "raw": "0300010000020000000014b23f76cac0218f7637c924e45212bb260cff29250001fc001160b72021007051d2207c45d7592bb7e3e5b4b006a29cfe1899aea8abf00c50ee8a40860000412015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f214108b1737186062205ee3a5f7e19454121b648e0806c7bc1e8bc073c38217a28e1",
-    "publicKeys": [
-        {
-            "contractBounds": null,
-            "id": 0,
-            "type": "ECDSA_SECP256K1",
-            "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
-            "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "MASTER",
-            "readOnly": false,
-            "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
-        },
-        {
-            "contractBounds": null,
-            "id": 1,
-            "type": "ECDSA_SECP256K1",
-            "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
-            "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "HIGH",
-            "readOnly": false,
-            "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
-        },
-        {
-            "contractBounds": null,
-            "id": 2,
-            "type": "ECDSA_SECP256K1",
-            "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
-            "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "CRITICAL",
-            "readOnly": false,
-            "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
-        }
-    ]
+    {
+      "contractBounds": null,
+      "id": 1,
+      "type": "ECDSA_SECP256K1",
+      "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
+      "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "HIGH",
+      "readOnly": false,
+      "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
+    },
+    {
+      "contractBounds": null,
+      "id": 2,
+      "type": "ECDSA_SECP256K1",
+      "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
+      "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "CRITICAL",
+      "readOnly": false,
+      "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
+    }
+  ]
 }
 ```
 ```json lines
 IDENTITY_CREATE with instantLock
 
 {
-    "type": 2,
-    "typeString": "IDENTITY_CREATE",
-    "fundingAddress": "yV1ZYoep5FFSBxKWM24JUwKfnAkFHnXXV7",
-    "assetLockProof": {
-        "coreChainLockedHeight": null,
-        "type": "instantSend",
-        "fundingAmount": 34999000,
-        "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
-        "vout": 0,
-        "fundingAddress": "yeMdYXBPum8RmHvrq5SsYE9zNYhMEimbUY",
-        "instantLock": 'AQEKM9t1ICNzvddKryjM4enKn0Y5amBn3o6DwDoC4uk5SAAAAAAdraxrxe5CKYujiUmN9V1mgT5gQ3Bz2TzaGCW+TN2J/JQP49yOk0uJ6el6ls9CmNo++yPYoX1Sx1lWEZTTAAAAhXiuCBXgzawuboxMAXDiXQpJCCPi417VE4mdcYPgTa0/Hd+RCHLAR6H+MXhqKazlGddI7AdWxxLZ94ZvQu+qIpe7G9XRRjQWeYwroIyc6MqQF5mKpvV0AUMYUNMXjCsq'
+  "type": 2,
+  "typeString": "IDENTITY_CREATE",
+  "fundingAddress": "yV1ZYoep5FFSBxKWM24JUwKfnAkFHnXXV7",
+  "assetLockProof": {
+    "coreChainLockedHeight": null,
+    "type": "instantSend",
+    "fundingAmount": 34999000,
+    "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
+    "vout": 0,
+    "fundingAddress": "yeMdYXBPum8RmHvrq5SsYE9zNYhMEimbUY",
+    "instantLock": 'AQEKM9t1ICNzvddKryjM4enKn0Y5amBn3o6DwDoC4uk5SAAAAAAdraxrxe5CKYujiUmN9V1mgT5gQ3Bz2TzaGCW+TN2J/JQP49yOk0uJ6el6ls9CmNo++yPYoX1Sx1lWEZTTAAAAhXiuCBXgzawuboxMAXDiXQpJCCPi417VE4mdcYPgTa0/Hd+RCHLAR6H+MXhqKazlGddI7AdWxxLZ94ZvQu+qIpe7G9XRRjQWeYwroIyc6MqQF5mKpvV0AUMYUNMXjCsq'
+  },
+  "userFeeIncrease": 0,
+  "identityId": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
+  "signature": "1fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f",
+  "raw": "03000400000000000000210258abe04886308feb52b8f3d64eace4913c9d049f4dda9a88a217e6ca6b89a107411f60451588fe72a067daaa0a1ee04279e77ce346128560129162386f76d51eccdc1d88704f2262fe173de57e5598010655d410da94ae2e1cf7086049878b08e966000100000200002103e6680bb560e40adb299a6b940d3dcbe2b08e6e1a64bc8f6bc9ec3d638655c3554120066559ccd6cea8ac2d366980f77a94cbfdfbd978803edbf4066f42bc53adcdb51956fb0d3c9cec2012583d17b66456094a8620109d6dae29dc562b2870592940000200000100002102326a8c19a1c58d30d142e113d0ddf381d95a6306f56c9ec4d3cb8c4823685b29411f5bb82721b58d92e67db9fb699ab939ccc4a6d5e2e498e80dfb8a3535c13f571923f045e645a898762f8305a4a2218bfedb060f8a8492c48ae9c96247ce17710b00030003010000210252a2d08f295871ec4b04cb0bcf7b2899b0b004702d9058982dd797141d527e78412044820dc7651186634326922eda85741bb3f9f005057d94b36845a7edc16ed1df4d5ccabd7e7f003e9c189847fbc06e943252640bc47963c42ae6c0d87b7b506b00c601014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b10100000077ba9d450b94520434c5d15339922aa7df81b51344b98588649a44752f1a355cd0d05ce3df52f3fb7fc6e64cc414fb7cd9d0ffc4d088e77d9e542fade30000008a8678665212af134cfa36ea40984009adca338efa3131667f5a62b489d2fb2713eb7eccd14dd83cc6679b597548feae18bdc393dae2ab2a50844220359d4b87c428507808dc8df62f56dabb8d1eae2c1859b9ca54b3b4820ebc8453f57c34f6ef03000800014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b1010000006a473044022070293df3b93c523373f1f86272c5dba7886ab41cfc50b0b89658c07d0825c16002201afdf3b31393c5b99373597042b4d651028e824fc12f802aa1be51cc165bcf1e012103d55244573359ad586597b9bb4dd31b8f145121b7c01146656bc26c4b99184a47ffffffff0240420f0000000000026a0049ac4c2e000000001976a91441bb9b42b9f0d589008b4a7f6a72a6bb342b386d88ac0000000024010140420f00000000001976a9145f573cd6a8570cb0b74c4b0ea15334e6bd6b34a788ac0000411fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f98b95bbff1488807c3a4ed36c5fde32f9a6f1e05a622938476652041669e4135",
+  "publicKeys": [
+    {
+      "contractBounds": null,
+      "id": 0,
+      "type": "ECDSA_SECP256K1",
+      "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
+      "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "MASTER",
+      "readOnly": false,
+      "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
     },
-    "userFeeIncrease": 0,
-    "identityId": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
-    "signature": "1fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f",
-    "raw": "03000400000000000000210258abe04886308feb52b8f3d64eace4913c9d049f4dda9a88a217e6ca6b89a107411f60451588fe72a067daaa0a1ee04279e77ce346128560129162386f76d51eccdc1d88704f2262fe173de57e5598010655d410da94ae2e1cf7086049878b08e966000100000200002103e6680bb560e40adb299a6b940d3dcbe2b08e6e1a64bc8f6bc9ec3d638655c3554120066559ccd6cea8ac2d366980f77a94cbfdfbd978803edbf4066f42bc53adcdb51956fb0d3c9cec2012583d17b66456094a8620109d6dae29dc562b2870592940000200000100002102326a8c19a1c58d30d142e113d0ddf381d95a6306f56c9ec4d3cb8c4823685b29411f5bb82721b58d92e67db9fb699ab939ccc4a6d5e2e498e80dfb8a3535c13f571923f045e645a898762f8305a4a2218bfedb060f8a8492c48ae9c96247ce17710b00030003010000210252a2d08f295871ec4b04cb0bcf7b2899b0b004702d9058982dd797141d527e78412044820dc7651186634326922eda85741bb3f9f005057d94b36845a7edc16ed1df4d5ccabd7e7f003e9c189847fbc06e943252640bc47963c42ae6c0d87b7b506b00c601014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b10100000077ba9d450b94520434c5d15339922aa7df81b51344b98588649a44752f1a355cd0d05ce3df52f3fb7fc6e64cc414fb7cd9d0ffc4d088e77d9e542fade30000008a8678665212af134cfa36ea40984009adca338efa3131667f5a62b489d2fb2713eb7eccd14dd83cc6679b597548feae18bdc393dae2ab2a50844220359d4b87c428507808dc8df62f56dabb8d1eae2c1859b9ca54b3b4820ebc8453f57c34f6ef03000800014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b1010000006a473044022070293df3b93c523373f1f86272c5dba7886ab41cfc50b0b89658c07d0825c16002201afdf3b31393c5b99373597042b4d651028e824fc12f802aa1be51cc165bcf1e012103d55244573359ad586597b9bb4dd31b8f145121b7c01146656bc26c4b99184a47ffffffff0240420f0000000000026a0049ac4c2e000000001976a91441bb9b42b9f0d589008b4a7f6a72a6bb342b386d88ac0000000024010140420f00000000001976a9145f573cd6a8570cb0b74c4b0ea15334e6bd6b34a788ac0000411fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f98b95bbff1488807c3a4ed36c5fde32f9a6f1e05a622938476652041669e4135",
-    "publicKeys": [
-        {
-            "contractBounds": null,
-            "id": 0,
-            "type": "ECDSA_SECP256K1",
-            "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
-            "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "MASTER",
-            "readOnly": false,
-            "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
-        },
-        {
-            "contractBounds": null,
-            "id": 1,
-            "type": "ECDSA_SECP256K1",
-            "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
-            "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "HIGH",
-            "readOnly": false,
-            "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
-        },
-        {
-            "contractBounds": null,
-            "id": 2,
-            "type": "ECDSA_SECP256K1",
-            "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
-            "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
-            "purpose": "AUTHENTICATION",
-            "securityLevel": "CRITICAL",
-            "readOnly": false,
-            "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
-        }
-    ]
+    {
+      "contractBounds": null,
+      "id": 1,
+      "type": "ECDSA_SECP256K1",
+      "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
+      "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "HIGH",
+      "readOnly": false,
+      "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
+    },
+    {
+      "contractBounds": null,
+      "id": 2,
+      "type": "ECDSA_SECP256K1",
+      "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
+      "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "CRITICAL",
+      "readOnly": false,
+      "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
+    }
+  ]
 }
 ```
 ```json
 {
-    "type": 3,
-    "typeString": "IDENTITY_TOP_UP",
-    "assetLockProof": {
-        "coreChainLockedHeight": null,
-        "type": "instantSend",
-        "fundingAmount": 999000,
-        "txid": "7734f498c5b59f64f73070e0a5ec4fa113065da00358223cf888c3c27317ea64",
-        "vout": 0,
-        "fundingAddress": "yWxCwVRgqRmePNPJxezgus1T7xSv5q17SU"
-    },
-    "identityId": "4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF",
-    "amount": 300000000,
-    "signature": "810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710",
-    "raw": "040000c60101ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d5660000000064ea1773c2c388f83c225803a05d0613a14feca5e07030f7649fb5c598f43477940fe3dc8e934b89e9e97a96cf4298da3efb23d8a17d52c759561194d3000000a5e81597e94558618bf1464801188ecbc09c7a12e73489225c63684259f075f87aa3d47ea9bbbe1f9c314086ddc35a6d18b30ff4fe579855779f9268b8bf5c79760c7d8c56d34163931f016c2e3036852dd33a6b643dd59dc8c54199f34e3d2def0300080001ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d566000000006a4730440220339d4d894eb2ff9c193bd8c33cdb3030a8be18ddbf30d983e8286c08c6c4c7d90220181741d9eed3814ec077030c26c0b9fff63b9ef10e1e6ca1c87069b261b0127a0121034951bbd5d0d500942426507d4b84e6d88406300ed82009a8db087f493017786affffffff02e093040000000000026a0078aa0a00000000001976a914706db5d1e8fb5f925c6db64104f4b77f0c8b73d488ac00000000240101e0930400000000001976a91474a509b4f3b80ce818465dc0f9f66e2103d9178b88ac003012c19b98ec0033addb36cd64b7f510670f2a351a4304b5f6994144286efdac411f810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710"
+  "type": 3,
+  "typeString": "IDENTITY_TOP_UP",
+  "assetLockProof": {
+    "coreChainLockedHeight": null,
+    "type": "instantSend",
+    "fundingAmount": 999000,
+    "txid": "7734f498c5b59f64f73070e0a5ec4fa113065da00358223cf888c3c27317ea64",
+    "vout": 0,
+    "fundingAddress": "yWxCwVRgqRmePNPJxezgus1T7xSv5q17SU"
+  },
+  "identityId": "4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF",
+  "amount": 300000000,
+  "signature": "810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710",
+  "raw": "040000c60101ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d5660000000064ea1773c2c388f83c225803a05d0613a14feca5e07030f7649fb5c598f43477940fe3dc8e934b89e9e97a96cf4298da3efb23d8a17d52c759561194d3000000a5e81597e94558618bf1464801188ecbc09c7a12e73489225c63684259f075f87aa3d47ea9bbbe1f9c314086ddc35a6d18b30ff4fe579855779f9268b8bf5c79760c7d8c56d34163931f016c2e3036852dd33a6b643dd59dc8c54199f34e3d2def0300080001ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d566000000006a4730440220339d4d894eb2ff9c193bd8c33cdb3030a8be18ddbf30d983e8286c08c6c4c7d90220181741d9eed3814ec077030c26c0b9fff63b9ef10e1e6ca1c87069b261b0127a0121034951bbd5d0d500942426507d4b84e6d88406300ed82009a8db087f493017786affffffff02e093040000000000026a0078aa0a00000000001976a914706db5d1e8fb5f925c6db64104f4b77f0c8b73d488ac00000000240101e0930400000000001976a91474a509b4f3b80ce818465dc0f9f66e2103d9178b88ac003012c19b98ec0033addb36cd64b7f510670f2a351a4304b5f6994144286efdac411f810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710"
 }
 ```
 ```json
 {
-    "type": 4,
-    "typeString": "DATA_CONTRACT_UPDATE",
-    "internalConfig": {
-        "canBeDeleted": false,
-        "readonly": false,
-        "keepsHistory": false,
-        "documentsKeepHistoryContractDefault": false,
-        "documentsMutableContractDefault": true,
-        "documentsCanBeDeletedContractDefault": true,
-        "requiresIdentityDecryptionBoundedKey": null,
-        "requiresIdentityEncryptionBoundedKey": null
-    },
-    "tokens": [],
-    "groups": [],
-    "identityContractNonce": 6,
-    "signaturePublicKeyId": 2,
-    "signature": "1ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903",
-    "userFeeIncrease": 0,
-    "ownerId": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
-    "dataContractId": "AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18",
-    "dataContractIdentityNonce": "0",
-    "schema": {
-        "note": {
-            "type": "object",
-            "properties": {
-                "message": {
-                    "type": "string",
-                    "position": 0
-                },
-                "author": {
-                    "type": "string",
-                    "position": 1
-                }
-            },
-            "additionalProperties": false
+  "type": 4,
+  "typeString": "DATA_CONTRACT_UPDATE",
+  "internalConfig": {
+    "canBeDeleted": false,
+    "readonly": false,
+    "keepsHistory": false,
+    "documentsKeepHistoryContractDefault": false,
+    "documentsMutableContractDefault": true,
+    "documentsCanBeDeletedContractDefault": true,
+    "requiresIdentityDecryptionBoundedKey": null,
+    "requiresIdentityEncryptionBoundedKey": null
+  },
+  "tokens": [],
+  "groups": [],
+  "identityContractNonce": 6,
+  "signaturePublicKeyId": 2,
+  "signature": "1ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903",
+  "userFeeIncrease": 0,
+  "ownerId": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
+  "dataContractId": "AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18",
+  "dataContractIdentityNonce": "0",
+  "schema": {
+    "note": {
+      "type": "object",
+      "properties": {
+        "message": {
+          "type": "string",
+          "position": 0
+        },
+        "author": {
+          "type": "string",
+          "position": 1
         }
-    },
-    "version": 2,
-    "dataContractOwner": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
-    "raw": "010006008a4af217f340e9c4c95857496cf33b68eb6c712ac6d20a1eb7854d14afd9ffcf00000000000101000002e901dfc172a96ce3f7d334d6c0b69df3b01c86d30ff03a7c24f516838f94340d0001046e6f7465160312047479706512066f626a656374120a70726f70657274696573160212076d65737361676516021204747970651206737472696e671208706f736974696f6e02001206617574686f7216021204747970651206737472696e671208706f736974696f6e020112146164646974696f6e616c50726f7065727469657313000002411ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903"
+      },
+      "additionalProperties": false
+    }
+  },
+  "version": 2,
+  "dataContractOwner": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
+  "raw": "010006008a4af217f340e9c4c95857496cf33b68eb6c712ac6d20a1eb7854d14afd9ffcf00000000000101000002e901dfc172a96ce3f7d334d6c0b69df3b01c86d30ff03a7c24f516838f94340d0001046e6f7465160312047479706512066f626a656374120a70726f70657274696573160212076d65737361676516021204747970651206737472696e671208706f736974696f6e02001206617574686f7216021204747970651206737472696e671208706f736974696f6e020112146164646974696f6e616c50726f7065727469657313000002411ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903"
 }
 ```
 ```json
@@ -2829,28 +3005,28 @@ IDENTITY_CREATE with instantLock
   "identityId": "4NGALjtX2t3AXE3ZCqJiSmYuiWEY3ZPQNUBxNWWRrRSp",
   "revision": 2,
   "publicKeysToAdd": [
-      {
-          "contractBounds": null,
-          "id": 5,
-          "type": "ECDSA_HASH160",
-          "data": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
-          "publicKeyHash": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
-          "purpose": "AUTHENTICATION",
-          "securityLevel": "HIGH",
-          "readOnly": false,
-          "signature": ""
-      },
-      {
-          "contractBounds": null,
-          "id": 6,
-          "type": "ECDSA_SECP256K1",
-          "data": "026213380930c93c4b53f6ddbc5adc5f5165102d8f92f7d9a495a8f9c6e61b30f0",
-          "publicKeyHash": "d39eda042126256a372c388bd191532a7c9612ce",
-          "purpose": "AUTHENTICATION",
-          "securityLevel": "MASTER",
-          "readOnly": false,
-          "signature": "1faf8b0f16320d0f9e29c1db12ab0d3ec87974b19f6fc1189a988cd85503d79f844d3ff778678d7f4f3829891e8e8d0183456194d9fc76ed66e503154996eefe06"
-      }
+    {
+      "contractBounds": null,
+      "id": 5,
+      "type": "ECDSA_HASH160",
+      "data": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
+      "publicKeyHash": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "HIGH",
+      "readOnly": false,
+      "signature": ""
+    },
+    {
+      "contractBounds": null,
+      "id": 6,
+      "type": "ECDSA_SECP256K1",
+      "data": "026213380930c93c4b53f6ddbc5adc5f5165102d8f92f7d9a495a8f9c6e61b30f0",
+      "publicKeyHash": "d39eda042126256a372c388bd191532a7c9612ce",
+      "purpose": "AUTHENTICATION",
+      "securityLevel": "MASTER",
+      "readOnly": false,
+      "signature": "1faf8b0f16320d0f9e29c1db12ab0d3ec87974b19f6fc1189a988cd85503d79f844d3ff778678d7f4f3829891e8e8d0183456194d9fc76ed66e503154996eefe06"
+    }
   ],
   "publicKeyIdsToDisable": [],
   "signature": "1f341c8eb7b890f416c7a970406dd37da078dab5f2c4aa8dd18375516933b234873127965dd72ee28b7392fcd87e28c4bfef890791b58fa9c34bce9e96d6536cb1",
@@ -2860,54 +3036,54 @@ IDENTITY_CREATE with instantLock
 ```
 ```json
 {
-    "type": 6,
-    "typeString": "IDENTITY_CREDIT_WITHDRAWAL",
-    "outputAddress": "yifJkXaxe7oM1NgBDTaXnWa6kXZAazBfjk",
-    "userFeeIncrease": 0,
-    "senderId": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
-    "amount": 200000,
-    "identityNonce": 6,
-    "outputScript": "76a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac",
-    "coreFeePerByte": 5,
-    "signature": "20cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b",
-    "signaturePublicKeyId": 3,
-    "pooling": "Standard",
-    "raw": "05017199f1f68404c86ecf60d9cb93aef318fa0f2b08e59ffd176bdef43154ffde6bfc00030d400500011976a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac0600034120cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b"
+  "type": 6,
+  "typeString": "IDENTITY_CREDIT_WITHDRAWAL",
+  "outputAddress": "yifJkXaxe7oM1NgBDTaXnWa6kXZAazBfjk",
+  "userFeeIncrease": 0,
+  "senderId": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
+  "amount": 200000,
+  "identityNonce": 6,
+  "outputScript": "76a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac",
+  "coreFeePerByte": 5,
+  "signature": "20cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b",
+  "signaturePublicKeyId": 3,
+  "pooling": "Standard",
+  "raw": "05017199f1f68404c86ecf60d9cb93aef318fa0f2b08e59ffd176bdef43154ffde6bfc00030d400500011976a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac0600034120cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b"
 }
 ```
 ```json
 {
-    "type": 7,
-    "typeString": "IDENTITY_CREDIT_TRANSFER",
-    "identityNonce": 1,
-    "userFeeIncrease": 0,
-    "senderId": "24YEeZmpy1QNKronDT8enYWLXnfoxYK7hrHUdpWHxURg",
-    "recipientId": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
-    "amount": 21856638,
-    "signaturePublicKeyId": 3,
-    "signature": "1f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8",
-    "raw": "07000fc3bf4a26bff60f4f79a1f4b929ce4d4c5833d226c1c7f68758e71d7ae229db569fd4f616b3dedecbeef95352cf38f1fb04d232a0d20623bc195b0c3f721840fc014d817e010003411f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8"
+  "type": 7,
+  "typeString": "IDENTITY_CREDIT_TRANSFER",
+  "identityNonce": 1,
+  "userFeeIncrease": 0,
+  "senderId": "24YEeZmpy1QNKronDT8enYWLXnfoxYK7hrHUdpWHxURg",
+  "recipientId": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
+  "amount": 21856638,
+  "signaturePublicKeyId": 3,
+  "signature": "1f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8",
+  "raw": "07000fc3bf4a26bff60f4f79a1f4b929ce4d4c5833d226c1c7f68758e71d7ae229db569fd4f616b3dedecbeef95352cf38f1fb04d232a0d20623bc195b0c3f721840fc014d817e010003411f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8"
 }
 ```
 ```json
 {
-    "type": 8,
-    "typeString": "IDENTITY_CREDIT_TRANSFER",
-    "indexValues": [
-        "EgRkYXNo",
-        "EgN5MDE="
-    ],
-    "contractId": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
-    "modifiedDataIds": [
-        "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse"
-    ],
-    "ownerId": "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse",
-    "signature": "2019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d",
-    "documentTypeName": "domain",
-    "indexName": "parentNameAndLabel",
-    "choice": "Abstain",
-    "proTxHash": "ad4e38fc81da72d61b14238ee6e5b91915554e24d725718800692d3a863c910b",
-    "raw": "08005b246080ba64350685fe302d3d790f5bb238cb619920d46230c844f079944a233bb2df460e72e3d59e7fe1c082ab3a5bd9445dd0dd5c4894a6d9f0d9ed9404b5000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c021204646173681203793031010c00412019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d"
+  "type": 8,
+  "typeString": "IDENTITY_CREDIT_TRANSFER",
+  "indexValues": [
+    "EgRkYXNo",
+    "EgN5MDE="
+  ],
+  "contractId": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+  "modifiedDataIds": [
+    "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse"
+  ],
+  "ownerId": "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse",
+  "signature": "2019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d",
+  "documentTypeName": "domain",
+  "indexName": "parentNameAndLabel",
+  "choice": "Abstain",
+  "proTxHash": "ad4e38fc81da72d61b14238ee6e5b91915554e24d725718800692d3a863c910b",
+  "raw": "08005b246080ba64350685fe302d3d790f5bb238cb619920d46230c844f079944a233bb2df460e72e3d59e7fe1c082ab3a5bd9445dd0dd5c4894a6d9f0d9ed9404b5000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c021204646173681203793031010c00412019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d"
 }
 ```
 ```json
@@ -2960,72 +3136,72 @@ IDENTITY_CREATE with instantLock
 ```
 ```json
 {
-    "type": 13,
-    "typeString": "ADDRESS_FUNDING_FROM_ASSET_LOCK",
-    "assetLockProof": {
-        "coreChainLockedHeight": null,
-        "type": "instantSend",
-        "instantLock": "AQKflfCMay9YZSHo7Yy2u5l0vwE0obDfr8cqfShF9bqn/gEAAAD2vDZ5zvy1mcNCSF5jfsxQkw0veXBo6aJNE/13WYR7awEAAACJfGgEXp9GdjneIf96kXXJEn+b/Qix6fYXJ1hgqBQzH/y3yJZU0Ky99rsWgfhfdvFC4UBFsddngtq6TJgBAAAAix7+tMc2flwUVAB1uquM+dk5TF/nhmAnX9PmNHbUnIUTFWvpfXw7lnqpLERjGgKeF5ITbSsXcFU2TiKYWg7esh/DYYYrbdXBbJ6OoiLVQjjI60Em+1NK4nPycG9g6xOX",
-        "fundingAmount": "100000000",
-        "fundingCoreTx": "1f3314a860582717f6e9b108fd9b7f12c975917aff21de3976469f5e04687c89",
-        "vout": 0
-    },
-    "userFeeIncrease": 0,
-    "inputs": [],
-    "inputWitness": [],
-    "outputs": [
-        {
-            "platformAddress": {
-              "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
-              "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
-            },
-            "credits": "0"
-        }
-    ],
-    "feeStrategy": [
-        {
-            "type": "ReduceOutput",
-            "value": 0
-        }
-    ],
-    "signature": "202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f4064",
-    "raw": "0d0000ea01029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe01000000f6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b01000000897c68045e9f467639de21ff7a9175c9127f9bfd08b1e9f617275860a814331ffcb7c89654d0acbdf6bb1681f85f76f142e14045b1d76782daba4c98010000008b1efeb4c7367e5c14540075baab8cf9d9394c5fe78660275fd3e63476d49c8513156be97d7c3b967aa92c44631a029e1792136d2b177055364e22985a0edeb21fc361862b6dd5c16c9e8ea222d54238c8eb4126fb534ae273f2706f60eb1397fb018303000800029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe010000006b483045022100bbfbd824846523f7d2c6799b47a9dea88c0fb60dd433d0d8971abee63dd4966b022008dcee6d9780aa962d37cfed6ca54e256f6dba1190c01c7a58cc749709179f450121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aefffffffff6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b010000006a473044022074bd9c8c4ca4557cdf57017627b6b666c7586b674503f3f26ae8f1fed714d2510220295ea1d64c5745988e94c963972059d20171d0e0f92b07c31469bb622a468f3c0121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aeffffffff0200e1f50500000000026a00a008510b000000001976a914f84b203ee59814a41f1aa2379043ab3af98143f188ac0000000024010100e1f505000000001976a91469dccf851a2cb6c2f18ee1274e4fd1669af7685a88ac000001005022deda5da7414a3aa460705a5bb16b1282c97a000101000041202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f406400"
+  "type": 13,
+  "typeString": "ADDRESS_FUNDING_FROM_ASSET_LOCK",
+  "assetLockProof": {
+    "coreChainLockedHeight": null,
+    "type": "instantSend",
+    "instantLock": "AQKflfCMay9YZSHo7Yy2u5l0vwE0obDfr8cqfShF9bqn/gEAAAD2vDZ5zvy1mcNCSF5jfsxQkw0veXBo6aJNE/13WYR7awEAAACJfGgEXp9GdjneIf96kXXJEn+b/Qix6fYXJ1hgqBQzH/y3yJZU0Ky99rsWgfhfdvFC4UBFsddngtq6TJgBAAAAix7+tMc2flwUVAB1uquM+dk5TF/nhmAnX9PmNHbUnIUTFWvpfXw7lnqpLERjGgKeF5ITbSsXcFU2TiKYWg7esh/DYYYrbdXBbJ6OoiLVQjjI60Em+1NK4nPycG9g6xOX",
+    "fundingAmount": "100000000",
+    "fundingCoreTx": "1f3314a860582717f6e9b108fd9b7f12c975917aff21de3976469f5e04687c89",
+    "vout": 0
+  },
+  "userFeeIncrease": 0,
+  "inputs": [],
+  "inputWitness": [],
+  "outputs": [
+    {
+      "platformAddress": {
+        "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
+        "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
+      },
+      "credits": "0"
+    }
+  ],
+  "feeStrategy": [
+    {
+      "type": "ReduceOutput",
+      "value": 0
+    }
+  ],
+  "signature": "202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f4064",
+  "raw": "0d0000ea01029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe01000000f6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b01000000897c68045e9f467639de21ff7a9175c9127f9bfd08b1e9f617275860a814331ffcb7c89654d0acbdf6bb1681f85f76f142e14045b1d76782daba4c98010000008b1efeb4c7367e5c14540075baab8cf9d9394c5fe78660275fd3e63476d49c8513156be97d7c3b967aa92c44631a029e1792136d2b177055364e22985a0edeb21fc361862b6dd5c16c9e8ea222d54238c8eb4126fb534ae273f2706f60eb1397fb018303000800029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe010000006b483045022100bbfbd824846523f7d2c6799b47a9dea88c0fb60dd433d0d8971abee63dd4966b022008dcee6d9780aa962d37cfed6ca54e256f6dba1190c01c7a58cc749709179f450121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aefffffffff6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b010000006a473044022074bd9c8c4ca4557cdf57017627b6b666c7586b674503f3f26ae8f1fed714d2510220295ea1d64c5745988e94c963972059d20171d0e0f92b07c31469bb622a468f3c0121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aeffffffff0200e1f50500000000026a00a008510b000000001976a914f84b203ee59814a41f1aa2379043ab3af98143f188ac0000000024010100e1f505000000001976a91469dccf851a2cb6c2f18ee1274e4fd1669af7685a88ac000001005022deda5da7414a3aa460705a5bb16b1282c97a000101000041202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f406400"
 }
 ```
 ```json
 {
-    "type": 14,
-    "typeString": "ADDRESS_CREDIT_WITHDRAWAL",
-    "userFeeIncrease": 0,
-    "inputs": [
-        {
-            "platformAddress": {
-              "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
-              "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
-            },
-            "credits": "250000000000",
-            "nonce": "5"
-        }
-    ],
-    "inputWitness": [
-        {
-            "type": "P2PKH",
-            "value": {
-                "signature": "2097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
-            }
-        }
-    ],
-    "output": null,
-    "feeStrategy": [
-        {
-            "type": "DeductFromInput",
-            "value": 0
-        }
-    ],
-    "pooling": 0,
-    "outputAddress": "yT6NQzvH2h16ggSKNj2b2Wu3NMFiYVKXeB",
-    "outputScript": "76a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac",
-    "raw": "0e000100914e8a18eb34517b7a6a4432cf237f68c5f8332e05fd0000003a352944000001000001001976a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac000100412097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
+  "type": 14,
+  "typeString": "ADDRESS_CREDIT_WITHDRAWAL",
+  "userFeeIncrease": 0,
+  "inputs": [
+    {
+      "platformAddress": {
+        "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
+        "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
+      },
+      "credits": "250000000000",
+      "nonce": "5"
+    }
+  ],
+  "inputWitness": [
+    {
+      "type": "P2PKH",
+      "value": {
+        "signature": "2097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
+      }
+    }
+  ],
+  "output": null,
+  "feeStrategy": [
+    {
+      "type": "DeductFromInput",
+      "value": 0
+    }
+  ],
+  "pooling": 0,
+  "outputAddress": "yT6NQzvH2h16ggSKNj2b2Wu3NMFiYVKXeB",
+  "outputScript": "76a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac",
+  "raw": "0e000100914e8a18eb34517b7a6a4432cf237f68c5f8332e05fd0000003a352944000001000001001976a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac000100412097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
 }
 ```
 Response codes:

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -2230,6 +2230,7 @@ Return an aggregate overview of the shielded pool.
 * `totalShieldedOut` — total credits moved out of the pool (`UNSHIELD` + `SHIELDED_WITHDRAWAL` + `IDENTITY_CREATE_FROM_SHIELDED_POOL`), as a string
 * `poolBalance` — `totalShieldedIn` − `totalShieldedOut`, an estimate of the current shielded pool size, as a string
 * `transitionsCount` — total number of shielded transitions
+* `notesCount` — total count of notes (leaves) in the shielded notes commitment tree, fetched from the platform; `null` when unavailable
 * `types` — per-type breakdown with `count` and summed `amount` (string)
 
 Note: `SHIELDED_TRANSFER` stays inside the pool and is counted in `types`/`transitionsCount` but excluded from `totalShieldedIn`/`totalShieldedOut`.
@@ -2241,6 +2242,7 @@ GET /transactions/shielded/statistic
     "totalShieldedOut": "150000000",
     "poolBalance": "150000000",
     "transitionsCount": 6,
+    "notesCount": 14,
     "types": [
         {
             "transactionType": "SHIELD",
@@ -2794,7 +2796,7 @@ DOCUMENT TRANSITION
 }
 ```
 ```json lines
-TOKEN TRANSITION
+TOKEN TRANSITION 
 
 {
   "type": 1,
@@ -2824,176 +2826,176 @@ TOKEN TRANSITION
 IDENTITY_CREATE with chainLock
 
 {
-  "type": 2,
-  "typeString": "IDENTITY_CREATE",
-  "fundingAddress": null,
-  "assetLockProof": {
-    "coreChainLockedHeight": 1138871,
-    "type": "chainLock",
-    "fundingAmount": null,
-    "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
-    "vout": 0,
+    "type": 2,
+    "typeString": "IDENTITY_CREATE",
     "fundingAddress": null,
-    "instantLock": null
-  },
-  "userFeeIncrease": 0,
-  "identityId": "awCc9STLEgw8pJozBq24QzGK5Th9mow7V3EjjY9M7aG",
-  "signature": "2015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f2141",
-  "raw": "0300010000020000000014b23f76cac0218f7637c924e45212bb260cff29250001fc001160b72021007051d2207c45d7592bb7e3e5b4b006a29cfe1899aea8abf00c50ee8a40860000412015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f214108b1737186062205ee3a5f7e19454121b648e0806c7bc1e8bc073c38217a28e1",
-  "publicKeys": [
-    {
-      "contractBounds": null,
-      "id": 0,
-      "type": "ECDSA_SECP256K1",
-      "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
-      "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
-      "purpose": "AUTHENTICATION",
-      "securityLevel": "MASTER",
-      "readOnly": false,
-      "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
+    "assetLockProof": {
+      "coreChainLockedHeight": 1138871,
+      "type": "chainLock",
+      "fundingAmount": null,
+      "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
+      "vout": 0,
+      "fundingAddress": null,
+      "instantLock": null
     },
-    {
-      "contractBounds": null,
-      "id": 1,
-      "type": "ECDSA_SECP256K1",
-      "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
-      "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
-      "purpose": "AUTHENTICATION",
-      "securityLevel": "HIGH",
-      "readOnly": false,
-      "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
-    },
-    {
-      "contractBounds": null,
-      "id": 2,
-      "type": "ECDSA_SECP256K1",
-      "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
-      "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
-      "purpose": "AUTHENTICATION",
-      "securityLevel": "CRITICAL",
-      "readOnly": false,
-      "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
-    }
-  ]
+    "userFeeIncrease": 0,
+    "identityId": "awCc9STLEgw8pJozBq24QzGK5Th9mow7V3EjjY9M7aG",
+    "signature": "2015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f2141",
+    "raw": "0300010000020000000014b23f76cac0218f7637c924e45212bb260cff29250001fc001160b72021007051d2207c45d7592bb7e3e5b4b006a29cfe1899aea8abf00c50ee8a40860000412015bf50b422df6ccfdc4bcdcae76a11106c8f6c627a284f37d2591184e413249350a722926c8899b5514fd94603598031358bc2a0ac031fb402ecc5b8025f214108b1737186062205ee3a5f7e19454121b648e0806c7bc1e8bc073c38217a28e1",
+    "publicKeys": [
+        {
+            "contractBounds": null,
+            "id": 0,
+            "type": "ECDSA_SECP256K1",
+            "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
+            "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
+            "purpose": "AUTHENTICATION",
+            "securityLevel": "MASTER",
+            "readOnly": false,
+            "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
+        },
+        {
+            "contractBounds": null,
+            "id": 1,
+            "type": "ECDSA_SECP256K1",
+            "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
+            "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
+            "purpose": "AUTHENTICATION",
+            "securityLevel": "HIGH",
+            "readOnly": false,
+            "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
+        },
+        {
+            "contractBounds": null,
+            "id": 2,
+            "type": "ECDSA_SECP256K1",
+            "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
+            "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
+            "purpose": "AUTHENTICATION",
+            "securityLevel": "CRITICAL",
+            "readOnly": false,
+            "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
+        }
+    ]
 }
 ```
 ```json lines
 IDENTITY_CREATE with instantLock
 
 {
-  "type": 2,
-  "typeString": "IDENTITY_CREATE",
-  "fundingAddress": "yV1ZYoep5FFSBxKWM24JUwKfnAkFHnXXV7",
-  "assetLockProof": {
-    "coreChainLockedHeight": null,
-    "type": "instantSend",
-    "fundingAmount": 34999000,
-    "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
-    "vout": 0,
-    "fundingAddress": "yeMdYXBPum8RmHvrq5SsYE9zNYhMEimbUY",
-    "instantLock": 'AQEKM9t1ICNzvddKryjM4enKn0Y5amBn3o6DwDoC4uk5SAAAAAAdraxrxe5CKYujiUmN9V1mgT5gQ3Bz2TzaGCW+TN2J/JQP49yOk0uJ6el6ls9CmNo++yPYoX1Sx1lWEZTTAAAAhXiuCBXgzawuboxMAXDiXQpJCCPi417VE4mdcYPgTa0/Hd+RCHLAR6H+MXhqKazlGddI7AdWxxLZ94ZvQu+qIpe7G9XRRjQWeYwroIyc6MqQF5mKpvV0AUMYUNMXjCsq'
-  },
-  "userFeeIncrease": 0,
-  "identityId": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
-  "signature": "1fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f",
-  "raw": "03000400000000000000210258abe04886308feb52b8f3d64eace4913c9d049f4dda9a88a217e6ca6b89a107411f60451588fe72a067daaa0a1ee04279e77ce346128560129162386f76d51eccdc1d88704f2262fe173de57e5598010655d410da94ae2e1cf7086049878b08e966000100000200002103e6680bb560e40adb299a6b940d3dcbe2b08e6e1a64bc8f6bc9ec3d638655c3554120066559ccd6cea8ac2d366980f77a94cbfdfbd978803edbf4066f42bc53adcdb51956fb0d3c9cec2012583d17b66456094a8620109d6dae29dc562b2870592940000200000100002102326a8c19a1c58d30d142e113d0ddf381d95a6306f56c9ec4d3cb8c4823685b29411f5bb82721b58d92e67db9fb699ab939ccc4a6d5e2e498e80dfb8a3535c13f571923f045e645a898762f8305a4a2218bfedb060f8a8492c48ae9c96247ce17710b00030003010000210252a2d08f295871ec4b04cb0bcf7b2899b0b004702d9058982dd797141d527e78412044820dc7651186634326922eda85741bb3f9f005057d94b36845a7edc16ed1df4d5ccabd7e7f003e9c189847fbc06e943252640bc47963c42ae6c0d87b7b506b00c601014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b10100000077ba9d450b94520434c5d15339922aa7df81b51344b98588649a44752f1a355cd0d05ce3df52f3fb7fc6e64cc414fb7cd9d0ffc4d088e77d9e542fade30000008a8678665212af134cfa36ea40984009adca338efa3131667f5a62b489d2fb2713eb7eccd14dd83cc6679b597548feae18bdc393dae2ab2a50844220359d4b87c428507808dc8df62f56dabb8d1eae2c1859b9ca54b3b4820ebc8453f57c34f6ef03000800014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b1010000006a473044022070293df3b93c523373f1f86272c5dba7886ab41cfc50b0b89658c07d0825c16002201afdf3b31393c5b99373597042b4d651028e824fc12f802aa1be51cc165bcf1e012103d55244573359ad586597b9bb4dd31b8f145121b7c01146656bc26c4b99184a47ffffffff0240420f0000000000026a0049ac4c2e000000001976a91441bb9b42b9f0d589008b4a7f6a72a6bb342b386d88ac0000000024010140420f00000000001976a9145f573cd6a8570cb0b74c4b0ea15334e6bd6b34a788ac0000411fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f98b95bbff1488807c3a4ed36c5fde32f9a6f1e05a622938476652041669e4135",
-  "publicKeys": [
-    {
-      "contractBounds": null,
-      "id": 0,
-      "type": "ECDSA_SECP256K1",
-      "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
-      "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
-      "purpose": "AUTHENTICATION",
-      "securityLevel": "MASTER",
-      "readOnly": false,
-      "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
+    "type": 2,
+    "typeString": "IDENTITY_CREATE",
+    "fundingAddress": "yV1ZYoep5FFSBxKWM24JUwKfnAkFHnXXV7",
+    "assetLockProof": {
+        "coreChainLockedHeight": null,
+        "type": "instantSend",
+        "fundingAmount": 34999000,
+        "txid": "fc89dd4cbe2518da3cd9737043603e81665df58d4989a38b2942eec56bacad1d",
+        "vout": 0,
+        "fundingAddress": "yeMdYXBPum8RmHvrq5SsYE9zNYhMEimbUY",
+        "instantLock": 'AQEKM9t1ICNzvddKryjM4enKn0Y5amBn3o6DwDoC4uk5SAAAAAAdraxrxe5CKYujiUmN9V1mgT5gQ3Bz2TzaGCW+TN2J/JQP49yOk0uJ6el6ls9CmNo++yPYoX1Sx1lWEZTTAAAAhXiuCBXgzawuboxMAXDiXQpJCCPi417VE4mdcYPgTa0/Hd+RCHLAR6H+MXhqKazlGddI7AdWxxLZ94ZvQu+qIpe7G9XRRjQWeYwroIyc6MqQF5mKpvV0AUMYUNMXjCsq'
     },
-    {
-      "contractBounds": null,
-      "id": 1,
-      "type": "ECDSA_SECP256K1",
-      "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
-      "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
-      "purpose": "AUTHENTICATION",
-      "securityLevel": "HIGH",
-      "readOnly": false,
-      "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
-    },
-    {
-      "contractBounds": null,
-      "id": 2,
-      "type": "ECDSA_SECP256K1",
-      "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
-      "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
-      "purpose": "AUTHENTICATION",
-      "securityLevel": "CRITICAL",
-      "readOnly": false,
-      "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
-    }
-  ]
-}
-```
-```json
-{
-  "type": 3,
-  "typeString": "IDENTITY_TOP_UP",
-  "assetLockProof": {
-    "coreChainLockedHeight": null,
-    "type": "instantSend",
-    "fundingAmount": 999000,
-    "txid": "7734f498c5b59f64f73070e0a5ec4fa113065da00358223cf888c3c27317ea64",
-    "vout": 0,
-    "fundingAddress": "yWxCwVRgqRmePNPJxezgus1T7xSv5q17SU"
-  },
-  "identityId": "4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF",
-  "amount": 300000000,
-  "signature": "810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710",
-  "raw": "040000c60101ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d5660000000064ea1773c2c388f83c225803a05d0613a14feca5e07030f7649fb5c598f43477940fe3dc8e934b89e9e97a96cf4298da3efb23d8a17d52c759561194d3000000a5e81597e94558618bf1464801188ecbc09c7a12e73489225c63684259f075f87aa3d47ea9bbbe1f9c314086ddc35a6d18b30ff4fe579855779f9268b8bf5c79760c7d8c56d34163931f016c2e3036852dd33a6b643dd59dc8c54199f34e3d2def0300080001ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d566000000006a4730440220339d4d894eb2ff9c193bd8c33cdb3030a8be18ddbf30d983e8286c08c6c4c7d90220181741d9eed3814ec077030c26c0b9fff63b9ef10e1e6ca1c87069b261b0127a0121034951bbd5d0d500942426507d4b84e6d88406300ed82009a8db087f493017786affffffff02e093040000000000026a0078aa0a00000000001976a914706db5d1e8fb5f925c6db64104f4b77f0c8b73d488ac00000000240101e0930400000000001976a91474a509b4f3b80ce818465dc0f9f66e2103d9178b88ac003012c19b98ec0033addb36cd64b7f510670f2a351a4304b5f6994144286efdac411f810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710"
-}
-```
-```json
-{
-  "type": 4,
-  "typeString": "DATA_CONTRACT_UPDATE",
-  "internalConfig": {
-    "canBeDeleted": false,
-    "readonly": false,
-    "keepsHistory": false,
-    "documentsKeepHistoryContractDefault": false,
-    "documentsMutableContractDefault": true,
-    "documentsCanBeDeletedContractDefault": true,
-    "requiresIdentityDecryptionBoundedKey": null,
-    "requiresIdentityEncryptionBoundedKey": null
-  },
-  "tokens": [],
-  "groups": [],
-  "identityContractNonce": 6,
-  "signaturePublicKeyId": 2,
-  "signature": "1ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903",
-  "userFeeIncrease": 0,
-  "ownerId": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
-  "dataContractId": "AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18",
-  "dataContractIdentityNonce": "0",
-  "schema": {
-    "note": {
-      "type": "object",
-      "properties": {
-        "message": {
-          "type": "string",
-          "position": 0
+    "userFeeIncrease": 0,
+    "identityId": "BHAuKDRVPHkJd99pLoQh8dfjUFobwk5bq6enubEBKpsv",
+    "signature": "1fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f",
+    "raw": "03000400000000000000210258abe04886308feb52b8f3d64eace4913c9d049f4dda9a88a217e6ca6b89a107411f60451588fe72a067daaa0a1ee04279e77ce346128560129162386f76d51eccdc1d88704f2262fe173de57e5598010655d410da94ae2e1cf7086049878b08e966000100000200002103e6680bb560e40adb299a6b940d3dcbe2b08e6e1a64bc8f6bc9ec3d638655c3554120066559ccd6cea8ac2d366980f77a94cbfdfbd978803edbf4066f42bc53adcdb51956fb0d3c9cec2012583d17b66456094a8620109d6dae29dc562b2870592940000200000100002102326a8c19a1c58d30d142e113d0ddf381d95a6306f56c9ec4d3cb8c4823685b29411f5bb82721b58d92e67db9fb699ab939ccc4a6d5e2e498e80dfb8a3535c13f571923f045e645a898762f8305a4a2218bfedb060f8a8492c48ae9c96247ce17710b00030003010000210252a2d08f295871ec4b04cb0bcf7b2899b0b004702d9058982dd797141d527e78412044820dc7651186634326922eda85741bb3f9f005057d94b36845a7edc16ed1df4d5ccabd7e7f003e9c189847fbc06e943252640bc47963c42ae6c0d87b7b506b00c601014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b10100000077ba9d450b94520434c5d15339922aa7df81b51344b98588649a44752f1a355cd0d05ce3df52f3fb7fc6e64cc414fb7cd9d0ffc4d088e77d9e542fade30000008a8678665212af134cfa36ea40984009adca338efa3131667f5a62b489d2fb2713eb7eccd14dd83cc6679b597548feae18bdc393dae2ab2a50844220359d4b87c428507808dc8df62f56dabb8d1eae2c1859b9ca54b3b4820ebc8453f57c34f6ef03000800014fae5c4ed0e736dd25610b65ff51b56cbe1b9467520f0ced40a9e3b58e4555b1010000006a473044022070293df3b93c523373f1f86272c5dba7886ab41cfc50b0b89658c07d0825c16002201afdf3b31393c5b99373597042b4d651028e824fc12f802aa1be51cc165bcf1e012103d55244573359ad586597b9bb4dd31b8f145121b7c01146656bc26c4b99184a47ffffffff0240420f0000000000026a0049ac4c2e000000001976a91441bb9b42b9f0d589008b4a7f6a72a6bb342b386d88ac0000000024010140420f00000000001976a9145f573cd6a8570cb0b74c4b0ea15334e6bd6b34a788ac0000411fc5b49ce2feb6cfc94f31de8167b806af0265657d5b8f01584e0db3ca011dba24328998bf40a50dd06b6ab10ed47622f46c07dec4d7cad3625b41aa52c9e11c2f98b95bbff1488807c3a4ed36c5fde32f9a6f1e05a622938476652041669e4135",
+    "publicKeys": [
+        {
+            "contractBounds": null,
+            "id": 0,
+            "type": "ECDSA_SECP256K1",
+            "data": "0348a6a633850f3c83a0cb30a9fceebbaa3b9ab3f923f123d92728cef234176dc5",
+            "publicKeyHash": "07630dddc55729c043de7bdeb145ee0d44feae3b",
+            "purpose": "AUTHENTICATION",
+            "securityLevel": "MASTER",
+            "readOnly": false,
+            "signature": "2042186a3dec52bfe9a24ee17b98adc5efcbc0a0a6bacbc9627f1405ea5e1bb7ae2bb94a270363400969669e9884ab9967659e9a0d8de7464ee7c47552c8cb0e99"
         },
-        "author": {
-          "type": "string",
-          "position": 1
+        {
+            "contractBounds": null,
+            "id": 1,
+            "type": "ECDSA_SECP256K1",
+            "data": "034278b0d7f5e6d902ec5a30ae5c656937a0323bdc813e851eb8a2d6a1d23c51cf",
+            "publicKeyHash": "e2615c5ef3f910ebe5ada7930e7b2c04a7ffbb23",
+            "purpose": "AUTHENTICATION",
+            "securityLevel": "HIGH",
+            "readOnly": false,
+            "signature": "1fbb0d0bb63d26c0d5b6e1f4b8c0eebef4d256c4e8aa933a2cb6bd6b2d8aae545215312924c7dd41c963071e2ccfe2187a8684d93c55063cb45fdd03e76344d6a4"
+        },
+        {
+            "contractBounds": null,
+            "id": 2,
+            "type": "ECDSA_SECP256K1",
+            "data": "0245c3b0f0323ddbb9ddf123f939bf37296af4f38fa489aad722c50486575cd8f4",
+            "publicKeyHash": "d53ee3b3518fee80816ab26af98a34ea60ae9af7",
+            "purpose": "AUTHENTICATION",
+            "securityLevel": "CRITICAL",
+            "readOnly": false,
+            "signature": "204013dcca13378b820e40cf1da77abe38662546ef0a304545de3c35845b83a7ad4b42051c2b3539c9181b3f0cb3fb4bc970db89663c6bd6ca1468568a62beaa75"
         }
-      },
-      "additionalProperties": false
-    }
-  },
-  "version": 2,
-  "dataContractOwner": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
-  "raw": "010006008a4af217f340e9c4c95857496cf33b68eb6c712ac6d20a1eb7854d14afd9ffcf00000000000101000002e901dfc172a96ce3f7d334d6c0b69df3b01c86d30ff03a7c24f516838f94340d0001046e6f7465160312047479706512066f626a656374120a70726f70657274696573160212076d65737361676516021204747970651206737472696e671208706f736974696f6e02001206617574686f7216021204747970651206737472696e671208706f736974696f6e020112146164646974696f6e616c50726f7065727469657313000002411ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903"
+    ]
+}
+```
+```json
+{
+    "type": 3,
+    "typeString": "IDENTITY_TOP_UP",
+    "assetLockProof": {
+        "coreChainLockedHeight": null,
+        "type": "instantSend",
+        "fundingAmount": 999000,
+        "txid": "7734f498c5b59f64f73070e0a5ec4fa113065da00358223cf888c3c27317ea64",
+        "vout": 0,
+        "fundingAddress": "yWxCwVRgqRmePNPJxezgus1T7xSv5q17SU"
+    },
+    "identityId": "4EfA9Jrvv3nnCFdSf7fad59851iiTRZ6Wcu6YVJ4iSeF",
+    "amount": 300000000,
+    "signature": "810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710",
+    "raw": "040000c60101ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d5660000000064ea1773c2c388f83c225803a05d0613a14feca5e07030f7649fb5c598f43477940fe3dc8e934b89e9e97a96cf4298da3efb23d8a17d52c759561194d3000000a5e81597e94558618bf1464801188ecbc09c7a12e73489225c63684259f075f87aa3d47ea9bbbe1f9c314086ddc35a6d18b30ff4fe579855779f9268b8bf5c79760c7d8c56d34163931f016c2e3036852dd33a6b643dd59dc8c54199f34e3d2def0300080001ecd6b031477f342806df5740b70f93b8a3e925bbf2d90d979a5ed162a8d7d566000000006a4730440220339d4d894eb2ff9c193bd8c33cdb3030a8be18ddbf30d983e8286c08c6c4c7d90220181741d9eed3814ec077030c26c0b9fff63b9ef10e1e6ca1c87069b261b0127a0121034951bbd5d0d500942426507d4b84e6d88406300ed82009a8db087f493017786affffffff02e093040000000000026a0078aa0a00000000001976a914706db5d1e8fb5f925c6db64104f4b77f0c8b73d488ac00000000240101e0930400000000001976a91474a509b4f3b80ce818465dc0f9f66e2103d9178b88ac003012c19b98ec0033addb36cd64b7f510670f2a351a4304b5f6994144286efdac411f810cd0bfe02104362941d35bd05fdf82cdc50c3bc8510077bfa62d47b68710"
+}
+```
+```json
+{
+    "type": 4,
+    "typeString": "DATA_CONTRACT_UPDATE",
+    "internalConfig": {
+        "canBeDeleted": false,
+        "readonly": false,
+        "keepsHistory": false,
+        "documentsKeepHistoryContractDefault": false,
+        "documentsMutableContractDefault": true,
+        "documentsCanBeDeletedContractDefault": true,
+        "requiresIdentityDecryptionBoundedKey": null,
+        "requiresIdentityEncryptionBoundedKey": null
+    },
+    "tokens": [],
+    "groups": [],
+    "identityContractNonce": 6,
+    "signaturePublicKeyId": 2,
+    "signature": "1ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903",
+    "userFeeIncrease": 0,
+    "ownerId": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
+    "dataContractId": "AJqYb8ZvfbA6ZFgpsvLfpMEzwjaYUPyVmeFxSJrafB18",
+    "dataContractIdentityNonce": "0",
+    "schema": {
+        "note": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string",
+                    "position": 0
+                },
+                "author": {
+                    "type": "string",
+                    "position": 1
+                }
+            },
+            "additionalProperties": false
+        }
+    },
+    "version": 2,
+    "dataContractOwner": "GgZekwh38XcWQTyWWWvmw6CEYFnLU7yiZFPWZEjqKHit",
+    "raw": "010006008a4af217f340e9c4c95857496cf33b68eb6c712ac6d20a1eb7854d14afd9ffcf00000000000101000002e901dfc172a96ce3f7d334d6c0b69df3b01c86d30ff03a7c24f516838f94340d0001046e6f7465160312047479706512066f626a656374120a70726f70657274696573160212076d65737361676516021204747970651206737472696e671208706f736974696f6e02001206617574686f7216021204747970651206737472696e671208706f736974696f6e020112146164646974696f6e616c50726f7065727469657313000002411ff9a776c62ee371a0e5ed95e8efe27c7955f247d5527670e43cbd837e73cfaef3613592b9798e9afd2526e3b92330f07d0c5f1396390d63ad39b4bebeb9c82903"
 }
 ```
 ```json
@@ -3005,28 +3007,28 @@ IDENTITY_CREATE with instantLock
   "identityId": "4NGALjtX2t3AXE3ZCqJiSmYuiWEY3ZPQNUBxNWWRrRSp",
   "revision": 2,
   "publicKeysToAdd": [
-    {
-      "contractBounds": null,
-      "id": 5,
-      "type": "ECDSA_HASH160",
-      "data": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
-      "publicKeyHash": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
-      "purpose": "AUTHENTICATION",
-      "securityLevel": "HIGH",
-      "readOnly": false,
-      "signature": ""
-    },
-    {
-      "contractBounds": null,
-      "id": 6,
-      "type": "ECDSA_SECP256K1",
-      "data": "026213380930c93c4b53f6ddbc5adc5f5165102d8f92f7d9a495a8f9c6e61b30f0",
-      "publicKeyHash": "d39eda042126256a372c388bd191532a7c9612ce",
-      "purpose": "AUTHENTICATION",
-      "securityLevel": "MASTER",
-      "readOnly": false,
-      "signature": "1faf8b0f16320d0f9e29c1db12ab0d3ec87974b19f6fc1189a988cd85503d79f844d3ff778678d7f4f3829891e8e8d0183456194d9fc76ed66e503154996eefe06"
-    }
+      {
+          "contractBounds": null,
+          "id": 5,
+          "type": "ECDSA_HASH160",
+          "data": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
+          "publicKeyHash": "c208ded6d1af562b8e5387c02a446ea6e8bb325f",
+          "purpose": "AUTHENTICATION",
+          "securityLevel": "HIGH",
+          "readOnly": false,
+          "signature": ""
+      },
+      {
+          "contractBounds": null,
+          "id": 6,
+          "type": "ECDSA_SECP256K1",
+          "data": "026213380930c93c4b53f6ddbc5adc5f5165102d8f92f7d9a495a8f9c6e61b30f0",
+          "publicKeyHash": "d39eda042126256a372c388bd191532a7c9612ce",
+          "purpose": "AUTHENTICATION",
+          "securityLevel": "MASTER",
+          "readOnly": false,
+          "signature": "1faf8b0f16320d0f9e29c1db12ab0d3ec87974b19f6fc1189a988cd85503d79f844d3ff778678d7f4f3829891e8e8d0183456194d9fc76ed66e503154996eefe06"
+      }
   ],
   "publicKeyIdsToDisable": [],
   "signature": "1f341c8eb7b890f416c7a970406dd37da078dab5f2c4aa8dd18375516933b234873127965dd72ee28b7392fcd87e28c4bfef890791b58fa9c34bce9e96d6536cb1",
@@ -3036,54 +3038,54 @@ IDENTITY_CREATE with instantLock
 ```
 ```json
 {
-  "type": 6,
-  "typeString": "IDENTITY_CREDIT_WITHDRAWAL",
-  "outputAddress": "yifJkXaxe7oM1NgBDTaXnWa6kXZAazBfjk",
-  "userFeeIncrease": 0,
-  "senderId": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
-  "amount": 200000,
-  "identityNonce": 6,
-  "outputScript": "76a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac",
-  "coreFeePerByte": 5,
-  "signature": "20cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b",
-  "signaturePublicKeyId": 3,
-  "pooling": "Standard",
-  "raw": "05017199f1f68404c86ecf60d9cb93aef318fa0f2b08e59ffd176bdef43154ffde6bfc00030d400500011976a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac0600034120cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b"
+    "type": 6,
+    "typeString": "IDENTITY_CREDIT_WITHDRAWAL",
+    "outputAddress": "yifJkXaxe7oM1NgBDTaXnWa6kXZAazBfjk",
+    "userFeeIncrease": 0,
+    "senderId": "8eTDkBhpQjHeqgbVeriwLeZr1tCa6yBGw76SckvD1cwc",
+    "amount": 200000,
+    "identityNonce": 6,
+    "outputScript": "76a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac",
+    "coreFeePerByte": 5,
+    "signature": "20cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b",
+    "signaturePublicKeyId": 3,
+    "pooling": "Standard",
+    "raw": "05017199f1f68404c86ecf60d9cb93aef318fa0f2b08e59ffd176bdef43154ffde6bfc00030d400500011976a914f51453a538d9a0a9fb3fe0f2948a0f80d9cf525a88ac0600034120cc6d48ed7341d47d6efbdad14ce0f471e67f75110acd56738b7c42c78a71d7da4fd870e1c77934239ea3a0ca0fd1145814b5165bd4ec76e87e774836c680b01b"
 }
 ```
 ```json
 {
-  "type": 7,
-  "typeString": "IDENTITY_CREDIT_TRANSFER",
-  "identityNonce": 1,
-  "userFeeIncrease": 0,
-  "senderId": "24YEeZmpy1QNKronDT8enYWLXnfoxYK7hrHUdpWHxURg",
-  "recipientId": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
-  "amount": 21856638,
-  "signaturePublicKeyId": 3,
-  "signature": "1f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8",
-  "raw": "07000fc3bf4a26bff60f4f79a1f4b929ce4d4c5833d226c1c7f68758e71d7ae229db569fd4f616b3dedecbeef95352cf38f1fb04d232a0d20623bc195b0c3f721840fc014d817e010003411f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8"
+    "type": 7,
+    "typeString": "IDENTITY_CREDIT_TRANSFER",
+    "identityNonce": 1,
+    "userFeeIncrease": 0,
+    "senderId": "24YEeZmpy1QNKronDT8enYWLXnfoxYK7hrHUdpWHxURg",
+    "recipientId": "6q9RFbeea73tE31LGMBLFZhtBUX3wZL3TcNynqE18Zgs",
+    "amount": 21856638,
+    "signaturePublicKeyId": 3,
+    "signature": "1f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8",
+    "raw": "07000fc3bf4a26bff60f4f79a1f4b929ce4d4c5833d226c1c7f68758e71d7ae229db569fd4f616b3dedecbeef95352cf38f1fb04d232a0d20623bc195b0c3f721840fc014d817e010003411f39c5c81434699df7924d68eba4326352ac97883688e3ec3ffed36746d6fb8c227d4a96a40fcd38673f80ed64ab8e3514cf81fe8be319774429071881d3c8b1f8"
 }
 ```
 ```json
 {
-  "type": 8,
-  "typeString": "IDENTITY_CREDIT_TRANSFER",
-  "indexValues": [
-    "EgRkYXNo",
-    "EgN5MDE="
-  ],
-  "contractId": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
-  "modifiedDataIds": [
-    "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse"
-  ],
-  "ownerId": "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse",
-  "signature": "2019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d",
-  "documentTypeName": "domain",
-  "indexName": "parentNameAndLabel",
-  "choice": "Abstain",
-  "proTxHash": "ad4e38fc81da72d61b14238ee6e5b91915554e24d725718800692d3a863c910b",
-  "raw": "08005b246080ba64350685fe302d3d790f5bb238cb619920d46230c844f079944a233bb2df460e72e3d59e7fe1c082ab3a5bd9445dd0dd5c4894a6d9f0d9ed9404b5000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c021204646173681203793031010c00412019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d"
+    "type": 8,
+    "typeString": "IDENTITY_CREDIT_TRANSFER",
+    "indexValues": [
+        "EgRkYXNo",
+        "EgN5MDE="
+    ],
+    "contractId": "GWRSAVFMjXx8HpQFaNJMqBV7MBgMK4br5UESsB4S31Ec",
+    "modifiedDataIds": [
+        "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse"
+    ],
+    "ownerId": "523FUhxg6WEvp24PfjqFAuHFYXW1gkoXdy8QywfriSse",
+    "signature": "2019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d",
+    "documentTypeName": "domain",
+    "indexName": "parentNameAndLabel",
+    "choice": "Abstain",
+    "proTxHash": "ad4e38fc81da72d61b14238ee6e5b91915554e24d725718800692d3a863c910b",
+    "raw": "08005b246080ba64350685fe302d3d790f5bb238cb619920d46230c844f079944a233bb2df460e72e3d59e7fe1c082ab3a5bd9445dd0dd5c4894a6d9f0d9ed9404b5000000e668c659af66aee1e72c186dde7b5b7e0a1d712a09c40d5721f622bf53c5315506646f6d61696e12706172656e744e616d65416e644c6162656c021204646173681203793031010c00412019d90a905092dd3074da3cd42b05abe944d857fc2573e81e1d39a16ba659c00c7b38b88bee46a853c5c30deb9c2ae3abf4fbb781eec12b86a0928ca7b02ced7d"
 }
 ```
 ```json
@@ -3136,72 +3138,72 @@ IDENTITY_CREATE with instantLock
 ```
 ```json
 {
-  "type": 13,
-  "typeString": "ADDRESS_FUNDING_FROM_ASSET_LOCK",
-  "assetLockProof": {
-    "coreChainLockedHeight": null,
-    "type": "instantSend",
-    "instantLock": "AQKflfCMay9YZSHo7Yy2u5l0vwE0obDfr8cqfShF9bqn/gEAAAD2vDZ5zvy1mcNCSF5jfsxQkw0veXBo6aJNE/13WYR7awEAAACJfGgEXp9GdjneIf96kXXJEn+b/Qix6fYXJ1hgqBQzH/y3yJZU0Ky99rsWgfhfdvFC4UBFsddngtq6TJgBAAAAix7+tMc2flwUVAB1uquM+dk5TF/nhmAnX9PmNHbUnIUTFWvpfXw7lnqpLERjGgKeF5ITbSsXcFU2TiKYWg7esh/DYYYrbdXBbJ6OoiLVQjjI60Em+1NK4nPycG9g6xOX",
-    "fundingAmount": "100000000",
-    "fundingCoreTx": "1f3314a860582717f6e9b108fd9b7f12c975917aff21de3976469f5e04687c89",
-    "vout": 0
-  },
-  "userFeeIncrease": 0,
-  "inputs": [],
-  "inputWitness": [],
-  "outputs": [
-    {
-      "platformAddress": {
-        "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
-        "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
-      },
-      "credits": "0"
-    }
-  ],
-  "feeStrategy": [
-    {
-      "type": "ReduceOutput",
-      "value": 0
-    }
-  ],
-  "signature": "202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f4064",
-  "raw": "0d0000ea01029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe01000000f6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b01000000897c68045e9f467639de21ff7a9175c9127f9bfd08b1e9f617275860a814331ffcb7c89654d0acbdf6bb1681f85f76f142e14045b1d76782daba4c98010000008b1efeb4c7367e5c14540075baab8cf9d9394c5fe78660275fd3e63476d49c8513156be97d7c3b967aa92c44631a029e1792136d2b177055364e22985a0edeb21fc361862b6dd5c16c9e8ea222d54238c8eb4126fb534ae273f2706f60eb1397fb018303000800029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe010000006b483045022100bbfbd824846523f7d2c6799b47a9dea88c0fb60dd433d0d8971abee63dd4966b022008dcee6d9780aa962d37cfed6ca54e256f6dba1190c01c7a58cc749709179f450121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aefffffffff6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b010000006a473044022074bd9c8c4ca4557cdf57017627b6b666c7586b674503f3f26ae8f1fed714d2510220295ea1d64c5745988e94c963972059d20171d0e0f92b07c31469bb622a468f3c0121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aeffffffff0200e1f50500000000026a00a008510b000000001976a914f84b203ee59814a41f1aa2379043ab3af98143f188ac0000000024010100e1f505000000001976a91469dccf851a2cb6c2f18ee1274e4fd1669af7685a88ac000001005022deda5da7414a3aa460705a5bb16b1282c97a000101000041202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f406400"
+    "type": 13,
+    "typeString": "ADDRESS_FUNDING_FROM_ASSET_LOCK",
+    "assetLockProof": {
+        "coreChainLockedHeight": null,
+        "type": "instantSend",
+        "instantLock": "AQKflfCMay9YZSHo7Yy2u5l0vwE0obDfr8cqfShF9bqn/gEAAAD2vDZ5zvy1mcNCSF5jfsxQkw0veXBo6aJNE/13WYR7awEAAACJfGgEXp9GdjneIf96kXXJEn+b/Qix6fYXJ1hgqBQzH/y3yJZU0Ky99rsWgfhfdvFC4UBFsddngtq6TJgBAAAAix7+tMc2flwUVAB1uquM+dk5TF/nhmAnX9PmNHbUnIUTFWvpfXw7lnqpLERjGgKeF5ITbSsXcFU2TiKYWg7esh/DYYYrbdXBbJ6OoiLVQjjI60Em+1NK4nPycG9g6xOX",
+        "fundingAmount": "100000000",
+        "fundingCoreTx": "1f3314a860582717f6e9b108fd9b7f12c975917aff21de3976469f5e04687c89",
+        "vout": 0
+    },
+    "userFeeIncrease": 0,
+    "inputs": [],
+    "inputWitness": [],
+    "outputs": [
+        {
+            "platformAddress": {
+              "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
+              "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
+            },
+            "credits": "0"
+        }
+    ],
+    "feeStrategy": [
+        {
+            "type": "ReduceOutput",
+            "value": 0
+        }
+    ],
+    "signature": "202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f4064",
+    "raw": "0d0000ea01029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe01000000f6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b01000000897c68045e9f467639de21ff7a9175c9127f9bfd08b1e9f617275860a814331ffcb7c89654d0acbdf6bb1681f85f76f142e14045b1d76782daba4c98010000008b1efeb4c7367e5c14540075baab8cf9d9394c5fe78660275fd3e63476d49c8513156be97d7c3b967aa92c44631a029e1792136d2b177055364e22985a0edeb21fc361862b6dd5c16c9e8ea222d54238c8eb4126fb534ae273f2706f60eb1397fb018303000800029f95f08c6b2f586521e8ed8cb6bb9974bf0134a1b0dfafc72a7d2845f5baa7fe010000006b483045022100bbfbd824846523f7d2c6799b47a9dea88c0fb60dd433d0d8971abee63dd4966b022008dcee6d9780aa962d37cfed6ca54e256f6dba1190c01c7a58cc749709179f450121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aefffffffff6bc3679cefcb599c342485e637ecc50930d2f797068e9a24d13fd7759847b6b010000006a473044022074bd9c8c4ca4557cdf57017627b6b666c7586b674503f3f26ae8f1fed714d2510220295ea1d64c5745988e94c963972059d20171d0e0f92b07c31469bb622a468f3c0121022bb6c14bedb4deb4059a260c7228f0d38f8274e7fadeea4b5739a4c120d651aeffffffff0200e1f50500000000026a00a008510b000000001976a914f84b203ee59814a41f1aa2379043ab3af98143f188ac0000000024010100e1f505000000001976a91469dccf851a2cb6c2f18ee1274e4fd1669af7685a88ac000001005022deda5da7414a3aa460705a5bb16b1282c97a000101000041202856c525c2d3c001cfd581bd46df6f73220db84fcbb111c6729bd66d2d07e2d37c84e543627bd9fbb953ff0bf98e0367abedc790970471fec6816df2ad6f406400"
 }
 ```
 ```json
 {
-  "type": 14,
-  "typeString": "ADDRESS_CREDIT_WITHDRAWAL",
-  "userFeeIncrease": 0,
-  "inputs": [
-    {
-      "platformAddress": {
-        "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
-        "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
-      },
-      "credits": "250000000000",
-      "nonce": "5"
-    }
-  ],
-  "inputWitness": [
-    {
-      "type": "P2PKH",
-      "value": {
-        "signature": "2097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
-      }
-    }
-  ],
-  "output": null,
-  "feeStrategy": [
-    {
-      "type": "DeductFromInput",
-      "value": 0
-    }
-  ],
-  "pooling": 0,
-  "outputAddress": "yT6NQzvH2h16ggSKNj2b2Wu3NMFiYVKXeB",
-  "outputScript": "76a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac",
-  "raw": "0e000100914e8a18eb34517b7a6a4432cf237f68c5f8332e05fd0000003a352944000001000001001976a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac000100412097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
+    "type": 14,
+    "typeString": "ADDRESS_CREDIT_WITHDRAWAL",
+    "userFeeIncrease": 0,
+    "inputs": [
+        {
+            "platformAddress": {
+              "base58": "yRpNvoc3hd66c3rNrPRGubVd9vGUoAVpZV",
+              "bech32m": "tdashevo1qq79z66rh34l4u2axlz3jv34zwshggnenut9k093"
+            },
+            "credits": "250000000000",
+            "nonce": "5"
+        }
+    ],
+    "inputWitness": [
+        {
+            "type": "P2PKH",
+            "value": {
+                "signature": "2097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
+            }
+        }
+    ],
+    "output": null,
+    "feeStrategy": [
+        {
+            "type": "DeductFromInput",
+            "value": 0
+        }
+    ],
+    "pooling": 0,
+    "outputAddress": "yT6NQzvH2h16ggSKNj2b2Wu3NMFiYVKXeB",
+    "outputScript": "76a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac",
+    "raw": "0e000100914e8a18eb34517b7a6a4432cf237f68c5f8332e05fd0000003a352944000001000001001976a9144a4fc56e14aa98799880abbcd46de5d2e09998fb88ac000100412097d5baef616aeeb6b19e5baf4fdc2bdadcc685bd01161844c199b22b41afe1547a90cef74d70a776263ef723f509711f495a6907a63f89b7ddb260956404299b"
 }
 ```
 Response codes:


### PR DESCRIPTION
# Issue
For additional data on frontend, backend must return more statistic from chain.

# Things done
- Expanded epoch info by adding: `totalCreatedDocumentsCount`, `totalDeletedDocumentsCount`, `totalRegisteredNamesCount`, `totalContestedDocumentsCount`, `blockProposers` and `avgBlockTime`
- Implemented `/blocks/avgBlockTime/history` which returns data for charts based on avg block time in interval
- Added geoIp info for validators
- Implemented `/validator/:proTxHash/income/stats` which returns data for charts about validator income 
- Implemented `/dataContracts/active` which returns data contracts rating in selected time interval based on activity
- Implemented `/transactions/input/history` which returns data for chart about inputs into a platform
- Implemented `/transactions/output/history` which returns data for chart about outputs from a platform
- Added time interval params for `/transactions/statistic`
- Added notes count into /transactions/shielded/statistic
- Updated docs
- Updated README.md
- Updated models
