### PR TITLE
Fix button wrapper types breaking `next build`

### DIFF
--- a/packages/frontend/src/components/ui/Buttons/ArrowButton.tsx
+++ b/packages/frontend/src/components/ui/Buttons/ArrowButton.tsx
@@ -1,10 +1,10 @@
 'use client'
 
-import type { ComponentProps } from 'react'
+import type { ComponentPropsWithoutRef } from 'react'
 import { ChevronIcon } from '../icons'
 import './ArrowButton.scss'
 
-function ArrowButton ({ children, className, ...props }: ComponentProps<'button'>) {
+function ArrowButton ({ children, className, ...props }: ComponentPropsWithoutRef<'button'>) {
   return (
     <button className={`ArrowButton ${className || ''}`} {...props}>
       <ChevronIcon/>

--- a/packages/frontend/src/components/ui/Buttons/BackButton.tsx
+++ b/packages/frontend/src/components/ui/Buttons/BackButton.tsx
@@ -1,9 +1,9 @@
 'use client'
 
-import type { ComponentProps } from 'react'
+import type { ComponentPropsWithoutRef } from 'react'
 import { useRouter } from 'next/navigation'
 
-interface BackButtonProps extends ComponentProps<'button'> {
+interface BackButtonProps extends ComponentPropsWithoutRef<'button'> {
   link?: string
 }
 

--- a/packages/frontend/src/components/ui/NavigationButton/NavigationButton.tsx
+++ b/packages/frontend/src/components/ui/NavigationButton/NavigationButton.tsx
@@ -1,7 +1,7 @@
-import type { ComponentProps, ReactNode } from 'react'
+import type { ComponentPropsWithoutRef, ReactNode } from 'react'
 import './NavigationButton.scss'
 
-interface NavigationButtonProps extends Omit<ComponentProps<'button'>, 'name'> {
+interface NavigationButtonProps extends Omit<ComponentPropsWithoutRef<'button'>, 'name'> {
   active?: boolean
   name?: ReactNode
   subName?: ReactNode


### PR DESCRIPTION
# Issue
`next build` fails on develop with a type error in `ArrowButton`:
`Type 'LegacyRef<HTMLButtonElement>' is not assignable to type 'Ref<HTMLButtonElement>'`.

`ArrowButton`, `BackButton` and `NavigationButton` type their props with
`ComponentProps<'button'>` (which includes `ref: LegacyRef`, allowing `string`) and spread
them onto a native `<button>`. A newer `@types/react` 18.3.x dropped string refs from `Ref`,
so the spread no longer type-checks. This amends the native-element spread pattern from #813.

# Things done
- Switched the three button wrappers to `ComponentPropsWithoutRef<'button'>` (they don't forward a ref).
- `npx tsc --noEmit` is green; no consumer passes `ref` to these buttons, so no call sites change.

# Notes
- Root cause is dependency drift (stale lockfile + `npm install`, floating `@types/react ^18.3`).
  Reproducibility hardening (`npm ci` + pinned `@types/react`) will follow in a separate PR.
