### PR TITLE
Improve validators API endpoint performance

### DIFF
--- a/packages/api/src/controllers/ValidatorsController.js
+++ b/packages/api/src/controllers/ValidatorsController.js
@@ -62,6 +62,19 @@ class ValidatorsController {
       cache.set(`${VALIDATORS_CACHE_KEY}_${validator.proTxHash}`, validatorInfo, VALIDATORS_CACHE_LIFE_INTERVAL)
     }
 
+    // For a validator that has left the masternode list, getProTxInfo resolves
+    // its state from the registration block, which reports it as not banned.
+    // This endpoint reports the precise final ban state instead (the list
+    // endpoint stays coarse). A present validator (no-fallback lookup succeeds)
+    // already carries its accurate ban height.
+    if (!isActive && validatorInfo.proTxInfo?.state) {
+      const currentProTxInfo = await DashCoreRPC.getProTxInfo(validator.proTxHash, undefined, false)
+
+      if (!currentProTxInfo) {
+        validatorInfo.proTxInfo.state.PoSeBanHeight = await getFinalPoSeBanHeight(validator.proTxHash)
+      }
+    }
+
     const { proTxInfo } = validatorInfo
 
     const [host] = proTxInfo?.state?.service?.match(/^\d+\.\d+\.\d+\.\d+/) ?? [null]
@@ -151,29 +164,15 @@ class ValidatorsController {
 
     let validatorsWithoutBan = []
 
-    // Ban status is derived from the current masternode list. Validators that
-    // have left the list (collateral spent) are not there anymore, so their ban
-    // state is resolved from their last block in the list (see getFinalPoSeBanHeight):
-    // banned-then-removed stays banned, cleanly-retired counts as not banned.
+    // Ban status is derived from the current masternode list. A validator that
+    // has left the list (collateral spent) is treated as banned here: resolving
+    // its precise final ban state requires a per-node historical lookup that is
+    // too expensive for the list endpoint (see getFinalPoSeBanHeight, used only
+    // on the single-validator endpoint).
     if (isBanned !== undefined) {
       const registeredMasternodes = await DashCoreRPC.getProTxList('registered', true)
 
-      const registeredHashes = new Set(registeredMasternodes.map(masternode => masternode.proTxHash.toUpperCase()))
-
-      const validatorsInDataBase = await this.validatorsDAO.getValidatorsHashes()
-
-      const removedValidators = validatorsInDataBase.filter(proTxHash => !registeredHashes.has(proTxHash.toUpperCase()))
-
-      const retiredValidators = (await Promise.all(removedValidators.map(async (proTxHash) => {
-        const finalPoSeBanHeight = await getFinalPoSeBanHeight(proTxHash)
-
-        return finalPoSeBanHeight === -1 ? { proTxHash } : null
-      }))).filter(Boolean)
-
-      validatorsWithoutBan = [
-        ...registeredMasternodes.filter(masternode => masternode.state?.PoSeBanHeight === -1),
-        ...retiredValidators
-      ]
+      validatorsWithoutBan = registeredMasternodes.filter(masternode => masternode.state?.PoSeBanHeight === -1)
     }
 
     const validators = await this.validatorsDAO.getValidators(

--- a/packages/api/test/integration/validators.spec.js
+++ b/packages/api/test/integration/validators.spec.js
@@ -2089,8 +2089,6 @@ describe('Validators routes', () => {
 
     describe('filter isBanned', async () => {
       let bannedValidators
-      let retiredValidators
-      let removedValidators
 
       before(() => {
         // restore the healthy mocks (preceding describes leave some throwing)
@@ -2099,47 +2097,22 @@ describe('Validators routes', () => {
             Promise.resolve(activeValidators.map(activeValidator =>
               ({ pro_tx_hash: activeValidator.pro_tx_hash }))))
 
-        // validators that have left the masternode list (a banned validator can
-        // never be active, so these come from the inactive set):
-        // - bannedValidators were PoSe-banned before removal -> banned
-        // - retiredValidators cleanly spent collateral        -> not banned
-        bannedValidators = inactiveValidators.slice(0, 10)
-        retiredValidators = inactiveValidators.slice(10, 15)
-        removedValidators = [...bannedValidators, ...retiredValidators]
+        mock.method(DashCoreRPC, 'getProTxInfo', async () => dashCoreRpcResponse)
 
-        // the registered list no longer contains the removed validators
+        // a banned validator can never be active, so ban a subset of the
+        // inactive validators by dropping them from the registered masternode
+        // list — the list endpoint treats any removed validator as banned
+        bannedValidators = inactiveValidators.slice(0, 10)
+
         mock.method(DashCoreRPC, 'getProTxList', async () =>
           validators
-            .filter(validator => !removedValidators.some(removed =>
-              removed.pro_tx_hash === validator.pro_tx_hash))
+            .filter(validator => !bannedValidators.some(banned =>
+              banned.pro_tx_hash === validator.pro_tx_hash))
             .map(validator =>
               ({ proTxHash: validator.pro_tx_hash, state: { PoSeBanHeight: -1 } })))
-
-        // getFinalPoSeBanHeight resolves a removed validator's last state: the
-        // registration lookup (fallback) provides registeredHeight, and the
-        // per-block probe (fallback disabled) reports the final PoSeBanHeight
-        mock.method(DashCoreRPC, 'getBlockCount', async () => 900000)
-        mock.method(DashCoreRPC, 'getBlockHash', async () => dashCoreRpcResponse.collateralHash)
-        mock.method(DashCoreRPC, 'getProTxInfo', async (proTxHash, blockHash, fallback = true) => {
-          if (fallback) {
-            return dashCoreRpcResponse
-          }
-
-          const isBanned = bannedValidators.some(validator =>
-            validator.pro_tx_hash === proTxHash)
-
-          return {
-            ...dashCoreRpcResponse,
-            state: {
-              ...dashCoreRpcResponse.state,
-              PoSeBanHeight: isBanned ? 1000 : -1
-            }
-          }
-        })
       })
 
       after(() => {
-        mock.method(DashCoreRPC, 'getProTxInfo', async () => dashCoreRpcResponse)
         mock.method(DashCoreRPC, 'getProTxList', async () =>
           validators.map(validator =>
             ({ proTxHash: validator.pro_tx_hash, state: { PoSeBanHeight: -1 } })))
@@ -2173,18 +2146,6 @@ describe('Validators routes', () => {
 
         for (const banned of bannedValidators) {
           assert.equal(returnedHashes.includes(banned.pro_tx_hash), false)
-        }
-      })
-
-      it('should treat cleanly retired validators as not banned', async () => {
-        const { body } = await client.get('/validators?isBanned=false&limit=0')
-          .expect(200)
-          .expect('Content-Type', 'application/json; charset=utf-8')
-
-        const returnedHashes = body.resultSet.map(validator => validator.proTxHash)
-
-        for (const retired of retiredValidators) {
-          assert.equal(returnedHashes.includes(retired.pro_tx_hash), true)
         }
       })
     })


### PR DESCRIPTION
# Issue
After previous PR #825 we cannot get validators on mainnet because 600+ validators cannot be normaly processed by current alghoritm

# Things done
- Updated alghoritm for getting banned validators
- Updated tests