### PR TITLE
Support time interval in shielded pool

### DIFF
--- a/packages/frontend/src/components/home/ShieldedPoolCard.js
+++ b/packages/frontend/src/components/home/ShieldedPoolCard.js
@@ -7,7 +7,6 @@ import { CardHead, Presets } from '../cards'
 import { RateTooltip } from '../ui/Tooltips'
 import { creditsToDash } from '../../util'
 import { Skeleton } from './Skeleton'
-import { compact } from './utils'
 import { PRESETS, presetRange } from './MetricChart'
 import './ShieldedPoolCard.scss'
 
@@ -144,12 +143,12 @@ export default function ShieldedPoolCard ({ rate, enabled = true }) {
                   </div>
                   <div className={'ShieldedPool__RowItem'}>
                     <span>Transitions</span>
-                    <span>{compact(period.transitions)}</span>
+                    <span>{period.transitions.toLocaleString('en-US')}</span>
                   </div>
                   {pool.notes != null &&
                     <div className={'ShieldedPool__RowItem'}>
                       <span>Notes</span>
-                      <span>{compact(pool.notes)}</span>
+                      <span>{Number(pool.notes).toLocaleString('en-US')}</span>
                     </div>}
                 </div>
 

--- a/packages/frontend/src/components/home/ShieldedPoolCard.js
+++ b/packages/frontend/src/components/home/ShieldedPoolCard.js
@@ -36,21 +36,27 @@ function fmtDash (dash) {
 
 // shielded pool overview: balance + in/out totals over diverging in/out flow bars
 export default function ShieldedPoolCard ({ rate, enabled = true }) {
-  const [stats, setStats] = useState({ loading: true, error: false, data: null })
+  const [pool, setPool] = useState({ loading: true, error: false, balance: null, notes: null })
+  const [period, setPeriod] = useState({ loading: true, in: 0, out: 0, transitions: 0 })
   const [flows, setFlows] = useState({ loading: true, buckets: [] })
   const [presetIdx, setPresetIdx] = useState(DEFAULT_PRESET)
   const [hover, setHover] = useState(null)
 
-  // pool balance and totals are all-time by nature: fetched once, unaffected by the preset
   useEffect(() => {
-    if (!enabled) {
-      setStats(s => ({ ...s, loading: true, error: false }))
-      return
-    }
-    Api.getShieldedStatistic()
-      .then(res => setStats({ loading: false, error: false, data: res }))
-      .catch(() => setStats({ loading: false, error: true, data: null }))
+    if (!enabled) { setPool(s => ({ ...s, loading: true, error: false })); return }
+    Api.getShieldedPool()
+      .then(res => setPool({ loading: false, error: false, balance: res?.poolBalance ?? null, notes: res?.notesCount ?? null }))
+      .catch(() => setPool({ loading: false, error: true, balance: null, notes: null }))
   }, [enabled])
+
+  useEffect(() => {
+    if (!enabled) { setPeriod(s => ({ ...s, loading: true })); return }
+    const { start, end } = presetRange(PRESETS[presetIdx])
+    setPeriod(s => ({ ...s, loading: true }))
+    Api.getShieldedStatistic(start, end)
+      .then(res => setPeriod({ loading: false, in: Number(res?.totalShieldedIn) || 0, out: Number(res?.totalShieldedOut) || 0, transitions: Number(res?.transitionsCount) || 0 }))
+      .catch(() => setPeriod({ loading: false, in: 0, out: 0, transitions: 0 }))
+  }, [presetIdx, enabled])
 
   useEffect(() => {
     if (!enabled) {
@@ -79,10 +85,9 @@ export default function ShieldedPoolCard ({ rate, enabled = true }) {
     })
   }, [presetIdx, enabled])
 
-  const data = stats.data
-  const balanceCredits = Number(data?.poolBalance) || 0
-  const inCredits = Number(data?.totalShieldedIn) || 0
-  const outCredits = Number(data?.totalShieldedOut) || 0
+  const balanceCredits = Number(pool.balance) || 0
+  const inCredits = period.in
+  const outCredits = period.out
 
   const buckets = flows.buckets
   const flowMax = buckets.reduce((max, b) => Math.max(max, b.inAmt, b.outAmt), 0)
@@ -110,7 +115,7 @@ export default function ShieldedPoolCard ({ rate, enabled = true }) {
       </CardHead>
 
       <div className={'ShieldedPool__Body'}>
-        {stats.loading
+        {pool.loading
           ? <>
               <Skeleton w={'140px'} h={'1.6em'}/>
               <div className={'ShieldedPool__Rows'}>
@@ -118,7 +123,7 @@ export default function ShieldedPoolCard ({ rate, enabled = true }) {
               </div>
               <Skeleton w={'100%'} h={`${SPARK_H}px`} radius={6}/>
             </>
-          : stats.error || !data
+          : pool.error
             ? <div className={'ShieldedPool__Empty'}>No data</div>
             : <>
                 <RateTooltip dash={creditsToDash(balanceCredits)} rate={rate?.data} placement={'top'}>
@@ -139,8 +144,13 @@ export default function ShieldedPoolCard ({ rate, enabled = true }) {
                   </div>
                   <div className={'ShieldedPool__RowItem'}>
                     <span>Transitions</span>
-                    <span>{compact(Number(data.transitionsCount) || 0)}</span>
+                    <span>{compact(period.transitions)}</span>
                   </div>
+                  {pool.notes != null &&
+                    <div className={'ShieldedPool__RowItem'}>
+                      <span>Notes</span>
+                      <span>{compact(pool.notes)}</span>
+                    </div>}
                 </div>
 
                 <div className={'ShieldedPool__Spark'}>

--- a/packages/frontend/src/components/home/ShieldedPoolCard.scss
+++ b/packages/frontend/src/components/home/ShieldedPoolCard.scss
@@ -5,7 +5,6 @@
     min-height: 200px;
     display: flex;
     flex-direction: column;
-    justify-content: center;
     gap: 14px;
   }
 
@@ -65,6 +64,7 @@
   }
 
   &__Spark {
+    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 5px;
@@ -74,12 +74,15 @@
   &__SparkWrap {
     position: relative;
     cursor: crosshair;
+    // grows into the spare height so the chart fills the card instead of leaving a bottom gap
+    flex: 1;
+    min-height: 56px;
   }
 
   &__SparkSvg {
     display: block;
     width: 100%;
-    height: 56px;
+    height: 100%;
     transition: opacity .2s;
 
     &.is-loading { opacity: 0.4; }

--- a/packages/frontend/src/components/home/ShieldedPoolCard.scss
+++ b/packages/frontend/src/components/home/ShieldedPoolCard.scss
@@ -5,6 +5,7 @@
     min-height: 200px;
     display: flex;
     flex-direction: column;
+    justify-content: center;
     gap: 14px;
   }
 
@@ -64,7 +65,6 @@
   }
 
   &__Spark {
-    flex: 1;
     display: flex;
     flex-direction: column;
     gap: 5px;
@@ -74,15 +74,12 @@
   &__SparkWrap {
     position: relative;
     cursor: crosshair;
-    // grows into the spare height so the chart fills the card instead of leaving a bottom gap
-    flex: 1;
-    min-height: 56px;
   }
 
   &__SparkSvg {
     display: block;
     width: 100%;
-    height: 100%;
+    height: 56px;
     transition: opacity .2s;
 
     &.is-loading { opacity: 0.4; }

--- a/packages/frontend/src/util/Api.ts
+++ b/packages/frontend/src/util/Api.ts
@@ -133,13 +133,23 @@ const getTransactionsStatistic = (start?: string, end?: string): Promise<Transac
 interface ShieldedStatistic {
   totalShieldedIn: string
   totalShieldedOut: string
-  poolBalance: string
   transitionsCount: number
-  types: Array<{ transactionType: string, count: number, amount: string }>
+  types?: Array<{ transactionType: string, count: number, amount: string }>
 }
 
-const getShieldedStatistic = (): Promise<ShieldedStatistic> => {
-  return call<ShieldedStatistic>('transactions/shielded/statistic', 'GET')
+// optional time interval; omitted → all-time
+const getShieldedStatistic = (start?: string, end?: string): Promise<ShieldedStatistic> => {
+  const range = start != null && end != null ? `?timestamp_start=${start}&timestamp_end=${end}` : ''
+  return call<ShieldedStatistic>(`transactions/shielded/statistic${range}`, 'GET')
+}
+
+interface ShieldedPool {
+  poolBalance: string | null
+  notesCount: number | null
+}
+
+const getShieldedPool = (): Promise<ShieldedPool> => {
+  return call<ShieldedPool>('transactions/shielded/pool', 'GET')
 }
 
 interface ShieldHistoryPoint {
@@ -689,6 +699,7 @@ export {
   getTransactionsHistory,
   getTransactionsStatistic,
   getShieldedStatistic,
+  getShieldedPool,
   getShieldHistory,
   getUnshieldHistory,
   getTransactions,


### PR DESCRIPTION
Pairs with #828, which adds the time interval to `/transactions/shielded/statistic` and moves the pool balance to the new `/transactions/shielded/pool`.

# Issue
The Shielded pool card read `poolBalance` + in/out/transitions from `/shielded/statistic` (all-time), so the header never changed with the range selector — and #828 removes `poolBalance` from that endpoint.

# Things done
- `getShieldedStatistic(start?, end?)` passes the interval; header in/out/transitions refetch per preset.
- New `getShieldedPool()` for the all-time pool balance + `notesCount`.
- Fill the card height (the flow chart grows to remove the empty space at the bottom).

> Merge after #828 reaches mainnet — no fallback, `/transactions/shielded/pool` 404s until then.