### PR TITLE
Add `batchTypes` into transactions statistic

### DIFF
--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -2243,6 +2243,7 @@ Return the count of state transitions grouped by transaction type.
 Optionally accepts a time interval. Without parameters the statistic is calculated over all time.
 
 * `timestamp_start` and `timestamp_end` must be set together
+* `batchTypes` — per-batch-type breakdown, present only on the `BATCH` entry, `null` for every other transaction type. Counts sum to the entry's `count`
 
 ```
 GET /transactions/statistic?timestamp_start=2024-10-01T00:00:00.000Z&timestamp_end=2024-11-01T00:00:00.000Z
@@ -2252,8 +2253,22 @@ GET /transactions/statistic?timestamp_start=2024-10-01T00:00:00.000Z&timestamp_e
         "count": 39
     },
     {
-        "transactionType": "DOCUMENTS_BATCH",
-        "count": 115
+        "transactionType": "BATCH",
+        "count": 115,
+        "batchTypes": [
+            {
+                "batchType": "DOCUMENT_CREATE",
+                "count": 80
+            },
+            {
+                "batchType": "DOCUMENT_REPLACE",
+                "count": 25
+            },
+            {
+                "batchType": "TOKEN_TRANSFER",
+                "count": 10
+            }, ...
+        ]
     }, ...
 ]
 ```

--- a/packages/api/src/dao/TransactionsDAO.js
+++ b/packages/api/src/dao/TransactionsDAO.js
@@ -604,8 +604,8 @@ module.exports = class TransactionsDAO {
 
   getTransactionStatistic = async (timestampStart, timestampEnd) => {
     let query = this.knex('state_transitions')
-      .select('type')
-      .groupBy('type')
+      .select('type', 'batch_type')
+      .groupBy('type', 'batch_type')
       .count()
 
     if (timestampStart && timestampEnd) {
@@ -617,9 +617,33 @@ module.exports = class TransactionsDAO {
 
     const rows = await query
 
-    return rows.map(row => ({
-      transactionType: StateTransitionEnum[row.type],
-      count: Number(row.count)
+    const statistic = rows.reduce((accumulator, row) => {
+      const count = Number(row.count)
+
+      const entry = accumulator[row.type] ?? {
+        transactionType: StateTransitionEnum[row.type],
+        count: 0,
+        batchTypes: null
+      }
+
+      entry.count += count
+
+      if (row.batch_type !== null) {
+        entry.batchTypes = [
+          ...entry.batchTypes ?? [],
+          { batchType: BatchEnum[row.batch_type], count }
+        ]
+      }
+
+      accumulator[row.type] = entry
+
+      return accumulator
+    }, {})
+
+    return Object.values(statistic).map(entry => ({
+      ...entry,
+      // hide for non batch transitions
+      batchTypes: entry.batchTypes?.sort((a, b) => b.count - a.count) ?? undefined
     }))
   }
 

--- a/packages/api/test/integration/transactions.spec.js
+++ b/packages/api/test/integration/transactions.spec.js
@@ -1537,24 +1537,62 @@ describe('Transaction routes', () => {
   })
 
   describe('getTransactionStatistic()', async () => {
+    // both the expected statistic and the response are sorted by name so the
+    // assertion does not depend on grouping order
+    const buildExpectedStatistic = (txs) => {
+      const countsByType = txs.reduce((acc, { transaction }) => {
+        acc[transaction.type] = acc[transaction.type] ?? { count: 0, batchTypes: {} }
+        acc[transaction.type].count += 1
+
+        if (transaction.batch_type !== null && transaction.batch_type !== undefined) {
+          acc[transaction.type].batchTypes[transaction.batch_type] =
+            (acc[transaction.type].batchTypes[transaction.batch_type] ?? 0) + 1
+        }
+
+        return acc
+      }, {})
+
+      return Object.entries(countsByType)
+        .map(([type, { count, batchTypes }]) => ({
+          transactionType: StateTransitionEnum[type],
+          count,
+          batchTypes: Object.keys(batchTypes).length > 0
+            ? Object.entries(batchTypes)
+              .map(([batchType, count]) => ({ batchType: BatchTypeEnum[batchType], count }))
+              .sort((a, b) => a.batchType.localeCompare(b.batchType))
+            : null
+        }))
+        .sort((a, b) => a.transactionType.localeCompare(b.transactionType))
+    }
+
+    const sortStatistic = (statistic) => statistic
+      .map(entry => ({
+        ...entry,
+        batchTypes: entry.batchTypes?.sort((a, b) => a.batchType.localeCompare(b.batchType)) ?? null
+      }))
+      .sort((a, b) => a.transactionType.localeCompare(b.transactionType))
+
     it('should return transaction count grouped by type', async () => {
       const { body } = await client.get('/transactions/statistic')
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      const countsByType = transactions.reduce((acc, { transaction }) => {
-        acc[transaction.type] = (acc[transaction.type] ?? 0) + 1
-        return acc
-      }, {})
+      assert.deepEqual(sortStatistic(body), buildExpectedStatistic(transactions))
+    })
 
-      const expectedStatistic = Object.entries(countsByType)
-        .map(([type, count]) => ({ transactionType: StateTransitionEnum[type], count }))
-        .sort((a, b) => a.transactionType.localeCompare(b.transactionType))
+    it('should return a batch type breakdown only for the BATCH entry', async () => {
+      const { body } = await client.get('/transactions/statistic')
+        .expect(200)
+        .expect('Content-Type', 'application/json; charset=utf-8')
 
-      assert.deepEqual(
-        body.sort((a, b) => a.transactionType.localeCompare(b.transactionType)),
-        expectedStatistic
-      )
+      const batchEntry = body.find(({ transactionType }) => transactionType === 'BATCH')
+
+      assert.notEqual(batchEntry, undefined)
+      assert.deepEqual(batchEntry.batchTypes, [{ batchType: 'TOKEN_CLAIM', count: batchEntry.count }])
+
+      body
+        .filter(({ transactionType }) => transactionType !== 'BATCH')
+        .forEach(entry => assert.equal(entry.batchTypes, null))
     })
 
     it('should return transaction count grouped by type in the given interval', async () => {
@@ -1565,24 +1603,13 @@ describe('Transaction routes', () => {
         .expect(200)
         .expect('Content-Type', 'application/json; charset=utf-8')
 
-      const countsByType = transactions
+      const transactionsInInterval = transactions
         .filter(({ block }) =>
           new Date(block.timestamp).getTime() >= start.getTime() &&
           new Date(block.timestamp).getTime() <= end.getTime()
         )
-        .reduce((acc, { transaction }) => {
-          acc[transaction.type] = (acc[transaction.type] ?? 0) + 1
-          return acc
-        }, {})
 
-      const expectedStatistic = Object.entries(countsByType)
-        .map(([type, count]) => ({ transactionType: StateTransitionEnum[type], count }))
-        .sort((a, b) => a.transactionType.localeCompare(b.transactionType))
-
-      assert.deepEqual(
-        body.sort((a, b) => a.transactionType.localeCompare(b.transactionType)),
-        expectedStatistic
-      )
+      assert.deepEqual(sortStatistic(body), buildExpectedStatistic(transactionsInInterval))
     })
 
     it('should return error if only one of start and end is set', async () => {

--- a/packages/frontend/src/app/api/content.md
+++ b/packages/frontend/src/app/api/content.md
@@ -2210,6 +2210,7 @@ Return the count of state transitions grouped by transaction type.
 Optionally accepts a time interval. Without parameters the statistic is calculated over all time.
 
 * `timestamp_start` and `timestamp_end` must be set together
+* `batchTypes` — per-batch-type breakdown, present only on the `BATCH` entry, `null` for every other transaction type. Counts sum to the entry's `count`
 
 ```
 GET /transactions/statistic?timestamp_start=2024-10-01T00:00:00.000Z&timestamp_end=2024-11-01T00:00:00.000Z
@@ -2219,8 +2220,22 @@ GET /transactions/statistic?timestamp_start=2024-10-01T00:00:00.000Z&timestamp_e
         "count": 39
     },
     {
-        "transactionType": "DOCUMENTS_BATCH",
-        "count": 115
+        "transactionType": "BATCH",
+        "count": 115,
+        "batchTypes": [
+            {
+                "batchType": "DOCUMENT_CREATE",
+                "count": 80
+            },
+            {
+                "batchType": "DOCUMENT_REPLACE",
+                "count": 25
+            },
+            {
+                "batchType": "TOKEN_TRANSFER",
+                "count": 10
+            }, ...
+        ]
     }, ...
 ]
 ```


### PR DESCRIPTION
# Issue
Currently exdpoint with transaction statistic doesn't provide any info about transitions inside batch

# Things done
- Added field `batchTypes` into transactions statistic
- Update tests
- Update `README.md`