### PR TITLE
Fix mobile tooltips and leaderboard layout

### DIFF
--- a/packages/frontend/src/components/home/HomeLeaders.css
+++ b/packages/frontend/src/components/home/HomeLeaders.css
@@ -123,7 +123,7 @@
   }
   .HomeLeaders__Head {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
+    grid-template-columns: minmax(0, 1fr);
     align-items: center;
     gap: 6px 8px;
     padding: 0 16px 12px;
@@ -145,11 +145,11 @@
     white-space: nowrap;
   }
   .HomeLeaders__Nav {
-    grid-column: 2;
-    grid-row: 1;
+    grid-column: 1;
+    grid-row: 3;
     margin-left: 0;
     flex-shrink: 0;
-    max-width: none;
+    max-width: 100%;
     padding: 2px;
     gap: 2px;
   }

--- a/packages/frontend/src/components/home/ShieldedPoolCard.css
+++ b/packages/frontend/src/components/home/ShieldedPoolCard.css
@@ -389,17 +389,22 @@
 .ShieldedPool__Tip {
   position: absolute;
   top: 10px;
-  transform: translateX(-50%);
+  box-sizing: border-box;
+  width: max-content;
+  max-width: calc(100% - 16px);
   display: flex;
   flex-direction: column;
-  gap: 2px;
-  padding: 7px 10px;
+  gap: 6px;
+  padding: 10px 12px;
   border-radius: 8px;
   background: rgba(10, 14, 16, 0.95);
   border: 1px solid rgba(var(--pe-color-gray-800-rgb), 0.9);
   font-family: var(--pe-font-mono);
-  font-size: 0.625rem;
-  white-space: nowrap;
+  font-size: 0.75rem;
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+  white-space: normal;
+  overflow-wrap: anywhere;
   pointer-events: none;
   z-index: 2;
 }
@@ -407,16 +412,32 @@
   color: var(--pe-color-gray-500);
 }
 .ShieldedPool__TipRow {
+  display: grid;
+  grid-template-columns: auto auto;
+  justify-content: start;
+  align-items: baseline;
+  gap: 12px;
   font-weight: 600;
   color: #fff;
 }
+.ShieldedPool__TipRow strong {
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-align: right;
+}
 .ShieldedPool__TipRow.is-tvl {
+  grid-template-columns: auto minmax(0, 1fr);
   color: var(--pe-color-brand-light);
 }
-.ShieldedPool__TipRow em {
-  font-style: normal;
-  font-weight: 500;
-  opacity: 0.62;
+.ShieldedPool__TipAmounts {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 2px 8px;
+  min-width: 0;
+}
+.ShieldedPool__TipSecondary {
+  color: var(--pe-color-gray-400);
 }
 .ShieldedPool__TipRow.is-in {
   color: #2cffb4;

--- a/packages/frontend/src/components/home/ShieldedPoolCard.tsx
+++ b/packages/frontend/src/components/home/ShieldedPoolCard.tsx
@@ -1,6 +1,14 @@
 'use client'
 
-import { useState, useEffect, useMemo, useRef, useId, type RefObject } from 'react'
+import {
+  useState,
+  useEffect,
+  useMemo,
+  useRef,
+  useId,
+  type RefObject,
+  type PointerEvent
+} from 'react'
 import * as d3 from 'd3'
 import useResizeObserver from '@react-hook/resize-observer'
 
@@ -135,6 +143,23 @@ export default function ShieldedPoolCard({
   const gid = useId().replace(/:/g, '')
   const fetchGen = useRef(0)
   const periodGen = useRef(0)
+
+  useEffect(() => {
+    const dismissOutside = (event: globalThis.PointerEvent) => {
+      if (event.target instanceof Node && !wrapRef.current?.contains(event.target)) {
+        setHoverI(null)
+      }
+    }
+    const dismissOnEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') setHoverI(null)
+    }
+    document.addEventListener('pointerdown', dismissOutside)
+    document.addEventListener('keydown', dismissOnEscape)
+    return () => {
+      document.removeEventListener('pointerdown', dismissOutside)
+      document.removeEventListener('keydown', dismissOnEscape)
+    }
+  }, [])
 
   useResizeObserver(wrapRef as RefObject<HTMLElement>, entry => {
     const { width: w, height: hh } = entry.contentRect
@@ -355,7 +380,7 @@ export default function ShieldedPoolCard({
     }
   }, [ready, points, width, plotH, showDeposits, showWithdrawals, k, inUsd])
 
-  const handleMove = (e: any) => {
+  const handleMove = (e: PointerEvent<HTMLDivElement>) => {
     if (!chart) return
     const rect = e.currentTarget.getBoundingClientRect()
     const mx = e.clientX - rect.left
@@ -373,6 +398,8 @@ export default function ShieldedPoolCard({
   }
 
   const hovered = chart && hoverI != null ? chart.pts[hoverI] : null
+  const tooltipPosition =
+    hovered && chart ? Math.min(1, Math.max(0, chart.x(hovered.x) / width)) : 0
 
   const statDash = isAll ? balanceDash : rangeNetDash
   const statCount = (() => {
@@ -521,8 +548,14 @@ export default function ShieldedPoolCard({
           <div
             ref={wrapRef}
             className={'ShieldedPool__Chart'}
-            onMouseMove={handleMove}
-            onMouseLeave={() => setHoverI(null)}
+            onPointerDown={handleMove}
+            onPointerMove={event => {
+              if (event.pointerType === 'mouse') handleMove(event)
+            }}
+            onPointerLeave={event => {
+              if (event.pointerType === 'mouse') setHoverI(null)
+            }}
+            onPointerCancel={() => setHoverI(null)}
           >
             {(pool.loading || series.loading) && !chart ? (
               <Skeleton className={'ShieldedPool__ChartSkel'} radius={8} />
@@ -680,22 +713,32 @@ export default function ShieldedPoolCard({
                   <div
                     className={'ShieldedPool__Tip'}
                     style={{
-                      left: `${Math.min(Math.max((chart.x(hovered.x) / width) * 100, 14), 86)}%`
+                      left: `calc(8px + (100% - 16px) * ${tooltipPosition})`,
+                      transform: `translateX(-${tooltipPosition * 100}%)`
                     }}
                   >
                     <span className={'ShieldedPool__TipDate'}>{chart.tipFmt(hovered.x)}</span>
                     <span className={'ShieldedPool__TipRow is-tvl'}>
-                      TVL {fmtAmt(hovered.tvlDash, inUsd, usdPx)}
-                      {usdPx != null && <em> · {fmtAmt(hovered.tvlDash, !inUsd, usdPx)}</em>}
+                      <span>TVL</span>
+                      <span className={'ShieldedPool__TipAmounts'}>
+                        <strong>{fmtAmt(hovered.tvlDash, inUsd, usdPx)}</strong>
+                        {usdPx != null && (
+                          <span className={'ShieldedPool__TipSecondary'}>
+                            ≈ {fmtAmt(hovered.tvlDash, !inUsd, usdPx)}
+                          </span>
+                        )}
+                      </span>
                     </span>
                     {showDeposits && (
                       <span className={'ShieldedPool__TipRow is-in'}>
-                        In +{fmtAmt(hovered.inDash, inUsd, usdPx)}
+                        <span>Deposits</span>
+                        <strong>+{fmtAmt(hovered.inDash, inUsd, usdPx)}</strong>
                       </span>
                     )}
                     {showWithdrawals && (
                       <span className={'ShieldedPool__TipRow is-out'}>
-                        Out −{fmtAmt(hovered.outDash, inUsd, usdPx)}
+                        <span>Withdrawals</span>
+                        <strong>−{fmtAmt(hovered.outDash, inUsd, usdPx)}</strong>
                       </span>
                     )}
                   </div>


### PR DESCRIPTION
# Issue

The shielded pool tooltip could overflow the mobile viewport, and leaderboard tabs overlapped the heading.

# Things done

- Keep the shielded pool tooltip within the chart bounds
- Improve tooltip readability with compact rows and inline currency values
- Support tap to open and outside tap or Escape to dismiss
- Place leaderboard navigation below the heading on mobile
- TypeScript and changed-file Biome checks pass (one existing isNaN warning)