### PR TITLE
Show data contract names in leaderboards

### DIFF
--- a/packages/frontend/src/components/home/HomeLeaders.tsx
+++ b/packages/frontend/src/components/home/HomeLeaders.tsx
@@ -327,9 +327,15 @@ export default function HomeLeaders({ rate, enabled = true }: { rate?: any; enab
           href={`/dataContract/${item.identifier}`}
           accent={list.accent}
           title={
-            <Identifier ellipsis avatar styles={['highlight-both']}>
-              {item.identifier}
-            </Identifier>
+            item.name ? (
+              <Alias ellipsis avatarSource={item.identifier}>
+                {item.name}
+              </Alias>
+            ) : (
+              <Identifier ellipsis avatar styles={['highlight-both']}>
+                {item.identifier}
+              </Identifier>
+            )
           }
           metric={
             <BigNumber>


### PR DESCRIPTION
# Issue

Data contract leaderboards displayed identifiers even when contract names were available.

# Things done

- Show contract names when available, falling back to identifiers
- Preserve avatars and links to contract details
- Reuse names from existing API responses without additional requests